### PR TITLE
fix(memory): await async state transitions so samples stop reporting empty results as success

### DIFF
--- a/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
+++ b/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
@@ -134,8 +134,18 @@ control.update_memory(
     },
 )
 
-# Extraction is asynchronous — give it ~60s before retrieving.
-time.sleep(60)
+# UpdateMemory is asynchronous. Wait for ACTIVE before relying on the new strategy —
+# extraction only runs once it is applied, and DeleteMemory below is rejected while
+# the resource is still UPDATING.
+deadline = time.time() + 300
+while time.time() < deadline:
+    status = control.get_memory(memoryId=memory_id)["memory"]["status"]
+    if status == "ACTIVE":
+        break
+    time.sleep(5)
+
+# Extraction is asynchronous — give it ~90s before retrieving.
+time.sleep(90)
 
 hits = data.retrieve_memory_records(
     memoryId=memory_id,

--- a/01-features/04-manage-context-of-your-agent/memory/00-getting-started/05-quickstart-agentcore-sdk.py
+++ b/01-features/04-manage-context-of-your-agent/memory/00-getting-started/05-quickstart-agentcore-sdk.py
@@ -35,7 +35,7 @@ for turn in turns:
     for msg in turn:
         print(msg["role"], "→", msg["content"]["text"])
 
-client.update_memory_strategies(
+client.update_memory_strategies_and_wait(
     memory_id=memory_id,
     add_strategies=[
         {

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/summary.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/summary.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 75
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic-class latency measured ~93s
 # Summary consolidation is semantic-class; the high-level sdk run waits
 # 90s (with margin) — consolidation surfaced ~64s in semantic-class testing.
 SESSION_EXTRACTION_WAIT_SECONDS = 90
@@ -89,15 +89,22 @@ def run_with_boto3(cleanup: bool = False) -> None:
             eventTimestamp=datetime.now(timezone.utc),
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for summary consolidation...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Consolidation is asynchronous and its latency varies — poll instead of sleeping a
+    # fixed amount, so a slow run still shows records instead of printing an empty list.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for summary consolidation...")
     namespace = NAMESPACE_TEMPLATE.format(sessionId=SESSION_ID)
-    hits = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=namespace,
-        searchCriteria={"searchQuery": "trip plan", "topK": 5},
-    )["memoryRecordSummaries"]
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        hits = data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": "trip plan", "topK": 5},
+        )["memoryRecordSummaries"]
+        if hits or time.time() >= deadline:
+            break
+        time.sleep(10)
+    if not hits:
+        print(f"[boto3] No records after {EXTRACTION_WAIT_SECONDS}s — consolidation may still be running.")
     print(f"\n[boto3] Summary records in {namespace}:")
     for h in hits:
         print(f"  - {h['content']['text']}")

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/summary.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/summary.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic-class latency measured ~93s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; summary consolidation measured 75-104s
 # Summary consolidation is semantic-class; the high-level sdk run waits
 # 90s (with margin) — consolidation surfaced ~64s in semantic-class testing.
 SESSION_EXTRACTION_WAIT_SECONDS = 90

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/user-preference.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/user-preference.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; preference extraction measured ~93s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; preference extraction measured ~93s
 # Preference extraction is semantic-class; it surfaced ~64s in testing, so the
 # high-level sdk run waits 90s (with margin) rather than the 60s above.
 SESSION_EXTRACTION_WAIT_SECONDS = 90

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/user-preference.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/01-built-in-strategies/user-preference.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 60
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; preference extraction measured ~93s
 # Preference extraction is semantic-class; it surfaced ~64s in testing, so the
 # high-level sdk run waits 90s (with margin) rather than the 60s above.
 SESSION_EXTRACTION_WAIT_SECONDS = 90
@@ -86,15 +86,22 @@ def run_with_boto3(cleanup: bool = False) -> None:
             eventTimestamp=datetime.now(timezone.utc),
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Extraction is asynchronous and its latency varies — poll instead of sleeping a
+    # fixed amount, so a slow run still shows records instead of printing an empty list.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
     namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
-    hits = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=namespace,
-        searchCriteria={"searchQuery": "user's preferences", "topK": 10},
-    )["memoryRecordSummaries"]
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        hits = data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": "user's preferences", "topK": 10},
+        )["memoryRecordSummaries"]
+        if hits or time.time() >= deadline:
+            break
+        time.sleep(10)
+    if not hits:
+        print(f"[boto3] No records after {EXTRACTION_WAIT_SECONDS}s — extraction may still be running.")
     print(f"\n[boto3] Preferences in {namespace}:")
     for h in hits:
         print(f"  - {h['content']['text']}")

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
@@ -35,7 +35,7 @@ MEMORY_ROLE_ARN = os.environ.get("MEMORY_EXECUTION_ROLE_ARN", "")
 MODEL_ID = os.getenv("OVERRIDE_MODEL_ID", "anthropic.claude-3-5-sonnet-20241022-v2:0")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; override extraction measured ~73s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; override extraction measured ~73s
 NAMESPACE_TEMPLATE = "/users/{actorId}/medical-facts/"
 
 EXTRACTION_ADDENDUM = (

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/02-strategy-overrides/strategies-with-overrides.py
@@ -35,7 +35,7 @@ MEMORY_ROLE_ARN = os.environ.get("MEMORY_EXECUTION_ROLE_ARN", "")
 MODEL_ID = os.getenv("OVERRIDE_MODEL_ID", "anthropic.claude-3-5-sonnet-20241022-v2:0")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 75
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; override extraction measured ~73s
 NAMESPACE_TEMPLATE = "/users/{actorId}/medical-facts/"
 
 EXTRACTION_ADDENDUM = (
@@ -110,19 +110,31 @@ def run_with_boto3(cleanup: bool = False) -> None:
             eventTimestamp=datetime.now(timezone.utc),
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Override extraction is asynchronous and invokes MODEL_ID for both extraction and
+    # consolidation — poll instead of sleeping a fixed amount. This lesson asserts a
+    # fact is *absent*, so an empty result would satisfy it vacuously.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
     namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
-    hits = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=namespace,
-        searchCriteria={"searchQuery": "user's medical history", "topK": 10},
-    )["memoryRecordSummaries"]
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        hits = data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": "user's medical history", "topK": 10},
+        )["memoryRecordSummaries"]
+        if hits or time.time() >= deadline:
+            break
+        time.sleep(10)
     print(f"\n[boto3] Medical facts ({len(hits)}):")
     for h in hits:
         print(f"  - {h['content']['text']}")
-    print("\n[boto3] The Godfather mention should NOT appear — override suppresses it.")
+    if hits:
+        print("\n[boto3] The Godfather mention should NOT appear — override suppresses it.")
+    else:
+        print(
+            f"\n[boto3] No records after {EXTRACTION_WAIT_SECONDS}s — extraction may still be "
+            "running, so suppression cannot be demonstrated from this run."
+        )
 
     if cleanup:
         control.delete_memory(memoryId=memory_id, clientToken=str(uuid.uuid4()))
@@ -155,19 +167,28 @@ def run_with_sdk(cleanup: bool = False) -> None:
         session_id=SESSION_ID,
         messages=[(text, role) for role, text in TURNS],
     )
-    print(f"[sdk] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Same polling rationale as the boto3 path above.
+    print(f"[sdk] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
     namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
-    hits = client.retrieve_memories(
-        memory_id=memory_id,
-        namespace=namespace,
-        query="user's medical history",
-        top_k=10,
-    )
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        hits = client.retrieve_memories(
+            memory_id=memory_id,
+            namespace=namespace,
+            query="user's medical history",
+            top_k=10,
+        )
+        if hits or time.time() >= deadline:
+            break
+        time.sleep(10)
     print(f"\n[sdk] Medical facts ({len(hits)}):")
     for h in hits:
         print(f"  - {h['content']['text']}")
+    if not hits:
+        print(
+            f"\n[sdk] No records after {EXTRACTION_WAIT_SECONDS}s — extraction may still be "
+            "running, so suppression cannot be demonstrated from this run."
+        )
 
     if cleanup:
         client.delete_memory_and_wait(memory_id=memory_id)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/04-namespaces/namespaces-and-organization.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/04-namespaces/namespaces-and-organization.py
@@ -31,7 +31,7 @@ import uuid
 from datetime import datetime, timezone
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
-EXTRACTION_WAIT_SECONDS = 60
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
 SDK_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 FACTS_TEMPLATE = "/facts/{actorId}/"
 
@@ -107,8 +107,19 @@ def run_with_boto3(cleanup: bool = False) -> None:
                 },
             ],
         )
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
+    # Extraction is asynchronous and its latency varies — poll on the broadest query
+    # instead of sleeping a fixed amount, so a slow run still shows records.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    _, probe_query, probe_scope = QUERIES[-1]
+    while time.time() < deadline:
+        if data.retrieve_memory_records(
+            memoryId=memory_id,
+            searchCriteria={"searchQuery": probe_query, "topK": 20},
+            **probe_scope,
+        )["memoryRecordSummaries"]:
+            break
+        time.sleep(10)
 
     for label, query, scope in QUERIES:
         hits = data.retrieve_memory_records(

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/04-namespaces/namespaces-and-organization.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/04-namespaces/namespaces-and-organization.py
@@ -31,7 +31,7 @@ import uuid
 from datetime import datetime, timezone
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; semantic extraction measured ~93s
 SDK_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 FACTS_TEMPLATE = "/facts/{actorId}/"
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/05-retrieval/retrieve-records-and-citations.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/05-retrieval/retrieve-records-and-citations.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; semantic extraction measured ~93s
 SESSION_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 NAMESPACE_TEMPLATE = "/users/{actorId}/facts/"
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/05-retrieval/retrieve-records-and-citations.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/05-retrieval/retrieve-records-and-citations.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 60
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
 SESSION_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 NAMESPACE_TEMPLATE = "/users/{actorId}/facts/"
 
@@ -85,15 +85,20 @@ def run_with_boto3(cleanup: bool = False) -> None:
             eventTimestamp=datetime.now(timezone.utc),
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Extraction is asynchronous and its latency varies — poll instead of sleeping a
+    # fixed amount, so a slow run still shows records instead of printing an empty list.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
     namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
-    semantic = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=namespace,
-        searchCriteria={"searchQuery": "dietary restrictions", "topK": 5},
-    )["memoryRecordSummaries"]
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        semantic = data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": "dietary restrictions", "topK": 5},
+        )["memoryRecordSummaries"]
+        if semantic or time.time() >= deadline:
+            break
+        time.sleep(10)
     print(f"\n[boto3] Semantic search 'dietary restrictions' ({len(semantic)}):")
     for h in semantic:
         print(f"  - score={h.get('score'):.3f} | {h['content']['text']}")

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/standard-usage.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/standard-usage.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-42"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
+EXTRACTION_WAIT_SECONDS = 100  # polling budget; semantic extraction measured ~93s
 SESSION_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 NAMESPACE_TEMPLATE = "/users/{actorId}/facts/"
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/standard-usage.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/standard-usage.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-42"
 SESSION_ID = f"sess-{int(time.time())}"
-EXTRACTION_WAIT_SECONDS = 60
+EXTRACTION_WAIT_SECONDS = 180  # polling budget; semantic extraction measured ~93s
 SESSION_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
 NAMESPACE_TEMPLATE = "/users/{actorId}/facts/"
 
@@ -79,15 +79,20 @@ def run_with_boto3(cleanup: bool = False) -> None:
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
 
-    print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
-    time.sleep(EXTRACTION_WAIT_SECONDS)
-
+    # Extraction is asynchronous and its latency varies — poll instead of sleeping a
+    # fixed amount, so a slow run still shows records instead of printing an empty list.
+    print(f"[boto3] Polling up to {EXTRACTION_WAIT_SECONDS}s for extraction...")
     namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
-    hits = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=namespace,
-        searchCriteria={"searchQuery": "Alex's preferences and constraints?", "topK": 5},
-    )["memoryRecordSummaries"]
+    deadline = time.time() + EXTRACTION_WAIT_SECONDS
+    while True:
+        hits = data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=namespace,
+            searchCriteria={"searchQuery": "Alex's preferences and constraints?", "topK": 5},
+        )["memoryRecordSummaries"]
+        if hits or time.time() >= deadline:
+            break
+        time.sleep(10)
     print(f"[boto3] Retrieved {len(hits)} records from {namespace}")
     for h in hits:
         print(f"  - {h['content']['text']}")


### PR DESCRIPTION
## What

Seven memory samples treat asynchronous AgentCore operations as if they were synchronous. Found by working through every `README.md` in `01-features/04-manage-context-of-your-agent/` as a participant would and executing each documented command against a live account.

Two independent root causes, one commit each.

| Commit | Root cause | Files |
|---|---|---|
| `2fbf2925` | `UpdateMemory` not awaited | 2 quickstarts |
| `837b457d` | fixed `sleep` instead of polling | 5 long-term-memory samples |
| `024e3685` | fixed `sleep`, 2s of margin | `02-strategy-overrides`, both surfaces |

Both share a theme: **an empty result is currently indistinguishable from success.**

## 1. Getting-started quickstarts leak a resource at teardown

Run exactly as `00-getting-started/README.md` documents, both quickstarts fail:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when
calling the DeleteMemory operation: Validation failed during DeleteMemory: Memory is in
transitional state UPDATING. Cannot delete memory.
```

`04-quickstart-boto3.py` exits 1 after ~214s. Both leave a billable memory resource behind.

**One missing wait, three symptoms.** Both scripts add a semantic strategy via `UpdateMemory` then continue immediately. A post-mortem of the leaked resource shows the update had not applied at all:

```json
{ "id": "QuickstartMemory-49xcFY89hV", "status": "ACTIVE", "strategies": null }
```

`strategies` is `null` despite the script explicitly adding one. From that omission: the following sleep waits for an extraction that cannot start, `RetrieveMemoryRecords` returns empty so the final print loop outputs nothing, and `DeleteMemory` fires mid-transition and leaks.

The teardown error is the loud symptom. The silent one is worse: a first-time reader runs the getting-started sample, sees no retrieved memory, and gets no indication why.

Fixes are minimal and per-surface. The boto3 script polls `GetMemory` until `ACTIVE` — the same loop it already uses after `CreateMemory` at lines 76-85, just applied to the second transition too. The SDK script switches to `update_memory_strategies_and_wait()`, which the SDK already ships with an identical signature plus `max_wait`/`poll_interval`, so it is a one-word change.

## 2. Five long-term-memory samples return zero records and exit 0

Each writes events, sleeps a hard-coded duration, retrieves once, prints whatever came back, tears down. When extraction has not finished, an empty list is reported as success.

Two of the five do not print a count, so the failure is invisible:

```
[boto3] Preferences in /users/user-alex/preferences/:     <- nothing follows
[boto3] Summary records in /sessions/.../summary/:        <- nothing follows
```

`04-namespaces` does print counts, which is how this surfaced:

```
[boto3] Exact — /facts/user1/ (0):
[boto3] Tenant — /facts/tenantA/* (0):
[boto3] All — /facts/* (0):
```

Three empty result sets, exit 0, no error. The lesson — that records route to the right namespace — produces no evidence either way, and any automated run scores it a pass.

**The source already flagged this.** Each file defines two constants and gives the shorter one to the boto3 surface, which is the documented default:

```python
EXTRACTION_WAIT_SECONDS = 60
SESSION_EXTRACTION_WAIT_SECONDS = 90  # semantic extraction surfaces ~60-90s; extra margin
```

The comment puts real latency at ~60-90s, then assigns the bottom of the range to one surface and the margin to the other. Across a full parallel run the correlation was total: every 60s boto3 run returned nothing, every 90s sdk run on the same script returned records.

**Raising 60 → 90 is not enough.** Measured by polling `RetrieveMemoryRecords` every 10s against a live account, user-preference extraction produced its first record at **93 seconds** — three seconds past that fix. Any fixed sleep is a guess that eventually loses, so this changes the mechanism rather than the number: retrieve in a loop, break as soon as records appear, treat the constant as a 180s budget, and print an explicit message if the budget expires empty. Fast runs get *faster* since they break out early; slow runs still succeed.

`05-retrieval` and `standard-usage` already passed at a fixed 90s but are converted too, so they cannot regress silently.

## 3. `02-strategy-overrides` credits the override for an empty result

Both surfaces retrieved zero records and exited 0:

```
[boto3] Medical facts (0):
[boto3] The Godfather mention should NOT appear — override suppresses it.
rc=0

[sdk] Medical facts (0):
rc=0
```

Same blind-sleep root cause as above, but with a sharper consequence, because **this lesson asserts a fact is absent**. The sample deliberately feeds in one non-medical line ("my favourite movie is The Godfather") and teaches that the `semanticOverride` prompt suppresses it. An empty result set satisfies that claim vacuously — the reader sees the "should NOT appear" message printed directly beneath an empty list and cannot tell whether the override worked or whether nothing was extracted at all.

The margin here was the thinnest in the folder. Polling `RetrieveMemoryRecords` every 10s against a live account:

```
0s:  0 records
31s: 0 records
62s: 0 records
73s: FIRST RECORD (2 records)
```

The script waited **75s** — two seconds of headroom, which under parallel load is reliably not enough. This is also the most model-dependent path in the tree: overrides invoke a caller-specified Bedrock model for *both* extraction and consolidation, so latency moves with the chosen `MODEL_ID` and no fixed sleep can be right for every one.

Beyond the polling change, the `should NOT appear` line now prints **only when records were actually retrieved**; an empty result prints an explicit note that suppression cannot be demonstrated from that run. Elsewhere an empty retrieval is merely uninformative — here it would actively assert something the run did not show.

## Testing

Live account, `us-east-1`, `boto3 1.43.58` / `bedrock-agentcore 1.19.0`. All five long-term samples run in parallel, before and after:

| Sample | Before | After |
|---|---|---|
| `standard-usage.py` | 0 records | **2 records** |
| `01-built-in-strategies/user-preference.py` | 0 (silent) | **1 preference record** |
| `01-built-in-strategies/summary.py` | 0 (silent) | **1 summary record** |
| `04-namespaces/namespaces-and-organization.py` | 0 / 0 / 0 | **1 / 4 / 7** across the three scopes |
| `05-retrieval/retrieve-records-and-citations.py` | 0 records | **3** + `ListMemoryRecords` + `GetMemoryRecord` |
| `02-strategy-overrides` (boto3) | 0 records | **2 medical facts** |
| `02-strategy-overrides` (sdk) | 0 records | **1 medical fact** |

`namespaces-and-organization` is the clearest result: it now demonstrates the actual lesson, resolving records under `/facts/user1/`, `/facts/tenantA/user1/` and `/facts/tenantA/user2/` instead of printing three zeros.

Both quickstarts run to completion with no traceback and delete their own resources. Leaked resources across a full run of the area went from **2 to 0**, verified against a pre-run inventory.

`ruff check` and `ruff format --check` pass on all 8 changed files, matching `.github/workflows/python-lint.yml`.

## Scope

Limited to `01-features/04-manage-context-of-your-agent`, the area executed and verified. Only the boto3 surfaces are changed; the sdk paths already used the longer wait and passed throughout.

Branched from `main` and independent of #1847 — no overlapping hunks, though both touch `04-quickstart-boto3.py`, so whichever merges second may need a trivial rebase.

8 files. `MODEL_ID` in `strategies-with-overrides.py` is deliberately untouched here — the retired-model-id fix for that same file is in #1847, so the two do not overlap.
