### PR TITLE
fix(gateway): prevent cleanup scripts from destroying shared resources

### DIFF
--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/semantic-search/cleanup.py
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/semantic-search/cleanup.py
@@ -13,6 +13,7 @@ Usage:
 
 import os
 import sys
+import time
 
 import boto3
 from botocore.exceptions import ClientError
@@ -46,10 +47,41 @@ def main():
         print("ERROR: GATEWAY_ID not set. Run deploy.py first.")
         sys.exit(1)
 
-    # 1. Delete gateway (targets + gateway)
-    print("--- Deleting Gateway and Targets ---")
+    # 1. Delete all targets, wait for deletion, then delete gateway
+    print("--- Deleting Gateway Targets ---")
     try:
-        admin.delete_gateway(gateway_id)
+        targets = admin.client.list_gateway_targets(
+            gatewayIdentifier=gateway_id, maxResults=50
+        )
+        for t in targets.get("items", []):
+            tid = t["targetId"]
+            print(f"  Deleting target: {tid}")
+            try:
+                admin.client.delete_gateway_target(
+                    gatewayIdentifier=gateway_id, targetId=tid
+                )
+            except ClientError as e:
+                if "ResourceNotFoundException" not in str(e):
+                    print(f"    Error: {e}")
+
+        # Wait for all targets to finish deleting
+        print("  Waiting for targets to finish deleting...")
+        for _ in range(12):
+            time.sleep(10)
+            remaining = admin.client.list_gateway_targets(
+                gatewayIdentifier=gateway_id, maxResults=50
+            )
+            if not remaining.get("items"):
+                break
+        else:
+            print("  WARNING: Targets still present after 2 minutes")
+    except ClientError as e:
+        if "ResourceNotFoundException" not in str(e):
+            print(f"  Error listing targets: {e}")
+
+    print("--- Deleting Gateway ---")
+    try:
+        admin.client.delete_gateway(gatewayIdentifier=gateway_id)
         print(f"  Gateway deleted: {gateway_id}")
     except ClientError as e:
         if "ResourceNotFoundException" in str(e):

--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/waf/cleanup.py
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/waf/cleanup.py
@@ -84,11 +84,15 @@ def main():
         except Exception as e:  # noqa: BLE001
             print(f"  Error: {e}")
 
-    # --- Delete the gateway (and its targets) ---
-    if gateway_id:
-        print("--- Deleting gateway (targets + gateway) ---")
+    # --- Delete only the target created by this tutorial ---
+    target_id = os.environ.get("TARGET_ID", "")
+    if gateway_id and target_id:
+        print(f"--- Deleting target {target_id} from gateway ---")
         try:
-            admin.delete_gateway(gateway_id)
+            admin.client.delete_gateway_target(
+                gatewayIdentifier=gateway_id, targetId=target_id
+            )
+            print(f"  Deleted target: {target_id}")
         except Exception as e:  # noqa: BLE001
             print(f"  Error: {e}")
 


### PR DESCRIPTION
## Summary

Two cleanup scripts have destructive bugs when used with shared gateways:

### 1. `scripts/waf/cleanup.py` — deletes entire gateway instead of its own target
- The WAF tutorial's `deploy.py` accepts an **existing** `GATEWAY_ID` and creates a single target on it
- But `cleanup.py` calls `admin.delete_gateway()` which deletes **all** targets and the gateway itself
- This destroys resources belonging to other tutorials running on the same gateway
- **Fix:** Only delete the specific target using `TARGET_ID` stored in `.env`

### 2. `scripts/semantic-search/cleanup.py` — race condition on gateway deletion
- Calls `admin.delete_gateway()` which deletes targets then immediately attempts gateway deletion
- Target deletion is asynchronous — gateway delete fails with `ValidationException: Gateway has targets associated`
- **Fix:** Explicitly delete targets, poll `list_gateway_targets` until empty (up to 2 min), then delete gateway

## Test plan
- [x] WAF cleanup: verified it only removes its own target, leaving other targets intact
- [x] Semantic search cleanup: verified targets are fully deleted before gateway deletion proceeds
- [x] Both scripts handle already-deleted resources gracefully (ResourceNotFoundException)

🤖 Generated with [Claude Code](https://claude.com/claude-code)