### PR TITLE
fix(gateway): fix semantic search invoke.py response parsing

### DIFF
--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/semantic-search/invoke.py
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/semantic-search/invoke.py
@@ -12,6 +12,7 @@ Usage:
     uv run python scripts/semantic-search/invoke.py
 """
 
+import json
 import os
 import sys
 import time
@@ -108,7 +109,8 @@ def main():
         {"query": "find me 3 credit research tools"},
     )
     elapsed = time.time() - start
-    tools_found = result.get("result", {}).get("structuredContent", {}).get("tools", [])
+    content = result.get("result", {}).get("content", [])
+    tools_found = json.loads(content[0]["text"]).get("tools", []) if content else []
     print(f"  Search completed in {elapsed:.2f}s")
     print(f"  Tools returned: {len(tools_found)}")
     for t in tools_found[:5]:
@@ -124,7 +126,8 @@ def main():
         {"query": "tools for booking a restaurant reservation"},
     )
     elapsed = time.time() - start
-    tools_found = result.get("result", {}).get("structuredContent", {}).get("tools", [])
+    content = result.get("result", {}).get("content", [])
+    tools_found = json.loads(content[0]["text"]).get("tools", []) if content else []
     print(f"  Search completed in {elapsed:.2f}s")
     print(f"  Tools returned: {len(tools_found)}")
     for t in tools_found[:5]:
@@ -140,7 +143,8 @@ def main():
         {"query": "tools for multiplying two numbers"},
     )
     elapsed = time.time() - start
-    tools_found = result.get("result", {}).get("structuredContent", {}).get("tools", [])
+    content = result.get("result", {}).get("content", [])
+    tools_found = json.loads(content[0]["text"]).get("tools", []) if content else []
     print(f"  Search completed in {elapsed:.2f}s")
     print(f"  Tools returned: {len(tools_found)}")
     for t in tools_found[:5]:


### PR DESCRIPTION
## Summary

- `scripts/semantic-search/invoke.py` parses the wrong response path for the `x_amz_bedrock_agentcore_search` tool
- **Before:** `result.get("result", {}).get("structuredContent", {}).get("tools", [])` — always returns `[]`
- **After:** `json.loads(result.get("result", {}).get("content", [])[0]["text"]).get("tools", [])` — returns actual results
- Also adds missing `import json`

### Root cause
The semantic search tool returns results as a JSON string inside `result.content[0].text`, not in `result.structuredContent`. The script silently returned empty tool lists.

## Test plan
- [x] Verified against live gateway with 318 tools — search for "credit research tools" returns 3 relevant matches
- [x] Verified search for "restaurant reservation" and "multiplying two numbers" also return correct results
- [x] Confirmed response format: `{"result": {"content": [{"type": "text", "text": "{\"tools\": [...]}"}]}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)