### PR TITLE
fix(memory): wait for eventual consistency of directly-written records, add missing skip-extraction sdk surface

### DIFF
--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/structured-metadata.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/structured-metadata.py
@@ -34,6 +34,30 @@ import uuid
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "tenant-acme"
 NAMESPACE = f"/tenants/{ACTOR_ID}/notes/"
+SEARCHABLE_WAIT_SECONDS = 180  # polling budget; records became searchable at 75-97s across runs
+EXPECTED_EU_RECORDS = 2  # of the 3 records written below, 2 carry region=EU
+
+
+def _search_until_visible(
+    op, expected: int = EXPECTED_EU_RECORDS, *, max_wait: int = SEARCHABLE_WAIT_SECONDS, poll: int = 10
+) -> list:
+    """Call `op()` until it returns `expected` records, or the deadline passes.
+
+    Directly-written records are eventually consistent. Measured against a live
+    account over three runs they became searchable at 75s, 86s and 97s after
+    BatchCreate, so any single fixed sleep is a guess that eventually loses.
+
+    This waits for the expected COUNT, not merely for a non-empty result: the index
+    populates record by record, so a run that stops at the first hit can report 1 of
+    the 2 EU records and look like the filter dropped one. The count is deterministic
+    here because the records are written directly rather than extracted.
+    """
+    deadline = time.time() + max_wait
+    while True:
+        hits = op()
+        if len(hits) >= expected or time.time() >= deadline:
+            return hits
+        time.sleep(poll)
 
 
 def _records() -> list[dict]:
@@ -97,28 +121,35 @@ def run_with_boto3(cleanup: bool = False) -> None:
     resp = data.batch_create_memory_records(memoryId=memory_id, records=_records())
     print(f"[boto3] Created {len(resp.get('successfulRecords', []))} records")
 
-    # Directly-written records are eventually consistent — they take ~30s to become
-    # searchable. Wait before filtering, or the query returns nothing.
-    time.sleep(35)
-
-    hits = data.retrieve_memory_records(
-        memoryId=memory_id,
-        namespace=NAMESPACE,
-        searchCriteria={
-            "searchQuery": "Acme",
-            "topK": 10,
-            "metadataFilters": [
-                {
-                    "left": {"metadataKey": "region"},
-                    "operator": "EQUALS_TO",
-                    "right": {"metadataValue": {"stringValue": "EU"}},
-                }
-            ],
-        },
-    )["memoryRecordSummaries"]
+    # Directly-written records are eventually consistent — poll until both EU records
+    # are searchable instead of sleeping a fixed amount.
+    print(f"[boto3] Polling up to {SEARCHABLE_WAIT_SECONDS}s for records to become searchable...")
+    hits = _search_until_visible(
+        lambda: data.retrieve_memory_records(
+            memoryId=memory_id,
+            namespace=NAMESPACE,
+            searchCriteria={
+                "searchQuery": "Acme",
+                "topK": 10,
+                "metadataFilters": [
+                    {
+                        "left": {"metadataKey": "region"},
+                        "operator": "EQUALS_TO",
+                        "right": {"metadataValue": {"stringValue": "EU"}},
+                    }
+                ],
+            },
+        )["memoryRecordSummaries"]
+    )
     print(f"\n[boto3] EU-only results ({len(hits)}):")
     for h in hits:
         print(f"  - {h['content']['text']} | meta={h.get('metadata')}")
+    if len(hits) < EXPECTED_EU_RECORDS:
+        print(
+            f"[boto3] Expected {EXPECTED_EU_RECORDS} EU records, got {len(hits)} after "
+            f"{SEARCHABLE_WAIT_SECONDS}s — still propagating, so the metadata filter cannot be "
+            "fully demonstrated from this run."
+        )
 
     if cleanup:
         control.delete_memory(memoryId=memory_id, clientToken=str(uuid.uuid4()))
@@ -174,26 +205,32 @@ def run_with_sdk(cleanup: bool = False) -> None:
         f"[sdk] Created {len(resp.get('successfulRecords', []))} records ({len(resp.get('failedRecords', []))} failed)"
     )
 
-    # Directly-written records are eventually consistent: they take ~30s to become
-    # searchable (with their indexed metadata). Wait before filtering, or it returns 0.
-    time.sleep(35)
-
-    # Same EU-only filter as boto3/sdk, but built via the typed expression helper.
+    # Same EU-only filter as boto3, but built via the typed expression helper.
     region_eu = MemoryMetadataFilter.build_expression(
         MemoryRecordLeftExpression.build("region"),
         MemoryRecordOperatorType.EQUALS_TO,
         MemoryRecordRightExpression.build_string("EU"),
     )
-    hits = session.search_long_term_memories(
-        query="Acme",
-        namespace=NAMESPACE,
-        top_k=10,
-        metadata_filters=[region_eu],
+    # Same eventual-consistency poll as the boto3 path above.
+    print(f"[sdk] Polling up to {SEARCHABLE_WAIT_SECONDS}s for records to become searchable...")
+    hits = _search_until_visible(
+        lambda: session.search_long_term_memories(
+            query="Acme",
+            namespace=NAMESPACE,
+            top_k=10,
+            metadata_filters=[region_eu],
+        )
     )
     print(f"\n[sdk] EU-only results ({len(hits)}):")
     for h in hits:
         # Each hit is a MemoryRecord (dict-like): content.text + metadata.
         print(f"  - {h['content']['text']} | meta={h.get('metadata')}")
+    if len(hits) < EXPECTED_EU_RECORDS:
+        print(
+            f"[sdk] Expected {EXPECTED_EU_RECORDS} EU records, got {len(hits)} after "
+            f"{SEARCHABLE_WAIT_SECONDS}s — still propagating, so the metadata filter cannot be "
+            "fully demonstrated from this run."
+        )
 
     if cleanup:
         client.delete_memory_and_wait(memory_id=memory_id)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/structured-metadata.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/06-record-metadata/structured-metadata.py
@@ -34,7 +34,7 @@ import uuid
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "tenant-acme"
 NAMESPACE = f"/tenants/{ACTOR_ID}/notes/"
-SEARCHABLE_WAIT_SECONDS = 180  # polling budget; records became searchable at 75-97s across runs
+SEARCHABLE_WAIT_SECONDS = 100  # polling budget; records became searchable at 75-97s across runs
 EXPECTED_EU_RECORDS = 2  # of the 3 records written below, 2 carry region=EU
 
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/07-skip-STM/batch-create-update-delete.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/07-skip-STM/batch-create-update-delete.py
@@ -49,7 +49,7 @@ from botocore.exceptions import ClientError
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 NAMESPACE = f"/users/{ACTOR_ID}/notes/"
-PROPAGATION_WAIT_SECONDS = 180  # polling budget; records became listable ~87s after the delete
+PROPAGATION_WAIT_SECONDS = 120  # polling budget; records became listable ~87s after the delete
 EXPECTED_REMAINING = 2  # each surface below creates 3 records and deletes 1
 
 

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/07-skip-STM/batch-create-update-delete.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/07-skip-STM/batch-create-update-delete.py
@@ -12,11 +12,19 @@ back-fills, migrations, and admin tooling.
 Each call accepts up to 100 records and reports per-record success/failure.
 
 Eventual consistency: a record returned as SUCCEEDED by BatchCreate is NOT
-immediately readable/updatable — BatchUpdate/Delete/List against it can raise
-ResourceNotFoundException for a while (observed from a few seconds to >50s, and
-the window varies run to run). This is expected for directly-written records.
-The real-world pattern — shown below — is to RETRY the dependent operation until
-the record has propagated, rather than assume it is available right after create.
+immediately readable/updatable. This is expected for directly-written records, and
+it shows up in two different ways, so this script handles it in two different ways:
+
+  - BatchUpdate/BatchDelete can raise ResourceNotFoundException until the record
+    propagates. Retry on that error (`_retry_until_propagated`).
+  - ListMemoryRecords does NOT raise — it succeeds and returns an empty page, and
+    it lags the furthest behind. Measured against a live account, update and delete
+    both succeeded on the first attempt while the surviving records took ~87s to
+    become listable. Retrying on an exception cannot help here, so poll until the
+    expected record count appears (`_list_until_visible`).
+
+The real-world pattern — shown below — is to wait for the dependent operation to
+reflect the write, rather than assume it is available right after create.
 
 Two ways to run it:
     python batch-create-update-delete.py boto3    # the raw AWS API, no SDK. Shows exactly what's on the wire.
@@ -41,6 +49,32 @@ from botocore.exceptions import ClientError
 REGION = os.getenv("AWS_REGION", "us-east-1")
 ACTOR_ID = "user-alex"
 NAMESPACE = f"/users/{ACTOR_ID}/notes/"
+PROPAGATION_WAIT_SECONDS = 180  # polling budget; records became listable ~87s after the delete
+EXPECTED_REMAINING = 2  # each surface below creates 3 records and deletes 1
+
+
+def _list_until_visible(
+    op, expected: int = EXPECTED_REMAINING, *, max_wait: int = PROPAGATION_WAIT_SECONDS, poll: int = 10
+) -> list:
+    """Call `op()` until it returns `expected` records, or the deadline passes.
+
+    List lags further behind BatchCreate than update/delete do: measured against a
+    live account, the update and delete below both succeeded on the first attempt
+    while the surviving records took ~87s to become listable. A bare List straight
+    after the delete therefore reports zero records, which contradicts the
+    create/update/delete arithmetic the script just printed.
+
+    This needs its own helper rather than `_retry_until_propagated`: there is no
+    exception to catch here, because an unpropagated List succeeds and simply
+    returns an empty page. Waiting for the expected count also rides out the
+    reverse case, where the deleted record is still visible.
+    """
+    deadline = time.time() + max_wait
+    while True:
+        records = op()
+        if len(records) == expected or time.time() >= deadline:
+            return records
+        time.sleep(poll)
 
 
 def _retry_until_propagated(op, *, max_wait: int = 150, poll: int = 10):
@@ -141,10 +175,18 @@ def run_with_boto3(cleanup: bool = False) -> None:
     )
     print(f"[boto3] Deleted {len(delete_resp.get('successfulRecords', []))}")
 
-    remaining = data.list_memory_records(memoryId=memory_id, namespace=NAMESPACE)["memoryRecordSummaries"]
+    # List is eventually consistent too, so poll for the expected count instead of
+    # listing once and reporting whatever happens to be visible (which right after
+    # the delete is nothing).
+    print(f"\n[boto3] Polling up to {PROPAGATION_WAIT_SECONDS}s for records to become listable...")
+    remaining = _list_until_visible(
+        lambda: data.list_memory_records(memoryId=memory_id, namespace=NAMESPACE)["memoryRecordSummaries"]
+    )
     print(f"\n[boto3] Remaining ({len(remaining)}):")
     for r in remaining:
         print(f"  - {r['content']['text']}")
+    if len(remaining) != EXPECTED_REMAINING:
+        print(f"[boto3] Expected {EXPECTED_REMAINING} records after {PROPAGATION_WAIT_SECONDS}s — still propagating.")
 
     if cleanup:
         control.delete_memory(memoryId=memory_id, clientToken=str(uuid.uuid4()))
@@ -233,10 +275,14 @@ def run_with_sdk(cleanup: bool = False) -> None:
 
     # list_long_term_memory_records is a first-class MemorySessionManager method
     # (returns a list of MemoryRecord directly, not a {"memoryRecordSummaries": ...} dict).
-    remaining = manager.list_long_term_memory_records(namespace=NAMESPACE)
+    # Same eventual-consistency poll as the boto3 path above.
+    print(f"\n[sdk] Polling up to {PROPAGATION_WAIT_SECONDS}s for records to become listable...")
+    remaining = _list_until_visible(lambda: manager.list_long_term_memory_records(namespace=NAMESPACE))
     print(f"\n[sdk] Remaining ({len(remaining)}):")
     for r in remaining:
         print(f"  - {r['content']['text']}")
+    if len(remaining) != EXPECTED_REMAINING:
+        print(f"[sdk] Expected {EXPECTED_REMAINING} records after {PROPAGATION_WAIT_SECONDS}s — still propagating.")
 
     if cleanup:
         client.delete_memory_and_wait(memory_id=memory_id)

--- a/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/08-manage-extraction/skip-extraction.py
+++ b/01-features/04-manage-context-of-your-agent/memory/02-long-term-memory/08-manage-extraction/skip-extraction.py
@@ -13,12 +13,25 @@ The flow:
     4. Wait for extraction to complete
     5. Retrieve records — only the non-skipped events produce results
 
+Two ways to run it:
+    python skip-extraction.py boto3   # direct service calls
+    python skip-extraction.py sdk     # AgentCore MemoryClient helpers
+
+The sdk run sends events with `MemoryClient.create_event(extraction_mode=...)` rather
+than the session API. `MemorySession.add_turns()` is the usual SDK way to write turns,
+but it does not accept `extraction_mode`, and choosing that per event is the whole
+lesson here.
+
+Add `--cleanup` to delete the memory resource at the end. By default the
+memory is kept so you can inspect it; the script prints the memoryId.
+
 Prerequisites:
-    pip install boto3
+    pip install boto3 bedrock-agentcore
     export AWS_REGION=us-east-1   # use any AgentCore-supported region
 """
 
 import os
+import sys
 import time
 import uuid
 from datetime import datetime, timezone
@@ -28,6 +41,33 @@ ACTOR_ID = "user-42"
 SESSION_ID = f"sess-skip-{int(time.time())}"
 EXTRACTION_WAIT_SECONDS = 90
 NAMESPACE_TEMPLATE = "/users/{actorId}/facts/"
+
+STRATEGY = {
+    "semanticMemoryStrategy": {
+        "name": "UserFacts",
+        "namespaces": [NAMESPACE_TEMPLATE],
+    }
+}
+
+# Normal events: these WILL be extracted into long-term memory.
+NORMAL_TURNS = [
+    ("USER", "My name is Alex. I'm a software engineer."),
+    ("ASSISTANT", "Nice to meet you, Alex! What languages do you work with?"),
+    ("USER", "I mostly write Python. It's my favorite language."),
+    ("ASSISTANT", "Python is great! Where are you based?"),
+    ("USER", "I live in Berlin, Germany. I moved here two years ago."),
+    ("ASSISTANT", "Berlin is a fantastic city for tech. Anything else I should know?"),
+    ("USER", "Yes — I'm allergic to peanuts. Please keep that in mind."),
+    ("ASSISTANT", "Noted, I'll remember your peanut allergy."),
+]
+
+# Skipped events: stored in short-term memory but NOT extracted into long-term.
+SKIPPED_TURNS = [
+    ("USER", "I just won the lottery and my bank account number is 123456789."),
+    ("ASSISTANT", "That's exciting! Congratulations on winning."),
+    ("USER", "My social security number is 987-65-4321, can you store that for me?"),
+    ("ASSISTANT", "I've noted that information for you."),
+]
 
 
 # === boto3 ============================================================
@@ -41,14 +81,7 @@ def run_with_boto3(cleanup: bool = False) -> None:
         name=f"SkipExtraction_{int(time.time())}",
         description="Demonstrates extractionMode=SKIP (boto3)",
         eventExpiryDuration=30,
-        memoryStrategies=[
-            {
-                "semanticMemoryStrategy": {
-                    "name": "UserFacts",
-                    "namespaces": [NAMESPACE_TEMPLATE],
-                }
-            }
-        ],
+        memoryStrategies=[STRATEGY],
     )["memory"]["id"]
     print(f"[boto3] Created memory {memory_id}")
 
@@ -58,18 +91,7 @@ def run_with_boto3(cleanup: bool = False) -> None:
             break
         time.sleep(5)
 
-    # --- Normal events: these WILL be extracted into long-term memory ---
-    normal_turns = [
-        ("USER", "My name is Alex. I'm a software engineer."),
-        ("ASSISTANT", "Nice to meet you, Alex! What languages do you work with?"),
-        ("USER", "I mostly write Python. It's my favorite language."),
-        ("ASSISTANT", "Python is great! Where are you based?"),
-        ("USER", "I live in Berlin, Germany. I moved here two years ago."),
-        ("ASSISTANT", "Berlin is a fantastic city for tech. Anything else I should know?"),
-        ("USER", "Yes — I'm allergic to peanuts. Please keep that in mind."),
-        ("ASSISTANT", "Noted, I'll remember your peanut allergy."),
-    ]
-    for role, text in normal_turns:
+    for role, text in NORMAL_TURNS:
         data.create_event(
             memoryId=memory_id,
             actorId=ACTOR_ID,
@@ -77,16 +99,9 @@ def run_with_boto3(cleanup: bool = False) -> None:
             eventTimestamp=datetime.now(timezone.utc),
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
         )
-    print(f"[boto3] Sent {len(normal_turns)} normal events (will be extracted)")
+    print(f"[boto3] Sent {len(NORMAL_TURNS)} normal events (will be extracted)")
 
-    # --- Skipped events: stored in STM but NOT extracted into LTM ---
-    skipped_turns = [
-        ("USER", "I just won the lottery and my bank account number is 123456789."),
-        ("ASSISTANT", "That's exciting! Congratulations on winning."),
-        ("USER", "My social security number is 987-65-4321, can you store that for me?"),
-        ("ASSISTANT", "I've noted that information for you."),
-    ]
-    for role, text in skipped_turns:
+    for role, text in SKIPPED_TURNS:
         data.create_event(
             memoryId=memory_id,
             actorId=ACTOR_ID,
@@ -95,7 +110,7 @@ def run_with_boto3(cleanup: bool = False) -> None:
             payload=[{"conversational": {"role": role, "content": {"text": text}}}],
             extractionMode="SKIP",
         )
-    print(f"[boto3] Sent {len(skipped_turns)} skipped events (extractionMode=SKIP, no extraction)")
+    print(f"[boto3] Sent {len(SKIPPED_TURNS)} skipped events (extractionMode=SKIP, no extraction)")
 
     # --- Verify the skipped events are still in short-term memory ---
     events = data.list_events(
@@ -104,7 +119,8 @@ def run_with_boto3(cleanup: bool = False) -> None:
         sessionId=SESSION_ID,
         includePayloads=True,
     )["events"]
-    print(f"[boto3] Short-term memory has {len(events)} events (all 12 stored)")
+    expected_events = len(NORMAL_TURNS) + len(SKIPPED_TURNS)
+    print(f"[boto3] Short-term memory has {len(events)} events (all {expected_events} stored)")
 
     # --- Wait for extraction, then retrieve long-term records ---
     print(f"[boto3] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
@@ -127,8 +143,86 @@ def run_with_boto3(cleanup: bool = False) -> None:
         print(f"[boto3] Keeping memory {memory_id} (pass --cleanup to delete)")
 
 
-if __name__ == "__main__":
-    import sys
+# === AgentCore SDK ====================================================
+# MemoryClient covers both planes we need here: create/delete the resource, and
+# create_event/list_events/retrieve_memories for the data plane. This sample stays on
+# MemoryClient rather than MemorySessionManager because `extraction_mode` is exposed on
+# MemoryClient.create_event and NOT on the session API's add_turns() — and choosing it
+# per event is the lesson.
+def run_with_sdk(cleanup: bool = False) -> None:
+    from bedrock_agentcore.memory import MemoryClient
 
+    client = MemoryClient(region_name=REGION)
+    memory = client.create_memory_and_wait(
+        name=f"SkipExtractionSdk_{int(time.time())}",
+        description="Demonstrates extraction_mode=SKIP (SDK)",
+        strategies=[STRATEGY],
+        event_expiry_days=30,
+    )
+    memory_id = memory["id"]
+    print(f"[sdk] Created memory {memory_id}")
+
+    # messages= takes (text, role) tuples — the reverse order of the (role, text)
+    # tuples used above, so unpack accordingly. One create_event per turn keeps this
+    # directly comparable to the boto3 run above.
+    for role, text in NORMAL_TURNS:
+        client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            messages=[(text, role)],
+        )
+    print(f"[sdk] Sent {len(NORMAL_TURNS)} normal events (will be extracted)")
+
+    for role, text in SKIPPED_TURNS:
+        client.create_event(
+            memory_id=memory_id,
+            actor_id=ACTOR_ID,
+            session_id=SESSION_ID,
+            messages=[(text, role)],
+            extraction_mode="SKIP",
+        )
+    print(f"[sdk] Sent {len(SKIPPED_TURNS)} skipped events (extraction_mode=SKIP, no extraction)")
+
+    # list_events returns the list directly (not a {"events": ...} dict) and defaults
+    # to include_payload=True.
+    events = client.list_events(memory_id=memory_id, actor_id=ACTOR_ID, session_id=SESSION_ID)
+    expected_events = len(NORMAL_TURNS) + len(SKIPPED_TURNS)
+    print(f"[sdk] Short-term memory has {len(events)} events (all {expected_events} stored)")
+
+    print(f"[sdk] Waiting {EXTRACTION_WAIT_SECONDS}s for extraction...")
+    time.sleep(EXTRACTION_WAIT_SECONDS)
+
+    namespace = NAMESPACE_TEMPLATE.format(actorId=ACTOR_ID)
+    hits = client.retrieve_memories(
+        memory_id=memory_id,
+        namespace=namespace,
+        query="What do I know about Alex?",
+        top_k=10,
+    )
+    print(f"[sdk] Retrieved {len(hits)} long-term records (only from non-skipped events)")
+    for h in hits:
+        print(f"  - {h['content']['text']}")
+
+    if cleanup:
+        client.delete_memory_and_wait(memory_id=memory_id)
+        print(f"[sdk] Deleted memory {memory_id}")
+    else:
+        print(f"[sdk] Keeping memory {memory_id} (pass --cleanup to delete)")
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if a != "--cleanup"]
     cleanup = "--cleanup" in sys.argv[1:]
-    run_with_boto3(cleanup=cleanup)
+    surface = args[0] if args else "boto3"
+    if surface == "boto3":
+        run_with_boto3(cleanup=cleanup)
+    elif surface == "sdk":
+        run_with_sdk(cleanup=cleanup)
+    else:
+        print(f"Unknown surface {surface!r}. Use boto3 | sdk.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three samples report a result the run does not support. All three exit 0 while doing it, so nothing flags the failure. Found by running every command in these folders' READMEs against a live account and checking the retrieved records rather than the exit code.

Each commit is one root cause and can be reviewed on its own.

## `b75e005c` — reading directly-written records before they propagate

Records written with `BatchCreateMemoryRecords` are eventually consistent, and both samples that use them read back too early.

**`07-batch-apis/batch-create-update-delete.py`** creates 3 records, deletes 1, then prints `Remaining (0)` when 2 should remain. Reproduces on both surfaces.

The file already retries `ResourceNotFoundException` for `BatchUpdate`/`BatchDelete` via `_retry_until_propagated`. That helper cannot cover the final read, because an unpropagated `ListMemoryRecords` does not raise — it succeeds and returns an empty page. `List` also lags the furthest behind: measured live, update and delete both succeeded on the first attempt while the surviving records took ~87s to become listable. The module docstring said the opposite (that `List` leads updatability) and is corrected.

**`06-record-metadata/structured-metadata.py`** filters on `region=EU` after a fixed `sleep(35)`, with a comment putting propagation at ~30s. Measured over three runs, records became searchable at 75s, 86s and 97s. The sleep was short every time; the runs that passed did so only under load that slowed them into the window.

Both now poll for the **expected record count** rather than for a non-empty result. That matters: an earlier version of the metadata fix broke on the first hit and returned 1 of the 2 EU records, which reads as though the filter dropped one. The counts are deterministic here because the records are written directly rather than extracted.

## `4eac09a8` — `skip-extraction.py sdk` silently ran the boto3 path

`08-manage-extraction/README.md` documents both `boto3` and `sdk`, but the script defined only `run_with_boto3` and its entrypoint read nothing except `--cleanup`. Passing `sdk` ran boto3. It exits 0 with correct records, so the only tells were `[boto3]` labels in an `sdk` run.

This is the only such mismatch in the area — all 16 README-documented `sdk` commands under `00-getting-started`, `01-short-term-memory` and `02-long-term-memory` were checked against the functions their scripts define.

Adds the missing surface rather than removing the documented command, keeping the two-way structure every other sample has. It uses `MemoryClient.create_event(extraction_mode=...)` rather than the session API, because `add_turns()` does not accept `extraction_mode` and choosing extraction per event is the whole lesson. `main()` now dispatches like its siblings, so an unknown surface exits 1 instead of silently running boto3.

## Verification

All live in `us-east-1`, `boto3 1.43.58` / `bedrock-agentcore 1.19.0`, run in parallel.

| Sample | Before | After |
|---|---|---|
| `batch-create-update-delete.py` (both surfaces) | `Remaining (0)` | `Remaining (2)`, update reflected, deleted record absent |
| `structured-metadata.py` (both surfaces) | `EU-only results (0)` | `EU-only results (2)`, no US record through the filter |
| `skip-extraction.py sdk` | ran the boto3 path | runs the SDK path; 12 events stored, 0 skipped events extracted |

4 runs each for the first two (2 trials x 2 surfaces), all correct. Unknown-surface dispatch confirmed to exit 1 without an AWS call. No leaked memory resources.

Passes `ruff check` and `ruff format --check` per `.github/workflows/python-lint.yml`.

## Relationship to #1847 and #1848

No file overlap with either, so this merges independently in any order. Same theme as #1848 (an async operation treated as synchronous) but a different mechanism: #1848 waits on model-driven *extraction*, this waits on *propagation* of records written directly. Note `08-manage-extraction/README.md` is touched by #1847, not here — the `sdk` command this commit implements was already documented there.
