### PR TITLE
feat(gateway): verify Coinbase Bazaar curation

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/README.md
@@ -109,8 +109,27 @@ agentcore deploy -y
 agentcore fetch access --name BazaarGateway --type gateway
 ```
 
-The `fetch access` output includes the Gateway URL you'll use in Step 2. If your Gateway uses
-`CUSTOM_JWT` inbound auth, the same output also lists `CLIENT_ID`, `CLIENT_SECRET`, and `TOKEN_URL`.
+The `fetch access` output includes the Gateway URL you'll use in Step 2. For a `CUSTOM_JWT`
+gateway it also prints a ready-to-use bearer token (and its expiry); the `CLIENT_ID`,
+`CLIENT_SECRET`, and `TOKEN_URL` the scripts need in Step 2 come from your OIDC provider, not from
+`fetch access` — see the note below.
+
+> **Enabling `CUSTOM_JWT` inbound auth (optional; the more secure choice for anything beyond local
+> experimentation).** The Gateway defaults to `NONE` inbound auth. To require a JWT instead, supply
+> an **existing** OIDC issuer when you add the gateway — the CLI does **not** create an identity
+> provider for you:
+> ```bash
+> agentcore add gateway --name BazaarGateway \
+>   --protocol-type MCP \
+>   --authorizer-type CUSTOM_JWT \
+>   --discovery-url https://<issuer>/.well-known/openid-configuration \
+>   --allowed-clients <client-id> \
+>   --client-id <client-id> --client-secret <client-secret>
+> ```
+> Any OIDC provider works — for example an Amazon Cognito user pool with a machine-to-machine
+> (`client_credentials`) app client. Use that provider's values for `CLIENT_ID`, `CLIENT_SECRET`,
+> and `TOKEN_URL` in Step 2; the scripts auto-detect them and attach the bearer token. (The
+> `--client-id`/`--client-secret` passed here let the CLI mint tokens for `fetch access`.)
 
 > **Prefer the Console?** Gateway → Create Gateway → Add Target → target type **Integrations** →
 > **Coinbase x402 Bazaar** (no outbound auth needed) configures the same Bazaar MCP server — the
@@ -126,8 +145,8 @@ GATEWAY_URL=https://<gateway-id>.gateway.bedrock-agentcore.<region>.amazonaws.co
 ```
 
 If your Gateway uses `CUSTOM_JWT` inbound auth, also add `CLIENT_ID`, `CLIENT_SECRET`, and
-`TOKEN_URL` from the `agentcore fetch access` output. If it uses `NONE` auth (the default), leave them
-unset — the script auto-detects which to use.
+`TOKEN_URL` from your OIDC provider (the identity provider you configured in Step 1). If it uses
+`NONE` auth (the default), leave them unset — the script auto-detects which to use.
 
 ### Step 3 — Run the discovery-driven agent
 
@@ -150,8 +169,9 @@ budget, and the `AgentCorePaymentsPlugin` handles each 402 automatically.
    with the SDK.
 3. **Connects to the Gateway** over MCP streamable HTTP (auto-detecting `NONE` vs `CUSTOM_JWT` auth)
    and builds a Strands agent with the Bazaar tools + `AgentCorePaymentsPlugin`.
-4. Runs four discovery scenarios: discover-and-call a paid tool, compare prices across categories,
-   make a budget-aware selection under $0.10, and chain multiple paid calls in one session.
+4. Runs five discovery scenarios: discover-and-call a paid tool, compare prices across categories,
+   make a budget-aware selection under $0.10, chain multiple paid calls in one session, and verify
+   the Bazaar's curation layer is active (`curatedOnly` search — no payment).
 5. **Prints session spend** (budget, remaining, spent) and a CloudWatch traces link.
 
 The discover → call → 402 → pay → retry sequence across the Gateway and Bazaar looks like this:
@@ -166,13 +186,42 @@ The discover → call → 402 → pay → retry sequence across the Gateway and 
 - Confirm `.env` has `GATEWAY_URL` set (and `CLIENT_ID`/`CLIENT_SECRET`/`TOKEN_URL` if `CUSTOM_JWT`).
 - The script itself prints per-session spend and remaining budget after the Bazaar calls.
 
+### Verify the Bazaar target through the Gateway (no payment)
+
+Confirm the three Bazaar tools are discoverable and that Coinbase's **curation** layer is active —
+neither requires a funded wallet.
+
+```bash
+# Confirm curation is enabled and the curatedOnly filter is honored (read-only, no payment).
+# Reports curated vs. uncurated coverage and a category breakdown.
+python validate_bazaar_curation.py
+```
+
+The three tools are exposed under the target-name prefix `CoinbaseBazaar___` —
+`CoinbaseBazaar___search_resources`, `CoinbaseBazaar___proxy_tool_call`, and
+`CoinbaseBazaar___validate_endpoint`. `validate_bazaar_curation.py` lists them at the top of its
+output as a quick health check.
+
+> **On "how many curated endpoints?"** `search_resources` returns at most 20 results per call, sets
+> `partialResults=true` when more match, and has **no offset/cursor** — so the full catalog can't be
+> enumerated through the API. The script reports the distinct curated endpoints it discovered across
+> a set of probe queries as a **lower bound**, and proves curation is working by showing the
+> `curatedOnly` filter excludes non-curated resources — it does not assert an exact count.
+
+Optionally, check whether an x402 URL is Bazaar-ready (read-only diagnostics, no payment):
+
+```bash
+python validate_endpoint_example.py https://api.example.com/your-endpoint GET
+```
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
 | `GATEWAY_URL not set in .env` | Gateway URL missing | Complete Step 1, then add `GATEWAY_URL=<url>` to the shared `.env` (Step 2) |
 | `agentcore: command not found` | AgentCore CLI not installed | `npm install -g @aws/agentcore` |
-| MCP connection fails / 401 / 403 | Gateway not deployed, or wrong/missing auth | `agentcore status` to confirm deploy; for `CUSTOM_JWT`, set `CLIENT_ID`/`CLIENT_SECRET`/`TOKEN_URL` from `agentcore fetch access` |
+| MCP connection fails / 401 / 403 | Gateway not deployed, or wrong/missing auth | `agentcore status` to confirm deploy; for `CUSTOM_JWT`, set `CLIENT_ID`/`CLIENT_SECRET`/`TOKEN_URL` from your OIDC provider (README Step 1) |
+| `ModuleNotFoundError: No module named 'requests'` | Older install predating the `requests` dependency | `pip install -r requirements.txt` (needed for the `CUSTOM_JWT` OAuth token fetch) |
 | `AssertionError: Instrument is ... — fund and delegate` | Instrument not `ACTIVE` | Fund the wallet with testnet USDC and grant delegated signing (Tutorial 00 or Tutorial 03) |
 | `search_resources` returns no results | Bazaar index / narrow query | Try broader terms like "market" or "weather"; verify the target endpoint is reachable |
 | `duplicate key: Set-Cookie` (or repeated transport errors) on `search_resources` / `proxy_tool_call` | Transient Coinbase Bazaar infrastructure issue — not your code or wallet | Re-run in a few minutes. The agent is instructed to stop after one retry rather than loop; no funds are charged on a failed settlement |

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/bazaar_gateway_agent.py
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/bazaar_gateway_agent.py
@@ -83,7 +83,7 @@ if not GATEWAY_URL:
         "then add GATEWAY_URL=<your-gateway-url> to .env and re-run."
     )
 
-from bedrock_agentcore.payments import PaymentManager  # noqa: E402
+from bedrock_agentcore.payments import PaymentManager
 
 manager = PaymentManager(payment_manager_arn=PAYMENT_MANAGER_ARN, region_name=REGION)
 instr = manager.get_payment_instrument(user_id=USER_ID, payment_instrument_id=INSTRUMENT_ID)
@@ -117,15 +117,14 @@ print(f"Created payment session: {SESSION_ID} (budget ${SESSION_BUDGET['maxSpend
 
 # ── Step 4: Connect to Gateway and Create Agent ───────────────────────────────
 print("\n── Step 4: Connect to Gateway and Create Agent ──")
-from mcp.client.streamable_http import streamablehttp_client  # noqa: E402
-from strands import Agent  # noqa: E402
-from strands.models import BedrockModel  # noqa: E402
-from strands.tools.mcp.mcp_client import MCPClient  # noqa: E402
-
-from bedrock_agentcore.payments.integrations.strands import (  # noqa: E402
+from bedrock_agentcore.payments.integrations.strands import (
     AgentCorePaymentsPlugin,
     AgentCorePaymentsPluginConfig,
 )
+from mcp.client.streamable_http import streamablehttp_client
+from strands import Agent
+from strands.models import BedrockModel
+from strands.tools.mcp.mcp_client import MCPClient
 
 # Gateway auth — auto-detect from .env
 gateway_headers = {}
@@ -259,6 +258,19 @@ with mcp_client:
 
     if getattr(result, "stop_reason", None) == "interrupt" or getattr(result, "interrupts", None):
         print("\n⚠️  A payment did not settle in Step 5d. Continuing to spend report.")
+
+    # ── Step 5e: Verify Bazaar Curation ──────────────────────────────────────
+    # Discovery-only (no proxy_tool_call, so no payment): exercises the curatedOnly
+    # filter to confirm Coinbase's curation layer is active. A single search returns
+    # at most 20 results, so this samples categories rather than counting the catalog.
+    print("\n── Step 5e: Verify Bazaar Curation ──")
+    result = agent(
+        "Use search_resources with curatedOnly=true to look at Coinbase-curated tools only. "
+        "Do NOT call any tool (no proxy_tool_call) — this is a read-only curation check. "
+        "List 5 example categories you see among the curated results (for example: web search, "
+        "finance, travel, crypto, maps), and confirm whether the curation layer appears active."
+    )
+    print(result.message)
 
 # ── Step 6: Check Session Spend ──────────────────────────────────────────────
 print("\n── Step 6: Check Session Spend ──")

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/requirements.txt
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/requirements.txt
@@ -9,5 +9,10 @@ strands-agents>=1.0.0
 # MCP client for Gateway connection
 mcp>=1.0.0
 
+# HTTP client for the OAuth token fetch on CUSTOM_JWT gateways
+# (utils.get_oauth_token). Only exercised when the Gateway uses CUSTOM_JWT
+# inbound auth, but required for that path to run.
+requests>=2.32.0
+
 # Config
 python-dotenv>=1.0.0

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_bazaar_curation.py
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_bazaar_curation.py
@@ -8,13 +8,24 @@ GATEWAY_URL in the shared .env).
 What it checks (read-only — no payments, no wallet required):
   1. The Gateway exposes the three Bazaar tools (search_resources, proxy_tool_call,
      validate_endpoint), prefixed with the target name (e.g. CoinbaseBazaar___...).
-  2. search_resources accepts the `curatedOnly` filter and the filter is HONORED —
-     i.e. an uncurated search surfaces resources a curated search does not.
+  2. Curation is enabled and honored. The Bazaar returns curated resources BY DEFAULT,
+     so the check does not pass a redundant curatedOnly=true; instead it verifies, from
+     each result's own curation metadata:
+       - the DEFAULT search (no curatedOnly) returns only curated resources — every
+         result carries _meta["x402/curation"].curated == true; and
+       - a curatedOnly=false search surfaces resources that omit that block entirely
+         (genuinely uncurated endpoints the default view hides), proving the filter
+         actually narrows results.
 
-Note on counting: search_resources returns at most 20 results per call, sets
-`partialResults=true` when more match, and has no offset/cursor — so the full catalog
-cannot be enumerated. This script reports the number of DISTINCT curated endpoints it
-discovered across a set of probe queries as a LOWER BOUND, not the catalog size.
+Why per-result metadata, not set math: search_resources returns at most 20 results per
+call, sets `partialResults=true` when more match, and has no offset/cursor — each result
+set is a relevance-ranked, truncated sample. Comparing two such samples by set difference
+is unreliable (they can differ from ranking alone). The per-result `curated` flag is
+deterministic, so the verdict uses it.
+
+Note on counting: because of the 20-result cap and lack of pagination, the full catalog
+cannot be enumerated. Endpoint counts below are the DISTINCT resources discovered across a
+set of probe queries — a LOWER BOUND, not the catalog size.
 
 Usage:
     python validate_bazaar_curation.py
@@ -25,9 +36,8 @@ as bazaar_gateway_agent.py). NONE-auth gateways need no credentials.
 
 Note: you may see MCP output-schema validation warnings on stderr. The Bazaar returns extra
 fields (e.g. `bundleSlugs`) that its advertised _meta.x402/curation schema doesn't declare, so
-strict validation rejects the response ("Additional properties are not allowed"). The warnings
-are benign (server-side schema drift) and do not affect the verdict — they only make the
-discovered count a conservative lower bound.
+strict validation rejects those responses. Such a probe is skipped (counted below) rather than
+failing the run, which only makes the discovered counts a more conservative lower bound.
 """
 
 import json
@@ -99,30 +109,46 @@ def _extract_json(tool_result):
     return {}
 
 
+def _is_curated(tool):
+    """True if the resource is tagged curated. Curated resources carry
+    _meta["x402/curation"].curated == true; uncurated resources omit that block entirely
+    (per the Bazaar schema), so absence of the flag means uncurated."""
+    meta = tool.get("_meta") or {}
+    curation = meta.get("x402/curation") or {}
+    return curation.get("curated") is True
+
+
 def search(mcp_client, query, curated_only, idx):
     """Call search_resources through the Gateway; return (tools, partialResults).
 
-    Some Bazaar responses fail Strands' output-schema validation (the server returns extra
-    fields its advertised _meta.x402/curation schema doesn't declare, e.g. `bundleSlugs`),
-    which raises here. We treat that as a skipped probe rather than a hard failure, so counts
-    are a lower bound.
+    `curated_only` is True/False to set the filter, or None to omit it (the Bazaar's
+    default, which returns curated resources only).
+
+    Returns (None, False) for a skipped probe. Some Bazaar responses fail Strands'
+    output-schema validation because the server returns extra fields its advertised
+    _meta.x402/curation schema doesn't declare (e.g. `bundleSlugs`). Depending on the
+    installed Strands/mcp version that surfaces either as a raised exception or as an
+    error ToolResult (status == "error") — both are treated as a skipped probe, so one
+    bad response never tanks the run and counts stay a lower bound.
     """
+    arguments = {"query": query, "limit": 20}
+    if curated_only is not None:
+        arguments["curatedOnly"] = curated_only
     try:
-        result = mcp_client.call_tool_sync(
-            tool_use_id=f"validate-{idx}",
-            name=SEARCH_TOOL,
-            arguments={"query": query, "curatedOnly": curated_only, "limit": 20},
-        )
+        result = mcp_client.call_tool_sync(tool_use_id=f"validate-{idx}", name=SEARCH_TOOL, arguments=arguments)
     except Exception as e:  # noqa: BLE001 — one bad response shouldn't tank the run
         print(f"  (skipped query {query!r} curatedOnly={curated_only}: {type(e).__name__})")
+        return None, False
+    if isinstance(result, dict) and result.get("status") == "error":
+        print(f"  (skipped query {query!r} curatedOnly={curated_only}: error ToolResult)")
         return None, False
     payload = _extract_json(result)
     return payload.get("tools", []), payload.get("partialResults", False)
 
 
 def discover(mcp_client, curated_only):
-    """Run every probe query; return {tool_name: description} deduped, whether any call
-    reported partialResults, and how many probes were skipped."""
+    """Run every probe query; return ({tool_name: (description, is_curated)}, whether any
+    call reported partialResults, and how many probes were skipped)."""
     found, partial_seen, skipped = {}, False, 0
     for i, q in enumerate(QUERIES):
         tools, partial = search(mcp_client, q, curated_only, i)
@@ -131,13 +157,13 @@ def discover(mcp_client, curated_only):
             continue
         partial_seen = partial_seen or bool(partial)
         for t in tools:
-            found[t["name"]] = t.get("description", "") or ""
+            found[t["name"]] = (t.get("description", "") or "", _is_curated(t))
     return found, partial_seen, skipped
 
 
 def categorize(tools):
     counts = {c: 0 for c in CATEGORIES}
-    for name, desc in tools.items():
+    for name, (desc, _curated) in tools.items():
         hay = f"{name} {desc}".lower()
         for cat, kws in CATEGORIES.items():
             if any(kw in hay for kw in kws):
@@ -184,49 +210,63 @@ def main():
         if missing:
             print(f"⚠️  Expected Bazaar tools not found: {sorted(missing)}")
 
-        # 2) Curated vs. uncurated
-        print(f"\nProbing search_resources with {len(QUERIES)} queries (curatedOnly=true and false)...")
-        curated, curated_partial, curated_skipped = discover(mcp_client, True)
-        uncurated, uncurated_partial, uncurated_skipped = discover(mcp_client, False)
+        # 2) Default view vs. unfiltered view. The Bazaar returns curated results by
+        # default, so we DON'T pass a redundant curatedOnly=true — we verify the default
+        # is curated-only, then pass curatedOnly=false to lift the filter and let
+        # uncurated resources through.
+        print(f"\nProbing search_resources with {len(QUERIES)} queries (default, then curatedOnly=false)...")
+        default_view, default_partial, default_skipped = discover(mcp_client, None)
+        unfiltered, unfiltered_partial, unfiltered_skipped = discover(mcp_client, False)
 
-    curated_only_names = set(curated) - set(uncurated)
-    uncurated_only_names = set(uncurated) - set(curated)
+    # Judge on each result's own curation flag (deterministic), not on set differences
+    # between two truncated, relevance-ranked samples (which can differ by ranking alone).
+    default_uncurated = sum(1 for _, (_, is_cur) in default_view.items() if not is_cur)
+    unfiltered_uncurated = sum(1 for _, (_, is_cur) in unfiltered.items() if not is_cur)
 
     print(f"\n{'=' * 64}")
-    print(f"Distinct curated endpoints discovered:   {len(curated)}  (lower bound)")
-    print(f"Distinct uncurated endpoints discovered: {len(uncurated)}  (lower bound)")
-    print(f"partialResults seen (more exist):        curated={curated_partial}, uncurated={uncurated_partial}")
-    if curated_skipped or uncurated_skipped:
-        print(f"probes skipped (output-schema validation):curated={curated_skipped}, uncurated={uncurated_skipped}")
+    print(f"Default view (no curatedOnly):       {len(default_view):3} distinct, {default_uncurated} uncurated")
+    print(
+        f"Unfiltered view (curatedOnly=false):{len(unfiltered):4} distinct, {unfiltered_uncurated} genuinely uncurated"
+    )
+    print(f"partialResults seen (more exist):    default={default_partial}, unfiltered={unfiltered_partial}")
+    if default_skipped or unfiltered_skipped:
+        print(f"probes skipped (schema validation):  default={default_skipped}, unfiltered={unfiltered_skipped}")
+    print("(counts are query-dependent lower bounds — 20 results/call, no pagination)")
     print(f"{'=' * 64}")
 
-    cats = categorize(curated)
+    cats = categorize(default_view)
     if cats:
         print("\nCurated endpoints by category (sample):")
         for cat, n in sorted(cats.items(), key=lambda kv: -kv[1]):
             print(f"  {n:3}  {cat}")
 
-    # Verdict: curation is ENABLED and HONORED if curated returns results AND the
-    # uncurated search surfaces resources the curated search excludes.
+    # Verdict — deterministic, from per-result curation metadata:
+    #   PASS = the default search returns resources AND none are uncurated (Bazaar
+    #          defaults to curated-only) AND curatedOnly=false surfaces genuinely-uncurated
+    #          resources the default view hides (the filter meaningfully narrows results).
     print(f"\n{'=' * 64}")
-    curation_returns = len(curated) > 0
-    filter_narrows = len(uncurated_only_names) > 0
-    if curation_returns and filter_narrows:
+    default_returns = len(default_view) > 0
+    default_is_curated = default_returns and default_uncurated == 0
+    filter_reveals_uncurated = unfiltered_uncurated > 0
+
+    if default_is_curated and filter_reveals_uncurated:
         print("✅ PASS — curation is enabled and the curatedOnly filter is honored.")
-        print(
-            f"   curated set is distinct from uncurated ({len(uncurated_only_names)} "
-            f"uncurated-only endpoints excluded by the filter)."
-        )
-        print("   NOTE: the count above is a query-dependent lower bound, not the catalog size")
-        print("   (search_resources caps at 20 results/call with no pagination).")
+        print(f"   the default search returns curated resources only ({len(default_view)} distinct, all")
+        print(f"   tagged curated=true), and curatedOnly=false surfaced {unfiltered_uncurated} uncurated")
+        print("   resource(s) the default view hides — so the filter genuinely narrows results.")
         code = 0
-    elif curation_returns and not filter_narrows:
-        print("⚠️  INCONCLUSIVE — curatedOnly=true returned results, but curated and uncurated")
-        print("   sets were identical across these probes. Curation may not be enabled on this")
-        print("   endpoint, or the probe set was too narrow. Try broadening QUERIES.")
+    elif default_returns and not default_is_curated:
+        print("⚠️  UNEXPECTED — the default search returned uncurated resources, so this endpoint")
+        print(f"   does not appear to default to curated-only ({default_uncurated} of {len(default_view)} untagged).")
+        print("   Curation may be disabled for this endpoint.")
+        code = 2
+    elif default_is_curated and not filter_reveals_uncurated:
+        print("⚠️  INCONCLUSIVE — the default view is curated-only, but no uncurated resources")
+        print("   surfaced with curatedOnly=false across these probes. Curation may cover")
+        print("   everything queried, or the probe set was too narrow. Broaden QUERIES.")
         code = 2
     else:
-        print("❌ FAIL — curatedOnly=true returned no endpoints. Check that the Bazaar target is")
+        print("❌ FAIL — the default search returned no endpoints. Check that the Bazaar target is")
         print("   reachable and that curation is enabled for this endpoint.")
         code = 1
     print(f"{'=' * 64}")

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_bazaar_curation.py
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_bazaar_curation.py
@@ -1,0 +1,237 @@
+"""
+Validate Bazaar Curation — standalone verification script.
+
+Confirms that the Coinbase x402 Bazaar's **curation** layer is active and honored
+through your AgentCore Gateway. Run after Step 1 of the README (Gateway deployed and
+GATEWAY_URL in the shared .env).
+
+What it checks (read-only — no payments, no wallet required):
+  1. The Gateway exposes the three Bazaar tools (search_resources, proxy_tool_call,
+     validate_endpoint), prefixed with the target name (e.g. CoinbaseBazaar___...).
+  2. search_resources accepts the `curatedOnly` filter and the filter is HONORED —
+     i.e. an uncurated search surfaces resources a curated search does not.
+
+Note on counting: search_resources returns at most 20 results per call, sets
+`partialResults=true` when more match, and has no offset/cursor — so the full catalog
+cannot be enumerated. This script reports the number of DISTINCT curated endpoints it
+discovered across a set of probe queries as a LOWER BOUND, not the catalog size.
+
+Usage:
+    python validate_bazaar_curation.py
+
+Requires: GATEWAY_URL in the shared .env (00-getting-started/.env). If the Gateway uses
+CUSTOM_JWT inbound auth, also CLIENT_ID / CLIENT_SECRET / TOKEN_URL (auto-detected, same
+as bazaar_gateway_agent.py). NONE-auth gateways need no credentials.
+
+Note: you may see MCP output-schema validation warnings on stderr. The Bazaar returns extra
+fields (e.g. `bundleSlugs`) that its advertised _meta.x402/curation schema doesn't declare, so
+strict validation rejects the response ("Additional properties are not allowed"). The warnings
+are benign (server-side schema drift) and do not affect the verdict — they only make the
+discovered count a conservative lower bound.
+"""
+
+import json
+import os
+import sys
+from datetime import timedelta
+
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mcp.client.streamable_http import streamablehttp_client
+from strands.tools.mcp.mcp_client import MCPClient
+
+# Shared Tutorial 00 .env (one directory up)
+ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
+load_dotenv(ENV_FILE, override=True)
+
+# Gateway target name used when the target was added (agentcore add gateway-target
+# --name CoinbaseBazaar ...). Gateway prefixes each tool with "<target>___".
+TARGET = os.environ.get("BAZAAR_TARGET_NAME", "CoinbaseBazaar")
+SEARCH_TOOL = f"{TARGET}___search_resources"
+
+# Probe queries — diverse terms so the 20-result-per-call cap surfaces a wide sample.
+# More/broader queries discover more distinct endpoints; this is a sample, not a census.
+QUERIES = [
+    "",
+    "search",
+    "data",
+    "weather",
+    "email",
+    "file",
+    "image",
+    "code",
+    "travel",
+    "finance",
+    "ai",
+    "api",
+    "crypto",
+    "stock",
+    "market",
+    "map",
+    "price",
+    "news",
+]
+
+# Rough category buckets for a human-readable breakdown of what curation surfaces.
+CATEGORIES = {
+    "web search": ["search", "tavily", "exa", "serp", "google"],
+    "finance/markets": ["stock", "price", "sec", "earning", "market", "defi", "kalshi", "polymarket", "messari"],
+    "crypto/onchain": ["wallet", "token", "dex", "chain", "nft", "blockchain", "solana", "eth"],
+    "travel": ["flight", "travel", "hotel", "seats", "tripadvisor"],
+    "maps/local": ["map", "nearby", "solar", "geo", "place"],
+    "enrichment/contacts": ["contact", "whitepages", "reddit", "clado", "people"],
+    "dev tools": ["screenshot", "upload", "openrouter", "lens", "render"],
+    "weather": ["weather", "forecast", "climate"],
+}
+
+
+def _extract_json(tool_result):
+    """Pull the JSON payload out of a Strands ToolResult (content is a list of blocks)."""
+    for block in tool_result.get("content", []) or []:
+        text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+        if text:
+            try:
+                return json.loads(text)
+            except (ValueError, TypeError):
+                continue
+    return {}
+
+
+def search(mcp_client, query, curated_only, idx):
+    """Call search_resources through the Gateway; return (tools, partialResults).
+
+    Some Bazaar responses fail Strands' output-schema validation (the server returns extra
+    fields its advertised _meta.x402/curation schema doesn't declare, e.g. `bundleSlugs`),
+    which raises here. We treat that as a skipped probe rather than a hard failure, so counts
+    are a lower bound.
+    """
+    try:
+        result = mcp_client.call_tool_sync(
+            tool_use_id=f"validate-{idx}",
+            name=SEARCH_TOOL,
+            arguments={"query": query, "curatedOnly": curated_only, "limit": 20},
+        )
+    except Exception as e:  # noqa: BLE001 — one bad response shouldn't tank the run
+        print(f"  (skipped query {query!r} curatedOnly={curated_only}: {type(e).__name__})")
+        return None, False
+    payload = _extract_json(result)
+    return payload.get("tools", []), payload.get("partialResults", False)
+
+
+def discover(mcp_client, curated_only):
+    """Run every probe query; return {tool_name: description} deduped, whether any call
+    reported partialResults, and how many probes were skipped."""
+    found, partial_seen, skipped = {}, False, 0
+    for i, q in enumerate(QUERIES):
+        tools, partial = search(mcp_client, q, curated_only, i)
+        if tools is None:
+            skipped += 1
+            continue
+        partial_seen = partial_seen or bool(partial)
+        for t in tools:
+            found[t["name"]] = t.get("description", "") or ""
+    return found, partial_seen, skipped
+
+
+def categorize(tools):
+    counts = {c: 0 for c in CATEGORIES}
+    for name, desc in tools.items():
+        hay = f"{name} {desc}".lower()
+        for cat, kws in CATEGORIES.items():
+            if any(kw in hay for kw in kws):
+                counts[cat] += 1
+    return {c: n for c, n in counts.items() if n}
+
+
+def main():
+    gateway_url = os.environ.get("GATEWAY_URL", "")
+    if not gateway_url:
+        print("ERROR: GATEWAY_URL not set in .env. Deploy the Gateway first (README Step 1).")
+        sys.exit(1)
+
+    # Gateway auth — auto-detect from .env (same logic as bazaar_gateway_agent.py)
+    gateway_headers = {}
+    client_id = os.environ.get("CLIENT_ID")
+    client_secret = os.environ.get("CLIENT_SECRET")
+    token_url = os.environ.get("TOKEN_URL")
+    if client_id and client_secret and token_url:
+        from utils import get_oauth_token
+
+        token = get_oauth_token(token_url, client_id, client_secret)
+        gateway_headers = {"Authorization": f"Bearer {token}"}
+        print("Gateway auth: CUSTOM_JWT (OAuth token acquired)")
+    else:
+        print("Gateway auth: NONE (no CLIENT_ID/CLIENT_SECRET/TOKEN_URL in .env)")
+
+    print(f"Gateway: {gateway_url}")
+
+    mcp_client = MCPClient(
+        lambda: streamablehttp_client(
+            gateway_url,
+            headers=gateway_headers,
+            timeout=timedelta(seconds=120),
+        )
+    )
+
+    with mcp_client:
+        # 1) Tool surface check
+        tool_names = [t.tool_name for t in mcp_client.list_tools_sync()]
+        print(f"\nGateway exposes {len(tool_names)} tool(s): {tool_names}")
+        expected = {f"{TARGET}___search_resources", f"{TARGET}___proxy_tool_call", f"{TARGET}___validate_endpoint"}
+        missing = expected - set(tool_names)
+        if missing:
+            print(f"⚠️  Expected Bazaar tools not found: {sorted(missing)}")
+
+        # 2) Curated vs. uncurated
+        print(f"\nProbing search_resources with {len(QUERIES)} queries (curatedOnly=true and false)...")
+        curated, curated_partial, curated_skipped = discover(mcp_client, True)
+        uncurated, uncurated_partial, uncurated_skipped = discover(mcp_client, False)
+
+    curated_only_names = set(curated) - set(uncurated)
+    uncurated_only_names = set(uncurated) - set(curated)
+
+    print(f"\n{'=' * 64}")
+    print(f"Distinct curated endpoints discovered:   {len(curated)}  (lower bound)")
+    print(f"Distinct uncurated endpoints discovered: {len(uncurated)}  (lower bound)")
+    print(f"partialResults seen (more exist):        curated={curated_partial}, uncurated={uncurated_partial}")
+    if curated_skipped or uncurated_skipped:
+        print(f"probes skipped (output-schema validation):curated={curated_skipped}, uncurated={uncurated_skipped}")
+    print(f"{'=' * 64}")
+
+    cats = categorize(curated)
+    if cats:
+        print("\nCurated endpoints by category (sample):")
+        for cat, n in sorted(cats.items(), key=lambda kv: -kv[1]):
+            print(f"  {n:3}  {cat}")
+
+    # Verdict: curation is ENABLED and HONORED if curated returns results AND the
+    # uncurated search surfaces resources the curated search excludes.
+    print(f"\n{'=' * 64}")
+    curation_returns = len(curated) > 0
+    filter_narrows = len(uncurated_only_names) > 0
+    if curation_returns and filter_narrows:
+        print("✅ PASS — curation is enabled and the curatedOnly filter is honored.")
+        print(
+            f"   curated set is distinct from uncurated ({len(uncurated_only_names)} "
+            f"uncurated-only endpoints excluded by the filter)."
+        )
+        print("   NOTE: the count above is a query-dependent lower bound, not the catalog size")
+        print("   (search_resources caps at 20 results/call with no pagination).")
+        code = 0
+    elif curation_returns and not filter_narrows:
+        print("⚠️  INCONCLUSIVE — curatedOnly=true returned results, but curated and uncurated")
+        print("   sets were identical across these probes. Curation may not be enabled on this")
+        print("   endpoint, or the probe set was too narrow. Try broadening QUERIES.")
+        code = 2
+    else:
+        print("❌ FAIL — curatedOnly=true returned no endpoints. Check that the Bazaar target is")
+        print("   reachable and that curation is enabled for this endpoint.")
+        code = 1
+    print(f"{'=' * 64}")
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_endpoint_example.py
+++ b/01-features/08-agents-that-transact/00-getting-started/04-agent-with-coinbase-bazaar-via-gateway/validate_endpoint_example.py
@@ -1,0 +1,97 @@
+"""
+Validate an x402 Endpoint — optional Bazaar seller-readiness example.
+
+Demonstrates the Bazaar's third tool, `validate_endpoint`: read-only diagnostics that
+probe an x402 URL and report whether it is correctly configured for Bazaar discovery
+(HTTPS, returns 402, valid x402 v2 payload, accepts[] fields, discovery extension, and
+whether the facilitator would index it). It does NOT make a payment or index anything —
+useful if you're publishing your own paid tool and want to check it's Bazaar-ready.
+
+Usage:
+    python validate_endpoint_example.py <https-url> [http-method]
+    # or set X402_URL / X402_METHOD in the environment
+
+Example:
+    python validate_endpoint_example.py https://api.example.com/weather GET
+
+Requires: GATEWAY_URL in the shared .env (00-getting-started/.env). CUSTOM_JWT gateways
+also need CLIENT_ID / CLIENT_SECRET / TOKEN_URL (auto-detected, same as the other scripts).
+"""
+
+import json
+import os
+import sys
+from datetime import timedelta
+
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mcp.client.streamable_http import streamablehttp_client
+from strands.tools.mcp.mcp_client import MCPClient
+
+ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
+load_dotenv(ENV_FILE, override=True)
+
+TARGET = os.environ.get("BAZAAR_TARGET_NAME", "CoinbaseBazaar")
+VALIDATE_TOOL = f"{TARGET}___validate_endpoint"
+
+
+def _extract_json(tool_result):
+    for block in tool_result.get("content", []) or []:
+        text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+        if text:
+            try:
+                return json.loads(text)
+            except (ValueError, TypeError):
+                return {"raw": text}
+    return {}
+
+
+def main():
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("X402_URL")
+    method = sys.argv[2] if len(sys.argv) > 2 else os.environ.get("X402_METHOD", "GET")
+    if not url:
+        print("Usage: python validate_endpoint_example.py <https-url> [http-method]")
+        print("Tip: pass the URL of an x402 endpoint you want to check for Bazaar readiness.")
+        sys.exit(1)
+
+    gateway_url = os.environ.get("GATEWAY_URL", "")
+    if not gateway_url:
+        print("ERROR: GATEWAY_URL not set in .env. Deploy the Gateway first (README Step 1).")
+        sys.exit(1)
+
+    # Gateway auth — auto-detect (same logic as bazaar_gateway_agent.py)
+    gateway_headers = {}
+    client_id = os.environ.get("CLIENT_ID")
+    client_secret = os.environ.get("CLIENT_SECRET")
+    token_url = os.environ.get("TOKEN_URL")
+    if client_id and client_secret and token_url:
+        from utils import get_oauth_token
+
+        token = get_oauth_token(token_url, client_id, client_secret)
+        gateway_headers = {"Authorization": f"Bearer {token}"}
+        print("Gateway auth: CUSTOM_JWT (OAuth token acquired)")
+    else:
+        print("Gateway auth: NONE (no CLIENT_ID/CLIENT_SECRET/TOKEN_URL in .env)")
+
+    print(f"Gateway: {gateway_url}")
+    print(f"Validating endpoint: {method} {url}\n")
+
+    mcp_client = MCPClient(
+        lambda: streamablehttp_client(gateway_url, headers=gateway_headers, timeout=timedelta(seconds=120))
+    )
+
+    with mcp_client:
+        result = mcp_client.call_tool_sync(
+            tool_use_id="validate-endpoint-1",
+            name=VALIDATE_TOOL,
+            arguments={"url": url, "method": method},
+        )
+
+    report = _extract_json(result)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -131,3 +131,4 @@
 - Chris Wajule (ggChris2)
 - Anil Nadiminti (aniloncloud)
 - ach1ntya
+- ratnopam


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/awslabs/amazon-bedrock-agentcore-samples/issues) relating to this Pull Request.
> 2. Once this Pull Request is ready for review please attach `review ready` label to it. Only PRs with `review ready` will be reviewed.

**Issue number**:

### Concise description of the PR


Adds read-only verification of Coinbase x402 Bazaar's **curation** layer and the
`validate_endpoint` tool to tutorial 04, because the tutorial demonstrates the
discover→call→pay pattern but never exercises the `curatedOnly` filter or
`validate_endpoint`. No change to the payment flow or the `NONE` auth default.

Changes:

- `validate_bazaar_curation.py` (new) — read-only check that the `curatedOnly`
  filter is honored (curated vs. uncurated result sets + category breakdown).
  Reports counts as a lower bound (API caps at 20 results/call, no cursor), not a
  fixed catalog size.
- `validate_endpoint_example.py` (new, optional) — demonstrates `validate_endpoint`
  (reachability / 402 / discovery diagnostics; no payment).
- `bazaar_gateway_agent.py` — adds discovery-only Step 5e confirming the curation
  layer is active (curated search, no `proxy_tool_call`).
- `README.md` — adds a "Verify the Bazaar target" section and curation note;
  corrects the `CUSTOM_JWT` credential source; documents enabling JWT without
  changing the `NONE` default; adds troubleshooting rows.
- `requirements.txt` — declares `requests>=2.32.0` (used by `utils.get_oauth_token`
  on the `CUSTOM_JWT` path; previously undeclared).

Both scripts reuse the sample's existing `MCPClient` + bearer-token auth and work
for both `NONE` and `CUSTOM_JWT` gateways.


### User experience

> Please share what the user experience looks like before and after this change

Before: nothing in the tutorial exercises or verifies Bazaar curation; the
`validate_endpoint` tool is never shown; the `CUSTOM_JWT` path fails with
`ModuleNotFoundError: requests` on a clean install, and the README misstates where
the JWT credentials come from.

After: `python validate_bazaar_curation.py` confirms the `curatedOnly` filter is
honored and prints a curated category breakdown (no payment); Step 5e shows the
agent confirming curation is active; `validate_endpoint_example.py` demonstrates
endpoint diagnostics; the `CUSTOM_JWT` path installs and runs, with corrected docs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTING.md)
* [x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/CONTRIBUTORS.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/amazon-bedrock-agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset?
* [x] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x] I agree to resolve any [issues](https://github.com/awslabs/amazon-bedrock-agent-samples/issues) created for this example in the future.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
