### PR TITLE
docs: add Agent402 to the sample MPP endpoints (Tempo)

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/08-mpp-machine-payments-protocol/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/08-mpp-machine-payments-protocol/README.md
@@ -207,6 +207,7 @@ print(sess["availableLimits"]["availableSpendAmount"])
 | Service     | URL                                              | Cost   |
 |:------------|:-------------------------------------------------|:-------|
 | AgentMail   | `GET https://mpp.api.agentmail.to/v0/inboxes`    | free   |
+| Agent402    | `POST https://agent402.tools/api/hash`           | $0.001 |
 | Browserbase | `POST https://mpp.browserbase.com/search`        | $0.01  |
 | Allium      | `POST https://agents.allium.so/api/v1/developer/prices` | $0.02 |
 


### PR DESCRIPTION
Adds Agent402 to the sample MPP endpoints table in Tutorial 08 (08-mpp-machine-payments-protocol).

Agent402 (agent402.tools) is an open-source catalog of 500+ deterministic tools; every paid endpoint serves an MPP `tempo/charge` challenge in USDC.e on Tempo mainnet (chain 4217) alongside x402 on the same 402. The listed endpoint returns `sha256("hello world")` for the example body, so a buyer can verify the paid response offline - a cheap ($0.001), repeatable happy-path target.

Verified live with the AgentCore Payments plugin (Stripe Privy instrument) buying it end to end on Tempo mainnet.

To verify the row: the endpoint returns HTTP 402 with a `WWW-Authenticate: Payment` tempo/charge challenge -

```
curl -i -X POST https://agent402.tools/api/hash \
  -H 'content-type: application/json' \
  -d '{"text":"hello world","algo":"sha256"}'
```