### PR TITLE
Add skill evaluations to Market Trends agent

### DIFF
--- a/02-use-cases/01-conversational-agents/market-trends-agent/.gitignore
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/.gitignore
@@ -27,3 +27,9 @@ ssm-policy.json
 
 # Node
 node_modules/
+
+# Skill-enabled runtime deployment and evaluation artifacts
+skill_agent_config.json
+market_trends_skill_agent.zip
+.skill-agent-build/
+evaluators/results/

--- a/02-use-cases/01-conversational-agents/market-trends-agent/README.md
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/README.md
@@ -141,6 +141,140 @@ while True:
 
 ---
 
+## Agent Skills and Built-In Skill Evaluators
+
+The existing `market_trends_agent.py` runtime remains the primary LangGraph sample with live browser tools and AgentCore Memory. Agent Skills are demonstrated through a separate `market_trends_skill_agent.py` runtime built with native Strands `AgentSkills`. The isolated runtime uses deterministic reference data, has no broker-profile tools or profile state, and does not change the skills plugin or behavior of neighboring deployments.
+
+### Evaluation Flow
+
+```mermaid
+flowchart LR
+    U[Evaluation scenarios] --> R[AgentCore Runtime]
+    R --> S[Native Strands AgentSkills]
+    R --> CW[Unified runtime log group]
+    CW --> EC[EvaluationClient]
+    CW --> BR[BatchEvaluationRunner]
+    EC --> E[Managed skill evaluators]
+    BR --> E
+```
+
+### Included Skills
+
+Each skill is a reusable `SKILL.md` workflow under `skills/`. Its `allowed-tools` frontmatter is advisory workflow metadata in the current Strands integration, not an enforced runtime access-control allowlist:
+
+| Skill | Use it for | Advisory tools (`allowed-tools`) |
+|:------|:-----------|:---------------------------------|
+| `trend-analysis` | Price direction, momentum, support, and resistance | `get_stock_data`, `get_sector_data`, `search_news` |
+| `sector-rotation` | Sector allocation and overweight/underweight recommendations | `get_market_overview`, `get_sector_data`, `search_news` |
+| `earnings-snapshot` | Earnings news, valuation, dividends, and fundamentals | `get_stock_data`, `search_news` |
+| `portfolio-risk` | Concentration, volatility exposure, and portfolio risk tier | `get_stock_data`, `get_sector_data` |
+
+General market-overview requests continue to use ordinary market tools directly and should not load a skill. Broker-profile persistence remains a capability of the primary LangGraph sample through AgentCore Memory; it is intentionally absent from the isolated deterministic skill runtime.
+
+### What the Evaluators Measure
+
+| Managed evaluator | Question answered | AWS label/value contract | Sample acceptance floor |
+|:------------------|:------------------|:-------------------------|:------------------------|
+| `Builtin.SkillSelectionAccuracy` | Did the agent load the best available skill for the request? | `Yes` = `1.0`; `No` = `0.0` | `1.0` |
+| `Builtin.SkillInstructionFollowing` | After loading the skill, how completely did the agent follow its required workflow? | `Fully Followed` = `1.0`; `Mostly Followed` = `0.75`; `Partially Followed` = `0.5`; `Minimally Followed` = `0.25`; `Not Followed` = `0.0` | `0.75` |
+
+The exact labels and values above are the managed evaluator contracts. The acceptance floors are policy chosen by this sample, not AWS-mandated thresholds. The runner locally fails any result that is malformed, uses an unknown label, has a non-finite/non-numeric value (including a Boolean), has a label/value mismatch, or falls below the sample floor.
+
+Both evaluators operate at the **tool-call level**. Native Strands `AgentSkills` emits the `skills` tool trace that the managed evaluators inspect. The sample calls these AWS-managed evaluators by ID and does not create, update, or delete evaluator resources.
+
+The evaluation script demonstrates both documented SDK interfaces:
+
+- `EvaluationClient.run(...)` evaluates each existing runtime session on demand.
+- `BatchEvaluationRunner.run_dataset_evaluation(...)` invokes the four-scenario dataset and returns service-side aggregate results.
+
+### Prerequisites
+
+Complete the [Quick Start](#quick-start), and ensure:
+
+- Your AWS credentials can create AgentCore Runtime, IAM, and S3 resources and invoke Amazon Bedrock.
+- The Anthropic Claude Haiku 4.5 model is available in the deployment region.
+- CloudWatch Transaction Search is enabled as described in the [AgentCore skill evaluator documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/skill-evaluators.html).
+
+The deployment sets `UNIFIED_TRACES_DESTINATION_ENABLED=true`. Both evaluation interfaces read only the new runtime's default unified log group, `/aws/bedrock-agentcore/runtimes/<agent-id>-DEFAULT`.
+
+### Deploy the Isolated Skill Runtime
+
+From this directory, deploy the skill-enabled runtime:
+
+```bash
+uv sync
+uv run python deploy_skill_agent.py --region us-west-2
+```
+
+The deployment validates the four `SKILL.md` files, packages the native Strands runtime, creates isolated IAM/S3/Runtime resources, enables unified telemetry, waits for `READY`, and writes `skill_agent_config.json`. It does not modify the existing LangGraph runtime.
+
+The script intentionally creates one isolated deployment. If `skill_agent_config.json` already exists, clean up the recorded resources before deploying again.
+
+### Run the Skill Evaluators
+
+Run all four positive scenarios and the no-skill control:
+
+```bash
+uv run python evaluators/scripts/evaluate_skills.py
+```
+
+The baseline checks these routes:
+
+- NVDA trend request -> `trend-analysis`
+- Cross-sector allocation request -> `sector-rotation`
+- LLY earnings request -> `earnings-snapshot`
+- NVDA/TSLA/JPM portfolio request -> `portfolio-risk`
+- General market overview -> no skill
+
+Telemetry ingestion is asynchronous; use `--wait 240` if the default 180 seconds is not enough. The script:
+
+1. Invokes all four skill scenarios and a no-skill market-overview control.
+2. Uses `EvaluationClient.run(...)` for per-session scores.
+3. Uses `BatchEvaluationRunner` with `log_group_names=[config["cw_log_group"]]` for the four-scenario dataset.
+4. Saves results to `evaluators/results/skill_evaluation_results.json` and exits nonzero if validation fails.
+
+A successful on-demand run includes output similar to:
+
+```text
+trend-analysis-nvda              Builtin.SkillSelectionAccuracy       1.0   Yes
+trend-analysis-nvda              Builtin.SkillInstructionFollowing    1.0   Fully Followed
+no-skill-market-overview         Builtin.SkillSelectionAccuracy       SKIPPED (0 results)
+no-skill-market-overview         Builtin.SkillInstructionFollowing    SKIPPED (0 results)
+```
+
+### Clean Up the Skill Runtime
+
+The generated config contains the exact runtime, role, policy, bucket, key, region, and unified runtime log group used by this isolated deployment. Load those values before deleting resources:
+
+```bash
+CONFIG=skill_agent_config.json
+REGION=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["region"])' "$CONFIG")
+AGENT_ID=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["agent_id"])' "$CONFIG")
+ROLE_NAME=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["role_name"])' "$CONFIG")
+POLICY_NAME=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["policy_name"])' "$CONFIG")
+S3_BUCKET=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["s3_bucket"])' "$CONFIG")
+CW_LOG_GROUP=$(uv run python -c 'import json, sys; print(json.load(open(sys.argv[1]))["cw_log_group"])' "$CONFIG")
+
+aws bedrock-agentcore-control delete-agent-runtime \
+  --agent-runtime-id "$AGENT_ID" \
+  --region "$REGION"
+```
+
+Wait until runtime deletion completes before removing its log group or IAM role. The bucket is dedicated to this sample, so remove all deployment objects before deleting it:
+
+```bash
+aws logs delete-log-group --log-group-name "$CW_LOG_GROUP" --region "$REGION"
+aws s3 rm "s3://$S3_BUCKET" --recursive --region "$REGION"
+aws s3api delete-bucket --bucket "$S3_BUCKET" --region "$REGION"
+aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name "$POLICY_NAME"
+aws iam delete-role --role-name "$ROLE_NAME"
+rm "$CONFIG"
+```
+
+These commands affect only resources recorded in the selected config; they do not delete the existing LangGraph runtime or the AWS-managed built-in evaluators.
+
+---
+
 ## Evaluating Your Agent with Custom Code-Based Evaluators
 
 Custom code-based evaluators let you replace the LLM-as-a-judge approach with deterministic Lambda functions — giving you full control over evaluation logic. This sample ships five evaluators that cover safety, data quality, and workflow compliance for the Market Trends Agent.

--- a/02-use-cases/01-conversational-agents/market-trends-agent/deploy_skill_agent.py
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/deploy_skill_agent.py
@@ -1,0 +1,331 @@
+"""Deploy the native AgentSkills Market Trends runtime.
+
+Usage:
+    uv run python deploy_skill_agent.py --region us-west-2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import boto3  # type: ignore[import-untyped]
+from boto3.session import Session  # type: ignore[import-untyped]
+
+_ROOT = Path(__file__).resolve().parent
+_CONFIG_PATH = _ROOT / "skill_agent_config.json"
+_AGENT_FILE = _ROOT / "market_trends_skill_agent.py"
+_SKILLS_DIR = _ROOT / "skills"
+_SKILLS = (
+    "earnings-snapshot",
+    "portfolio-risk",
+    "sector-rotation",
+    "trend-analysis",
+)
+_PACKAGES = (
+    "bedrock-agentcore==1.8.0",
+    "strands-agents[otel]==1.38.0",
+    "aws-opentelemetry-distro==0.19.0",
+)
+_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def _validate_source() -> None:
+    if not _AGENT_FILE.is_file():
+        raise FileNotFoundError(_AGENT_FILE)
+    discovered = tuple(sorted(path.parent.name for path in _SKILLS_DIR.glob("*/SKILL.md")))
+    if discovered != _SKILLS:
+        raise ValueError(f"Expected skills {_SKILLS}, found {discovered}")
+
+
+def _install_command(target: Path) -> list[str]:
+    uv = shutil.which("uv")
+    if uv:
+        return [
+            uv,
+            "pip",
+            "install",
+            "--target",
+            str(target),
+            "--python-platform",
+            "aarch64-manylinux2014",
+            "--python-version",
+            "3.13",
+            "--only-binary=:all:",
+            "--no-compile",
+            "--quiet",
+            *_PACKAGES,
+        ]
+    return [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--target",
+        str(target),
+        "--platform",
+        "manylinux2014_aarch64",
+        "--implementation",
+        "cp",
+        "--python-version",
+        "3.13",
+        "--only-binary=:all:",
+        "--no-compile",
+        "--quiet",
+        *_PACKAGES,
+    ]
+
+
+def _build_artifact(work_dir: Path) -> Path:
+    package_dir = work_dir / "package"
+    package_dir.mkdir()
+    subprocess.run(_install_command(package_dir), check=True)
+    shutil.copy2(_AGENT_FILE, package_dir / _AGENT_FILE.name)
+    shutil.copytree(_SKILLS_DIR, package_dir / "skills")
+
+    instrument = package_dir / "bin/opentelemetry-instrument"
+    lines = instrument.read_text(encoding="utf-8").splitlines()
+    instrument.write_text(
+        "\n".join(["#!/usr/bin/env python3", *lines[1:]]) + "\n",
+        encoding="utf-8",
+    )
+
+    artifact = work_dir / "market_trends_skill_agent.zip"
+    with zipfile.ZipFile(artifact, "w", zipfile.ZIP_DEFLATED) as archive:
+        for source in sorted(package_dir.rglob("*")):
+            if not source.is_file() or "__pycache__" in source.parts:
+                continue
+            relative = source.relative_to(package_dir)
+            info = zipfile.ZipInfo(relative.as_posix(), (1980, 1, 1, 0, 0, 0))
+            info.create_system = 3
+            mode = 0o755 if relative == Path("bin/opentelemetry-instrument") else 0o644
+            info.external_attr = (stat.S_IFREG | mode) << 16
+            archive.writestr(info, source.read_bytes(), compress_type=zipfile.ZIP_DEFLATED)
+    return artifact
+
+
+def _partition(identity_arn: str) -> str:
+    return identity_arn.split(":", 2)[1]
+
+
+def _trust_policy(
+    partition: str,
+    account_id: str,
+    region: str,
+    runtime_name: str,
+) -> dict[str, Any]:
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "StringEquals": {"aws:SourceAccount": account_id},
+                    "ArnLike": {
+                        "aws:SourceArn": (
+                            f"arn:{partition}:bedrock-agentcore:{region}:{account_id}:runtime/{runtime_name}-*"
+                        )
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _execution_policy(
+    partition: str,
+    account_id: str,
+    region: str,
+    runtime_name: str,
+) -> dict[str, Any]:
+    log_group = f"arn:{partition}:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/{runtime_name}-*"
+    model_id = _MODEL_ID.removeprefix("us.")
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "InvokeModel",
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock:InvokeModel",
+                    "bedrock:InvokeModelWithResponseStream",
+                ],
+                "Resource": [
+                    f"arn:{partition}:bedrock:{region}:{account_id}:inference-profile/{_MODEL_ID}",
+                    f"arn:{partition}:bedrock:*::foundation-model/{model_id}",
+                ],
+            },
+            {
+                "Sid": "WriteRuntimeTelemetry",
+                "Effect": "Allow",
+                "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:PutResourcePolicy",
+                    "logs:DescribeLogGroups",
+                    "logs:DescribeLogStreams",
+                ],
+                "Resource": [log_group, f"{log_group}:log-stream:*"],
+            },
+            {
+                "Sid": "WriteTracesAndMetrics",
+                "Effect": "Allow",
+                "Action": [
+                    "xray:PutTraceSegments",
+                    "xray:PutTelemetryRecords",
+                    "xray:GetSamplingRules",
+                    "xray:GetSamplingTargets",
+                    "cloudwatch:PutMetricData",
+                ],
+                "Resource": "*",
+            },
+        ],
+    }
+
+
+def _create_role(
+    iam: Any,
+    partition: str,
+    account_id: str,
+    region: str,
+    runtime_name: str,
+    suffix: str,
+) -> tuple[str, str, str]:
+    role_name = f"AgentCoreMarketTrendsSkills-{suffix}"
+    policy_name = f"MarketTrendsSkills-{suffix}"
+    role = iam.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=json.dumps(_trust_policy(partition, account_id, region, runtime_name)),
+        Description="Execution role for the Market Trends AgentSkills sample",
+    )["Role"]
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName=policy_name,
+        PolicyDocument=json.dumps(_execution_policy(partition, account_id, region, runtime_name)),
+    )
+    time.sleep(10)
+    return str(role["Arn"]), role_name, policy_name
+
+
+def _create_bucket(s3: Any, bucket: str, region: str) -> None:
+    request: dict[str, Any] = {"Bucket": bucket}
+    if region != "us-east-1":
+        request["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3.create_bucket(**request)
+    s3.put_public_access_block(
+        Bucket=bucket,
+        PublicAccessBlockConfiguration={
+            "BlockPublicAcls": True,
+            "IgnorePublicAcls": True,
+            "BlockPublicPolicy": True,
+            "RestrictPublicBuckets": True,
+        },
+    )
+
+
+def _wait_until_ready(control: Any, agent_id: str) -> dict[str, Any]:
+    for _ in range(40):
+        runtime = control.get_agent_runtime(agentRuntimeId=agent_id)
+        if not isinstance(runtime, dict):
+            raise TypeError("get_agent_runtime returned a non-object response")
+        status = runtime.get("status")
+        print(f"Runtime status: {status}")
+        if status == "READY":
+            return runtime
+        if status == "FAILED":
+            raise RuntimeError(runtime.get("failureReason", "Runtime deployment failed"))
+        time.sleep(15)
+    raise TimeoutError("Runtime did not become ready within 10 minutes")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--region", default=None)
+    args = parser.parse_args()
+
+    if _CONFIG_PATH.exists():
+        parser.error(f"{_CONFIG_PATH.name} already exists. Clean up that deployment before creating another one.")
+    _validate_source()
+
+    region = args.region or Session().region_name or "us-east-1"
+    sts = boto3.client("sts", region_name=region)
+    identity = sts.get_caller_identity()
+    account_id = str(identity["Account"])
+    partition = _partition(str(identity["Arn"]))
+    suffix = uuid.uuid4().hex[:8]
+    runtime_name = f"market_trends_skills_{suffix}"
+    role_arn, role_name, policy_name = _create_role(
+        boto3.client("iam", region_name=region),
+        partition,
+        account_id,
+        region,
+        runtime_name,
+        suffix,
+    )
+
+    bucket = f"agentcore-market-trends-{account_id}-{region}-{suffix}"
+    key = "runtime/market_trends_skill_agent.zip"
+    s3 = boto3.client("s3", region_name=region)
+    _create_bucket(s3, bucket, region)
+
+    with tempfile.TemporaryDirectory(prefix="market-trends-skills-") as temp:
+        artifact = _build_artifact(Path(temp))
+        s3.upload_file(str(artifact), bucket, key)
+
+    control = boto3.client("bedrock-agentcore-control", region_name=region)
+    created = control.create_agent_runtime(
+        agentRuntimeName=runtime_name,
+        agentRuntimeArtifact={
+            "codeConfiguration": {
+                "code": {"s3": {"bucket": bucket, "prefix": key}},
+                "runtime": "PYTHON_3_13",
+                "entryPoint": [
+                    "opentelemetry-instrument",
+                    _AGENT_FILE.name,
+                ],
+            }
+        },
+        roleArn=role_arn,
+        networkConfiguration={"networkMode": "PUBLIC"},
+        protocolConfiguration={"serverProtocol": "HTTP"},
+        environmentVariables={"UNIFIED_TRACES_DESTINATION_ENABLED": "true"},
+    )
+    runtime = _wait_until_ready(control, str(created["agentRuntimeId"]))
+    agent_id = str(runtime["agentRuntimeId"])
+    config = {
+        "account_id": account_id,
+        "agent_id": agent_id,
+        "agent_arn": str(runtime["agentRuntimeArn"]),
+        "cw_log_group": f"/aws/bedrock-agentcore/runtimes/{agent_id}-DEFAULT",
+        "policy_name": policy_name,
+        "region": region,
+        "role_name": role_name,
+        "s3_bucket": bucket,
+        "s3_key": key,
+        "service_name": f"{runtime_name}.DEFAULT",
+        "skills": list(_SKILLS),
+    }
+    _CONFIG_PATH.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    print("\nDeployment complete")
+    print(f"Runtime ARN: {config['agent_arn']}")
+    print(f"Unified log group: {config['cw_log_group']}")
+    print(f"Config: {_CONFIG_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/02-use-cases/01-conversational-agents/market-trends-agent/evaluators/scripts/evaluate_skills.py
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/evaluators/scripts/evaluate_skills.py
@@ -1,0 +1,321 @@
+"""Evaluate Market Trends Agent Skills with AgentCore Evaluations.
+
+Prerequisite:
+    uv run python deploy_skill_agent.py --region us-west-2
+
+Usage:
+    uv run python evaluators/scripts/evaluate_skills.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import uuid
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import boto3  # type: ignore[import-untyped]
+from bedrock_agentcore.evaluation import (
+    AgentInvokerInput,
+    AgentInvokerOutput,
+    Dataset,
+    EvaluationClient,
+    PredefinedScenario,
+    Turn,
+)
+from bedrock_agentcore.evaluation.runner.batch.batch_evaluation_models import (
+    BatchEvaluationRunConfig,
+    BatchEvaluatorConfig,
+    CloudWatchDataSourceConfig,
+)
+from bedrock_agentcore.evaluation.runner.batch.batch_evaluation_runner import (
+    BatchEvaluationRunner,
+)
+from boto3.session import Session  # type: ignore[import-untyped]
+
+_PROJECT_DIR = Path(__file__).resolve().parents[2]
+_DEFAULT_CONFIG = _PROJECT_DIR / "skill_agent_config.json"
+_RESULTS_PATH = _PROJECT_DIR / "evaluators/results/skill_evaluation_results.json"
+_EVALUATOR_IDS = [
+    "Builtin.SkillSelectionAccuracy",
+    "Builtin.SkillInstructionFollowing",
+]
+_SCENARIOS = [
+    (
+        "trend-analysis",
+        ("Use the trend-analysis skill to analyze NVDA's price trend, momentum, support, resistance, and confidence."),
+    ),
+    (
+        "sector-rotation",
+        ("Use the sector-rotation skill to recommend sectors to overweight and underweight in the current market."),
+    ),
+    (
+        "earnings-snapshot",
+        (
+            "Use the earnings-snapshot skill to assess LLY's earnings outlook, "
+            "valuation, dividend yield, and relevant earnings news."
+        ),
+    ),
+    (
+        "portfolio-risk",
+        (
+            "Use the portfolio-risk skill to evaluate a portfolio of NVDA, TSLA, "
+            "and JPM for concentration and volatility risk."
+        ),
+    ),
+]
+_NO_SKILL_SCENARIO = (
+    "no-skill",
+    "Give me a concise general market overview with major indices and top movers.",
+)
+_EXPECTED_LABELS = {
+    "Builtin.SkillSelectionAccuracy": {"Yes": 1.0},
+    "Builtin.SkillInstructionFollowing": {
+        "Fully Followed": 1.0,
+        "Mostly Followed": 0.75,
+    },
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run AgentCore's built-in skill evaluators")
+    parser.add_argument("--config", type=Path, default=_DEFAULT_CONFIG)
+    parser.add_argument("--region", default=None)
+    parser.add_argument(
+        "--wait",
+        type=int,
+        default=180,
+        help="Seconds to allow unified telemetry ingestion (default: 180)",
+    )
+    args = parser.parse_args()
+    if args.wait < 0:
+        parser.error("--wait must be zero or greater")
+    return args
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Deployment config not found: {path}. Run deploy_skill_agent.py first.")
+    raw_config = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw_config, dict):
+        raise TypeError("Deployment config must contain a JSON object")
+    config: dict[str, Any] = raw_config
+    required = {"agent_id", "agent_arn", "cw_log_group", "service_name", "region"}
+    missing = sorted(required - config.keys())
+    if missing:
+        raise ValueError(f"Deployment config is missing: {', '.join(missing)}")
+    return config
+
+
+def _response_text(raw: str) -> str:
+    """Return text from AgentCore's JSON, SSE, or plain-text response."""
+    parts: list[str] = []
+    for line in raw.splitlines():
+        if not line.startswith("data:"):
+            continue
+        value = line.removeprefix("data:").strip()
+        if value == "[DONE]":
+            continue
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            pass
+        parts.append(str(value))
+    if parts:
+        return "".join(parts)
+    try:
+        return str(json.loads(raw))
+    except json.JSONDecodeError:
+        return raw
+
+
+def _invoke(client: Any, agent_arn: str, session_id: str, prompt: Any) -> str:
+    payload = {"prompt": prompt} if isinstance(prompt, str) else prompt
+    response = client.invoke_agent_runtime(
+        agentRuntimeArn=agent_arn,
+        qualifier="DEFAULT",
+        runtimeSessionId=session_id,
+        payload=json.dumps(payload).encode("utf-8"),
+    )
+    raw = response["response"].read().decode("utf-8", errors="replace")
+    return _response_text(raw)
+
+
+def _evaluator_id(result: dict[str, Any]) -> str:
+    value = str(result.get("evaluatorId", ""))
+    for evaluator_id in _EVALUATOR_IDS:
+        if value == evaluator_id or value.endswith(f"/{evaluator_id}"):
+            return evaluator_id
+    return value
+
+
+def _validate_session_results(
+    scenario_id: str,
+    results: list[dict[str, Any]],
+    *,
+    expects_skill: bool,
+) -> list[str]:
+    if not expects_skill:
+        return [] if not results else [f"{scenario_id}: expected no skill results"]
+
+    failures: list[str] = []
+    grouped: dict[str, list[dict[str, Any]]] = {evaluator_id: [] for evaluator_id in _EVALUATOR_IDS}
+    for result in results:
+        evaluator_id = _evaluator_id(result)
+        if evaluator_id in grouped:
+            grouped[evaluator_id].append(result)
+
+    for evaluator_id, evaluator_results in grouped.items():
+        if len(evaluator_results) != 1:
+            failures.append(f"{scenario_id}: expected one {evaluator_id} result, received {len(evaluator_results)}")
+            continue
+        result = evaluator_results[0]
+        if result.get("errorCode"):
+            failures.append(f"{scenario_id} / {evaluator_id}: {result['errorCode']} - {result.get('errorMessage', '')}")
+            continue
+        label = result.get("label")
+        value = result.get("value")
+        expected = _EXPECTED_LABELS[evaluator_id]
+        if label not in expected or value != expected.get(label):
+            failures.append(f"{scenario_id} / {evaluator_id}: unexpected label/value {label!r}/{value!r}")
+    return failures
+
+
+def _print_results(scenario_id: str, results: list[dict[str, Any]]) -> None:
+    if not results:
+        print(f"  {scenario_id:<24} no skill evaluation results")
+        return
+    for result in results:
+        evaluator_id = _evaluator_id(result)
+        label = result.get("label", result.get("errorCode", "N/A"))
+        value = result.get("value", "N/A")
+        print(f"  {scenario_id:<24} {evaluator_id:<38} {value!s:<5} {label}")
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        scenarios=[
+            PredefinedScenario(
+                scenario_id=skill_name,
+                turns=[Turn(input=prompt)],
+            )
+            for skill_name, prompt in _SCENARIOS
+        ]
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        config = _load_config(args.config)
+    except (OSError, TypeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    region = args.region or config["region"] or Session().region_name or "us-east-1"
+    if region != config["region"]:
+        print("ERROR: --region must match the deployed runtime region", file=sys.stderr)
+        return 1
+
+    runtime_client = boto3.client("bedrock-agentcore", region_name=region)
+    evaluation_client = EvaluationClient(region_name=region)
+    agent_arn = str(config["agent_arn"])
+
+    print("Market Trends Agent Skills Evaluation")
+    print(f"  Runtime log group: {config['cw_log_group']}")
+    print("  Telemetry source: unified runtime log group only")
+
+    sessions: list[tuple[str, str, bool]] = []
+    for scenario_id, prompt in [*_SCENARIOS, _NO_SKILL_SCENARIO]:
+        session_id = f"skill-eval-{uuid.uuid4()}"
+        response = _invoke(runtime_client, agent_arn, session_id, prompt)
+        print(f"\n[Invoke] {scenario_id}: {response[:160]}")
+        sessions.append((scenario_id, session_id, scenario_id != "no-skill"))
+
+    if args.wait:
+        print(f"\nWaiting {args.wait}s for unified telemetry ingestion ...")
+        time.sleep(args.wait)
+
+    failures: list[str] = []
+    on_demand_results: dict[str, Any] = {}
+    print("\nEvaluationClient results:")
+    for scenario_id, session_id, expects_skill in sessions:
+        results = evaluation_client.run(
+            evaluator_ids=_EVALUATOR_IDS,
+            session_id=session_id,
+            agent_id=str(config["agent_id"]),
+            log_group_name=str(config["cw_log_group"]),
+            look_back_time=timedelta(hours=2),
+        )
+        _print_results(scenario_id, results)
+        failures.extend(
+            _validate_session_results(
+                scenario_id,
+                results,
+                expects_skill=expects_skill,
+            )
+        )
+        on_demand_results[scenario_id] = {
+            "session_id": session_id,
+            "results": results,
+        }
+
+    def agent_invoker(invoker_input: AgentInvokerInput) -> AgentInvokerOutput:
+        if not invoker_input.session_id:
+            raise ValueError("Batch evaluation did not provide a session ID")
+        output = _invoke(
+            runtime_client,
+            agent_arn,
+            invoker_input.session_id,
+            invoker_input.payload,
+        )
+        return AgentInvokerOutput(agent_output=output)
+
+    batch_config = BatchEvaluationRunConfig(
+        batch_evaluation_name=f"market_trends_skills_{uuid.uuid4().hex[:8]}",
+        evaluator_config=BatchEvaluatorConfig(evaluator_ids=_EVALUATOR_IDS),
+        data_source=CloudWatchDataSourceConfig(
+            service_names=[str(config["service_name"])],
+            log_group_names=[str(config["cw_log_group"])],
+            ingestion_delay_seconds=args.wait,
+        ),
+    )
+    print("\nStarting BatchEvaluationRunner ...")
+    batch_runner = BatchEvaluationRunner(region=region)
+    batch_result = batch_runner.run_dataset_evaluation(
+        config=batch_config,
+        dataset=_dataset(),
+        agent_invoker=agent_invoker,
+    )
+    print(f"  Batch ID: {batch_result.batch_evaluation_id}")
+    print(f"  Status: {batch_result.status}")
+    if batch_result.status != "COMPLETED":
+        failures.append(f"batch evaluation ended with status {batch_result.status}")
+
+    output = {
+        "evaluation_client": on_demand_results,
+        "batch_evaluation": batch_result.model_dump(),
+        "validation_failures": failures,
+    }
+    _RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _RESULTS_PATH.write_text(
+        json.dumps(output, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+    print(f"\nResults saved to {_RESULTS_PATH}")
+
+    if failures:
+        print("\nValidation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("\nAll four skills passed both built-in evaluators; no-skill control passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/02-use-cases/01-conversational-agents/market-trends-agent/market_trends_skill_agent.py
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/market_trends_skill_agent.py
@@ -1,0 +1,543 @@
+"""Native Strands AgentSkills runtime for deterministic market analysis."""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from collections.abc import Mapping
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent, AgentSkills, tool
+from strands.models import BedrockModel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = BedrockAgentCoreApp()
+
+_AGENT_DIR = Path(__file__).resolve().parent
+_SKILLS_DIR = _AGENT_DIR / "skills"
+_EXPECTED_SKILLS = (
+    "trend-analysis",
+    "sector-rotation",
+    "earnings-snapshot",
+    "portfolio-risk",
+)
+
+
+def _validate_skill_files() -> None:
+    """Fail fast when a required local AgentSkills definition is missing."""
+    missing_files = [
+        _SKILLS_DIR / skill_name / "SKILL.md"
+        for skill_name in _EXPECTED_SKILLS
+        if not (_SKILLS_DIR / skill_name / "SKILL.md").is_file()
+    ]
+    if missing_files:
+        missing = ", ".join(str(path) for path in missing_files)
+        raise FileNotFoundError(f"Missing required AgentSkills files: {missing}")
+
+
+_validate_skill_files()
+
+_SKILLS_PLUGIN = AgentSkills(skills=[str(_SKILLS_DIR)])
+_MODEL = BedrockModel(model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0")
+
+# Deterministic MarketTrends mock data.
+_STOCKS: dict[str, dict[str, Any]] = {
+    "AAPL": {
+        "name": "Apple Inc.",
+        "price": 175.43,
+        "change": +1.24,
+        "change_pct": +0.71,
+        "sector": "Technology",
+        "market_cap": "2.7T",
+        "pe_ratio": 28.4,
+        "dividend_yield": 0.52,
+    },
+    "MSFT": {
+        "name": "Microsoft Corp.",
+        "price": 415.28,
+        "change": -2.15,
+        "change_pct": -0.52,
+        "sector": "Technology",
+        "market_cap": "3.1T",
+        "pe_ratio": 35.2,
+        "dividend_yield": 0.71,
+    },
+    "GOOGL": {
+        "name": "Alphabet Inc.",
+        "price": 164.32,
+        "change": +3.41,
+        "change_pct": +2.12,
+        "sector": "Technology",
+        "market_cap": "2.0T",
+        "pe_ratio": 24.1,
+        "dividend_yield": 0.0,
+    },
+    "AMZN": {
+        "name": "Amazon.com Inc.",
+        "price": 198.67,
+        "change": +5.23,
+        "change_pct": +2.70,
+        "sector": "Consumer Discretionary",
+        "market_cap": "2.1T",
+        "pe_ratio": 54.3,
+        "dividend_yield": 0.0,
+    },
+    "TSLA": {
+        "name": "Tesla Inc.",
+        "price": 242.84,
+        "change": -8.42,
+        "change_pct": -3.35,
+        "sector": "Consumer Discretionary",
+        "market_cap": "0.77T",
+        "pe_ratio": 62.1,
+        "dividend_yield": 0.0,
+    },
+    "NVDA": {
+        "name": "NVIDIA Corp.",
+        "price": 875.20,
+        "change": +23.45,
+        "change_pct": +2.76,
+        "sector": "Technology",
+        "market_cap": "2.2T",
+        "pe_ratio": 68.4,
+        "dividend_yield": 0.03,
+    },
+    "META": {
+        "name": "Meta Platforms Inc.",
+        "price": 512.63,
+        "change": +7.84,
+        "change_pct": +1.55,
+        "sector": "Technology",
+        "market_cap": "1.3T",
+        "pe_ratio": 26.8,
+        "dividend_yield": 0.39,
+    },
+    "JPM": {
+        "name": "JPMorgan Chase & Co.",
+        "price": 198.43,
+        "change": -1.32,
+        "change_pct": -0.66,
+        "sector": "Financials",
+        "market_cap": "0.57T",
+        "pe_ratio": 11.8,
+        "dividend_yield": 2.31,
+    },
+    "GS": {
+        "name": "Goldman Sachs Group",
+        "price": 468.32,
+        "change": +8.15,
+        "change_pct": +1.77,
+        "sector": "Financials",
+        "market_cap": "0.15T",
+        "pe_ratio": 13.2,
+        "dividend_yield": 2.07,
+    },
+    "JNJ": {
+        "name": "Johnson & Johnson",
+        "price": 152.84,
+        "change": +0.43,
+        "change_pct": +0.28,
+        "sector": "Healthcare",
+        "market_cap": "0.37T",
+        "pe_ratio": 15.2,
+        "dividend_yield": 3.14,
+    },
+    "LLY": {
+        "name": "Eli Lilly & Co.",
+        "price": 782.45,
+        "change": +15.32,
+        "change_pct": +2.00,
+        "sector": "Healthcare",
+        "market_cap": "0.74T",
+        "pe_ratio": 58.3,
+        "dividend_yield": 0.62,
+    },
+    "XOM": {
+        "name": "Exxon Mobil Corp.",
+        "price": 113.65,
+        "change": -2.10,
+        "change_pct": -1.82,
+        "sector": "Energy",
+        "market_cap": "0.45T",
+        "pe_ratio": 13.7,
+        "dividend_yield": 3.42,
+    },
+    "CVX": {
+        "name": "Chevron Corp.",
+        "price": 156.43,
+        "change": -1.85,
+        "change_pct": -1.17,
+        "sector": "Energy",
+        "market_cap": "0.29T",
+        "pe_ratio": 14.2,
+        "dividend_yield": 4.15,
+    },
+    "KO": {
+        "name": "Coca-Cola Co.",
+        "price": 62.34,
+        "change": +0.21,
+        "change_pct": +0.34,
+        "sector": "Consumer Staples",
+        "market_cap": "0.27T",
+        "pe_ratio": 24.1,
+        "dividend_yield": 3.16,
+    },
+    "PG": {
+        "name": "Procter & Gamble",
+        "price": 158.72,
+        "change": +0.84,
+        "change_pct": +0.53,
+        "sector": "Consumer Staples",
+        "market_cap": "0.37T",
+        "pe_ratio": 26.4,
+        "dividend_yield": 2.38,
+    },
+    "SPY": {
+        "name": "SPDR S&P 500 ETF",
+        "price": 512.34,
+        "change": +2.15,
+        "change_pct": +0.42,
+        "sector": "ETF",
+        "market_cap": "N/A",
+        "pe_ratio": 22.1,
+        "dividend_yield": 1.32,
+    },
+}
+
+_CONSUMER_DISCRETIONARY_NEWS = [
+    "Amazon Prime membership +8% YoY; AWS cloud revenue accelerates to +35% growth",
+    "Tesla Q1 delivery miss widens to 13%; management cites Austin production ramp issues",
+    "Consumer confidence index hits 18-month high on cooling CPI data",
+]
+_CONSUMER_STAPLES_NEWS = [
+    ("Coca-Cola maintains full-year guidance as global pricing and volume growth offset currency pressure"),
+    ("Procter & Gamble margins expand as input-cost inflation eases across household product categories"),
+    ("Consumer staples companies report resilient demand while shoppers continue selective trade-down"),
+]
+_NEWS: dict[str, list[str]] = {
+    "technology": [
+        "NVIDIA Q1 earnings beat estimates by 15%; raises full-year guidance on AI demand surge",
+        "Apple Vision Pro 2 pre-orders open amid strong enterprise adoption signals",
+        "Microsoft Azure AI revenue grows 42% YoY; Copilot enterprise seats reach 1.2M",
+        "Alphabet launches Gemini Ultra 2.0 with multimodal capabilities, challenging OpenAI",
+        "Meta Llama 4 open-weights model outperforms proprietary models on 8 of 10 benchmarks",
+    ],
+    "healthcare": [
+        "Eli Lilly GLP-1 drug Mounjaro sees 78% revenue growth; supply constraints ease in Q2",
+        "Johnson & Johnson oncology pipeline Phase 3 results positive; stock up 4% pre-market",
+        "Pfizer restructures R&D after COVID-19 revenue normalization; targets $4B in savings",
+        "FDA approves novel Alzheimer's treatment; healthcare sector ETF gains 2.3%",
+        "UnitedHealth raises guidance after Q1 claims ratio improves 120bps YoY",
+    ],
+    "energy": [
+        "Exxon Mobil cuts 2026 capex by $2B amid oil price volatility; maintains dividend",
+        "OPEC+ extends production cuts through Q3 2026; Brent crude holds at $82/barrel",
+        "Solar and wind capacity additions hit global record in Q1 2026; utilities outperform",
+        "Natural gas prices fall 8% on mild weather; US LNG export volumes remain strong",
+    ],
+    "financials": [
+        "JPMorgan Q1 profits rise 6% on higher interest income; NIM expands 12bps to 2.81%",
+        "Goldman Sachs investment banking revenue surges 34% as IPO market reopens",
+        "Federal Reserve signals two rate cuts in 2026; bank stocks rally on improved NIMs",
+        "Bank of America deposit growth stabilizes; commercial loan losses below guidance",
+    ],
+    "consumer_discretionary": _CONSUMER_DISCRETIONARY_NEWS,
+    "consumer_staples": _CONSUMER_STAPLES_NEWS,
+    "consumer": _CONSUMER_DISCRETIONARY_NEWS + _CONSUMER_STAPLES_NEWS,
+    "macro": [
+        "US CPI cools to 2.8% in March; Fed June rate cut probability rises to 72%",
+        "Q1 GDP growth revised to +2.4% annualized; labor market adds 180K non-farm payrolls",
+        "10-year Treasury yield at 4.32% as term premium rebuilds on fiscal deficit concerns",
+        "US-China trade talks resume; targeted tariff reductions signal improving relations",
+    ],
+}
+
+_SECTOR_DATA: dict[str, dict[str, Any]] = {
+    "technology": {
+        "trend": "Outperforming (+1.24% today, +8.3% YTD)",
+        "key_themes": [
+            "AI infrastructure buildout driving hyperscaler capex ($200B+ in 2026)",
+            "Semiconductor supercycle: memory pricing recovery + AI chip demand",
+            "Cloud computing compounding at 25-30% YoY across major providers",
+        ],
+        "risks": [
+            "Premium valuations (sector P/E 34x vs S&P 500 22x)",
+            "Regulatory scrutiny: EU AI Act, US antitrust probes",
+            "Export restrictions on advanced chips to China",
+        ],
+        "outlook": ("Bullish. AI demand is a multi-year structural driver. Prefer NVDA, MSFT, GOOGL."),
+        "top_holdings": ["NVDA", "MSFT", "AAPL", "GOOGL", "META"],
+    },
+    "healthcare": {
+        "trend": "Neutral (+0.31% today, +2.1% YTD)",
+        "key_themes": [
+            "GLP-1 obesity/diabetes drugs (Eli Lilly, Novo Nordisk) reshaping pharma",
+            "AI-accelerated drug discovery compressing development timelines",
+            "Biosimilar competition eroding revenue for legacy biologics",
+        ],
+        "risks": [
+            "Medicare drug price negotiation under IRA limiting pharma margins",
+            "Patent cliff: $200B+ revenues exposed through 2028",
+            "Clinical trial failures in oncology and CNS pipelines",
+        ],
+        "outlook": ("Selective. Biotech innovation vs. pharma headwinds. Overweight LLY, UNH; underweight PFE."),
+        "top_holdings": ["LLY", "UNH", "JNJ", "ABBV", "MRK"],
+    },
+    "energy": {
+        "trend": "Underperforming (-1.12% today, -3.4% YTD)",
+        "key_themes": [
+            "Energy transition accelerating renewable deployment globally",
+            "LNG infrastructure investment surge for energy security",
+        ],
+        "risks": [
+            "Oil price compression from rising supply and demand uncertainty",
+            "ESG capital allocation shifts reducing fossil fuel investment",
+            "Geopolitical supply disruptions in Middle East and Russia",
+        ],
+        "outlook": ("Mixed. Avoid pure-play oil. Prefer diversified energy with renewable exposure (XOM, CVX)."),
+        "top_holdings": ["XOM", "CVX", "COP", "EOG", "SLB"],
+    },
+    "financials": {
+        "trend": "Improving (+0.67% today, +5.8% YTD)",
+        "key_themes": [
+            "Rate normalization cycle supporting net interest margins",
+            "Investment banking recovery: IPO pipeline strongest since 2021",
+        ],
+        "risks": [
+            "Credit quality deterioration in commercial real estate",
+            "Basel III endgame capital requirements reducing returns",
+        ],
+        "outlook": "Cautiously optimistic. Rate cuts are net positive. Prefer JPM, GS.",
+        "top_holdings": ["JPM", "BAC", "GS", "MS", "BLK"],
+    },
+    "consumer_staples": {
+        "trend": "Stable (+0.22% today, +1.9% YTD)",
+        "key_themes": ["Pricing power normalization as input cost inflation eases"],
+        "risks": ["Consumer trade-down to private labels compressing margins"],
+        "outlook": ("Defensive. Attractive for risk-off positioning. Focus on dividend growers: KO, PG."),
+        "top_holdings": ["KO", "PG", "PEP", "COST", "WMT"],
+    },
+    "consumer_discretionary": {
+        "trend": "Mixed (-0.45% today, +3.1% YTD)",
+        "key_themes": ["E-commerce dominance with Amazon capturing 38% of US online sales"],
+        "risks": [
+            "Consumer spending slowdown if labor market softens",
+            "Tesla competitive pressure from BYD and legacy OEMs",
+        ],
+        "outlook": "Selective. AMZN is core holding. Avoid pure EV plays; cautious on TSLA.",
+        "top_holdings": ["AMZN", "HD", "MCD", "SBUX", "TSLA"],
+    },
+}
+
+
+@tool
+def get_stock_data(symbol: str) -> dict[str, Any]:
+    """Get current stock price and market data for a given ticker symbol.
+
+    Args:
+        symbol: Stock ticker symbol (AAPL, MSFT, GOOGL, AMZN, TSLA, NVDA, META,
+            JPM, GS, JNJ, LLY, XOM, CVX, KO, PG, SPY).
+
+    Returns:
+        Price, change, sector, market cap, P/E ratio, and dividend yield.
+    """
+    normalized_symbol = symbol.upper().replace(".", "")
+    data = _STOCKS.get(normalized_symbol) or _STOCKS.get(symbol.upper())
+    if not data:
+        return {
+            "error": f"Symbol '{symbol}' not found.",
+            "supported_symbols": list(_STOCKS.keys()),
+        }
+    return {"symbol": normalized_symbol, **data}
+
+
+@tool
+def search_news(query: str, sector: str = "macro") -> dict[str, Any]:
+    """Search for recent market news headlines.
+
+    Args:
+        query: Topic or keyword, such as ``AI chips``, ``rate cuts``, or
+            ``earnings``.
+        sector: technology, healthcare, energy, financials,
+            consumer_discretionary, consumer_staples, consumer, or macro.
+
+    Returns:
+        The resolved deterministic news sector and matching headlines. Unknown
+        sectors resolve to the macro bucket.
+    """
+    requested_key = sector.lower().replace(" ", "_").replace("-", "_")
+    key = requested_key if requested_key in _NEWS else "macro"
+    return {"query": query, "sector": key, "headlines": _NEWS[key]}
+
+
+@tool
+def get_market_overview() -> dict[str, Any]:
+    """Get a snapshot of major indices, sector performance, and top movers."""
+    return {
+        "indices": {
+            "S&P 500": {"level": 5234.18, "change_pct": +0.42, "ytd_pct": +7.8},
+            "NASDAQ": {"level": 16421.54, "change_pct": +0.87, "ytd_pct": +9.3},
+            "Dow Jones": {"level": 38742.15, "change_pct": +0.18, "ytd_pct": +4.1},
+            "VIX": {"level": 14.23, "change_pct": -3.21, "note": "low volatility"},
+        },
+        "sector_performance_today": {
+            "Technology": +1.24,
+            "Healthcare": +0.31,
+            "Financials": +0.67,
+            "Energy": -1.12,
+            "Consumer Discretionary": -0.45,
+            "Consumer Staples": +0.22,
+        },
+        "top_gainers": [
+            {"symbol": "NVDA", "change_pct": +2.76},
+            {"symbol": "AMZN", "change_pct": +2.70},
+        ],
+        "top_losers": [
+            {"symbol": "TSLA", "change_pct": -3.35},
+            {"symbol": "XOM", "change_pct": -1.82},
+        ],
+        "market_sentiment": "Moderately Bullish",
+    }
+
+
+@tool
+def get_sector_data(sector: str) -> dict[str, Any]:
+    """Get detailed analysis for a market sector.
+
+    Args:
+        sector: technology, healthcare, energy, financials, consumer_staples,
+            or consumer_discretionary.
+
+    Returns:
+        Trend, key themes, risks, outlook, and top holdings.
+    """
+    key = sector.lower().replace(" ", "_").replace("-", "_")
+    data = _SECTOR_DATA.get(key)
+    if not data:
+        return {
+            "error": f"Sector '{sector}' not found.",
+            "available": list(_SECTOR_DATA.keys()),
+        }
+    return {"sector": key, **data}
+
+
+@tool
+def compare_stocks(symbols: str) -> dict[str, Any]:
+    """Compare multiple stocks side by side on key metrics.
+
+    Args:
+        symbols: Comma-separated ticker symbols, such as ``AAPL,MSFT,GOOGL``.
+
+    Returns:
+        A comparison table and count of matched symbols.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for symbol in [item.strip().upper() for item in symbols.split(",")]:
+        data = _STOCKS.get(symbol.replace(".", "")) or _STOCKS.get(symbol)
+        if data:
+            result[symbol] = {
+                "name": data["name"],
+                "price": data["price"],
+                "change_pct": data["change_pct"],
+                "sector": data["sector"],
+                "pe_ratio": data["pe_ratio"],
+                "dividend_yield": data["dividend_yield"],
+            }
+    return {"comparison": result, "count": len(result)}
+
+
+SYSTEM_PROMPT = """\
+You are an expert market intelligence analyst for MarketPulse Pro, providing
+financial insights to investment brokers and advisors.
+
+IMPORTANT: You have access to structured market analysis skills (listed in the
+<available_skills> section above). Before performing any specialised analysis
+task, ALWAYS activate the relevant skill first using the `skills` tool:
+
+  skills(skill_name="trend-analysis")    — price trend / momentum
+  skills(skill_name="sector-rotation")   — sector rotation / allocation
+  skills(skill_name="earnings-snapshot") — earnings / valuation assessment
+  skills(skill_name="portfolio-risk")    — portfolio risk evaluation
+
+After activating a skill, follow its instructions precisely and use the tools
+it specifies. For general market-overview requests, use the ordinary market
+tools directly without activating a skill.
+
+Always include specific numbers from tool results in your responses.
+"""
+
+_MAX_SESSION_AGENTS = 32
+_SESSION_AGENTS: OrderedDict[str, Agent] = OrderedDict()
+_SESSION_AGENTS_LOCK = Lock()
+
+
+def _create_agent() -> Agent:
+    """Create a session-local Strands agent without making a model request."""
+    return Agent(
+        model=_MODEL,
+        tools=[
+            get_stock_data,
+            search_news,
+            get_market_overview,
+            get_sector_data,
+            compare_stocks,
+        ],
+        plugins=[_SKILLS_PLUGIN],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+
+def _get_agent(session_id: str | None) -> Agent:
+    """Return the cached agent for a session, or an uncached safe fallback."""
+    if not session_id:
+        return _create_agent()
+
+    with _SESSION_AGENTS_LOCK:
+        agent = _SESSION_AGENTS.get(session_id)
+        if agent is None:
+            agent = _create_agent()
+            _SESSION_AGENTS[session_id] = agent
+            if len(_SESSION_AGENTS) > _MAX_SESSION_AGENTS:
+                _SESSION_AGENTS.popitem(last=False)
+        else:
+            _SESSION_AGENTS.move_to_end(session_id)
+        return agent
+
+
+def _safe_string(value: Any) -> str:
+    """Convert streamed values to text without propagating conversion errors."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+
+    return str(value)
+
+
+@app.entrypoint
+async def invoke(payload: Mapping[str, Any], context: Any) -> str:
+    """Invoke the session-scoped MarketTrends agent and collect text chunks."""
+    prompt = _safe_string(payload.get("prompt", ""))
+    raw_session_id = getattr(context, "session_id", None)
+    session_id = _safe_string(raw_session_id) if raw_session_id is not None else None
+    logger.info("Received prompt (session=%s): %s", session_id, prompt[:80])
+
+    agent = _get_agent(session_id)
+    chunks: list[str] = []
+    async for event in agent.stream_async(prompt):
+        if isinstance(event, Mapping) and "data" in event:
+            chunk = _safe_string(event["data"])
+            if chunk:
+                chunks.append(chunk)
+    return "".join(chunks)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/02-use-cases/01-conversational-agents/market-trends-agent/pyproject.toml
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/pyproject.toml
@@ -18,7 +18,10 @@ dependencies = [
     # create_ab_test, create_gateway).
     # The [simulation] extra pulls in strands-agents-evals, which drives
     # LLM-actor conversations in SimulatedScenario evaluations.
-    "bedrock-agentcore[simulation]>=1.7.0",
+    "bedrock-agentcore[simulation]==1.8.0",
+    # Exact runtime dependencies for the isolated native AgentSkills variant.
+    "strands-agents[otel]==1.38.0",
+    "aws-opentelemetry-distro==0.19.0",
     "jinja2",
     # AgentCore observability — framework-level auto-instrumentation for
     # LangChain / LangGraph. Emits gen_ai.*, traceloop.entity.* attributes

--- a/02-use-cases/01-conversational-agents/market-trends-agent/requirements.txt
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/requirements.txt
@@ -3,5 +3,7 @@ langchain-aws
 langchain-core
 boto3
 playwright
-bedrock-agentcore
+bedrock-agentcore==1.8.0
+strands-agents[otel]==1.38.0
+aws-opentelemetry-distro==0.19.0
 jsonschema>=4.24.0,<4.25.0

--- a/02-use-cases/01-conversational-agents/market-trends-agent/skills/earnings-snapshot/SKILL.md
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/skills/earnings-snapshot/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: earnings-snapshot
+description: Generate a concise earnings and fundamental snapshot for a stock, covering valuation, recent earnings news, and analyst positioning
+allowed-tools:
+  - get_stock_data
+  - search_news
+---
+
+# Earnings Snapshot Skill
+
+Use this skill when a user asks about a company's earnings, valuation metrics, fundamentals, whether a stock is cheap or expensive, or how recent results compared to expectations.
+
+## Required workflow
+
+1. Retrieve stock data using `get_stock_data` for the requested symbol.
+2. Search for earnings-related news using `search_news` with the stock's sector.
+3. Extract the following fundamental metrics from stock data:
+   - P/E ratio (compare to sector average: Technology ~34x, Healthcare ~22x, Financials ~13x, Energy ~14x, Consumer Discretionary ~30x, Consumer Staples ~25x)
+   - Dividend yield (0% = growth stock; >2% = income stock)
+   - Market cap tier (Mega >$1T, Large $100B-$1T, Mid $10B-$100B)
+4. Assess valuation:
+   - P/E > 1.3× sector average → **Premium** (growth priced in)
+   - P/E within 0.7×–1.3× sector average → **Fair Value**
+   - P/E < 0.7× sector average → **Discount** (value opportunity or value trap)
+5. Identify the most relevant earnings headline from news results.
+6. Provide a 2-sentence earnings outlook.
+
+## Output Format
+
+```
+Earnings Snapshot: {SYMBOL} — {Company Name}
+  Price         : ${price}
+  P/E Ratio     : {pe_ratio}x  ({Premium | Fair Value | Discount} vs. {sector} avg {sector_avg}x)
+  Dividend Yield: {yield}%
+  Market Cap    : ${cap}  ({tier})
+  Earnings News : {top headline}
+  Outlook       : {2-sentence assessment}
+```

--- a/02-use-cases/01-conversational-agents/market-trends-agent/skills/portfolio-risk/SKILL.md
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/skills/portfolio-risk/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: portfolio-risk
+description: Assess the risk profile of a set of stocks or a sector allocation, scoring concentration risk, volatility exposure, and overall risk tier
+allowed-tools:
+  - get_stock_data
+  - get_sector_data
+---
+
+# Portfolio Risk Assessment Skill
+
+Use this skill when a user asks about portfolio risk, how risky a set of holdings is, concentration risk, diversification, or whether a portfolio is suitable for a given risk tolerance.
+
+## Required workflow
+
+1. For each stock in the portfolio, retrieve data using `get_stock_data`.
+2. Retrieve sector data for each unique sector represented using `get_sector_data`.
+3. Compute concentration risk:
+   - If any single sector > 50% of holdings → **High Concentration Risk**
+   - If any single sector 30–50% → **Moderate Concentration Risk**
+   - Otherwise → **Diversified**
+4. Assess volatility exposure:
+   - High-beta sectors (Technology, Consumer Discretionary): count them
+   - If > 50% of holdings in high-beta sectors → **High Volatility Exposure**
+   - If 25–50% → **Moderate**; < 25% → **Low**
+5. Identify the single largest risk factor from sector risk lists.
+6. Score overall risk tier: **Conservative**, **Moderate**, **Aggressive**:
+   - Conservative: Low volatility + Diversified
+   - Aggressive: High volatility OR High Concentration
+   - Moderate: all other combinations
+7. Suggest one defensive addition (from Consumer Staples or Healthcare sectors) if risk is Aggressive.
+
+## Output Format
+
+```
+Portfolio Risk Assessment
+  Holdings analyzed : {symbols list}
+  Sector breakdown  : {sector: count breakdown}
+  Concentration     : {High | Moderate | Diversified}
+  Volatility exposure: {High | Moderate | Low}
+  Top risk factor   : {single biggest risk from sector data}
+  Overall risk tier : {Conservative | Moderate | Aggressive}
+  Recommendation    : {1-2 sentences on risk mitigation or confirmation}
+```

--- a/02-use-cases/01-conversational-agents/market-trends-agent/skills/sector-rotation/SKILL.md
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/skills/sector-rotation/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sector-rotation
+description: Identify which market sectors to overweight or underweight based on current macro conditions and sector performance data
+allowed-tools:
+  - get_market_overview
+  - get_sector_data
+  - search_news
+---
+
+# Sector Rotation Skill
+
+Use this skill when a user asks about sector allocation, where to rotate capital, which sectors to favor or avoid, or how to position a portfolio across sectors.
+
+## Required workflow
+
+1. Retrieve the overall market overview using `get_market_overview`.
+2. Retrieve detailed data for the following sectors using `get_sector_data` for each: technology, healthcare, financials, energy, consumer_staples, consumer_discretionary.
+3. Search for macro news using `search_news` with sector="macro" to understand the rate/GDP backdrop.
+4. Rank sectors by today's performance and YTD trend direction.
+5. Classify each sector as **Overweight**, **Neutral**, or **Underweight** based on:
+   - Today's performance relative to the broad market
+   - Outlook field from sector data
+   - Macro backdrop (rate environment, growth signals)
+6. Identify the top 2 sectors to overweight and the bottom 2 to underweight.
+7. Provide a rotation rationale (2–3 sentences) explaining the macro driver.
+
+## Output Format
+
+```
+Sector Rotation Recommendation
+  Market backdrop : {brief macro summary}
+  Overweight  (1) : {sector}  —  {reason}
+  Overweight  (2) : {sector}  —  {reason}
+  Neutral         : {sectors list}
+  Underweight (1) : {sector}  —  {reason}
+  Underweight (2) : {sector}  —  {reason}
+  Rotation theme  : {1–2 sentence theme}
+```

--- a/02-use-cases/01-conversational-agents/market-trends-agent/skills/trend-analysis/SKILL.md
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/skills/trend-analysis/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: trend-analysis
+description: Analyze price and volume trends for one or more stocks to determine momentum direction and key technical levels
+allowed-tools:
+  - get_stock_data
+  - get_sector_data
+  - search_news
+---
+
+# Trend Analysis Skill
+
+Use this skill when a user asks about price trends, momentum, technical analysis, or whether a stock is trending up or down.
+
+## Required workflow
+
+1. Retrieve current stock data using `get_stock_data` for each symbol in the request.
+2. Retrieve sector data for the stock's sector using `get_sector_data`.
+3. Search for recent news affecting the stock using `search_news` with the stock's sector.
+4. Evaluate momentum: classify the trend as **Uptrend**, **Downtrend**, or **Sideways** based on:
+   - Daily price change direction and magnitude
+   - Sector trend (outperforming / underperforming / neutral)
+   - News sentiment (positive / negative / mixed)
+5. Identify key support level: approximate as price × 0.95 (−5% from current).
+6. Identify key resistance level: approximate as price × 1.05 (+5% from current).
+7. Assign a confidence score (Low / Medium / High) based on alignment across price, sector, and news signals.
+8. Output a structured Trend Analysis Report with: symbol, current price, trend direction, momentum signal, key levels, and confidence.
+
+## Output Format
+
+```
+Trend Analysis: {SYMBOL}
+  Price       : ${price}  ({change_pct:+.2f}% today)
+  Trend       : {Uptrend | Downtrend | Sideways}
+  Momentum    : {signal description}
+  Support     : ${support}
+  Resistance  : ${resistance}
+  Confidence  : {Low | Medium | High}
+  Summary     : {1-2 sentence rationale}
+```

--- a/02-use-cases/01-conversational-agents/market-trends-agent/uv.lock
+++ b/02-use-cases/01-conversational-agents/market-trends-agent/uv.lock
@@ -2,8 +2,11 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version < '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
 ]
 
 [[package]]
@@ -173,6 +176,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -188,6 +203,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "aws-opentelemetry-distro"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "bytecode", version = "0.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "cachetools" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-distro" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-aio-pika" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-instrumentation-aiokafka" },
+    { name = "opentelemetry-instrumentation-aiopg" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-instrumentation-asyncpg" },
+    { name = "opentelemetry-instrumentation-aws-lambda" },
+    { name = "opentelemetry-instrumentation-boto3sqs" },
+    { name = "opentelemetry-instrumentation-botocore" },
+    { name = "opentelemetry-instrumentation-cassandra" },
+    { name = "opentelemetry-instrumentation-celery" },
+    { name = "opentelemetry-instrumentation-confluent-kafka" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-falcon" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-flask" },
+    { name = "opentelemetry-instrumentation-grpc" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-jinja2" },
+    { name = "opentelemetry-instrumentation-kafka-python" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-mysql" },
+    { name = "opentelemetry-instrumentation-mysqlclient" },
+    { name = "opentelemetry-instrumentation-openai-agents-v2" },
+    { name = "opentelemetry-instrumentation-pika" },
+    { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-pymemcache" },
+    { name = "opentelemetry-instrumentation-pymongo" },
+    { name = "opentelemetry-instrumentation-pymysql" },
+    { name = "opentelemetry-instrumentation-pyramid" },
+    { name = "opentelemetry-instrumentation-redis" },
+    { name = "opentelemetry-instrumentation-remoulade" },
+    { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-instrumentation-sqlite3" },
+    { name = "opentelemetry-instrumentation-starlette" },
+    { name = "opentelemetry-instrumentation-system-metrics" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-instrumentation-tornado" },
+    { name = "opentelemetry-instrumentation-tortoiseorm" },
+    { name = "opentelemetry-instrumentation-urllib" },
+    { name = "opentelemetry-instrumentation-urllib3" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-processor-baggage" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-propagator-b3" },
+    { name = "opentelemetry-propagator-jaeger" },
+    { name = "opentelemetry-propagator-ot-trace" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk-extension-aws" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/00/aaa53dff5e149ca572cfa20df9a21eb9115e91fe92a1c4708f711d09fc5b/aws_opentelemetry_distro-0.19.0.tar.gz", hash = "sha256:d1da452156d2c437879543badf20a154141dfcf9e765a9f9f2fa7ce514fe8190", size = 651401, upload-time = "2026-07-23T16:49:27.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/f0/12e3f463096bb8e655e8f74eb5209855c6f2120b631eb2b57d2652458f45/aws_opentelemetry_distro-0.19.0-py3-none-any.whl", hash = "sha256:6ceee32cfd64584955b15ef97787400177ecf953ed36e33eeb8abcf3f1f05147", size = 398045, upload-time = "2026-07-23T16:49:26.157Z" },
 ]
 
 [[package]]
@@ -300,6 +390,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/03/b7/416ae6f1461d6fec3b3aaffc4759371319c71a21f7ab4c3106ee574fda8d/botocore-1.43.1.tar.gz", hash = "sha256:270d6357d662550fdb84973ec247e02bece0b6283d90bf37319c7753515336e4", size = 15296915, upload-time = "2026-04-30T20:26:50.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/48/dc2290d2af8b1dc3a44d210555a90f0cb76ef913c52b0c4f31a43cce27b8/botocore-1.43.1-py3-none-any.whl", hash = "sha256:955edc6a398b9c4100cf0d5a31433fdba3835500bf38c1ef171e6e75f4b477d2", size = 14979119, upload-time = "2026-04-30T20:26:46.031Z" },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c4/4818b392104bd426171fc2ce9c79c8edb4019ba6505747626d0f7107766c/bytecode-0.17.0.tar.gz", hash = "sha256:0c37efa5bd158b1b873f530cceea2c645611d55bd2dc2a4758b09f185749b6fd", size = 105863, upload-time = "2025-09-03T19:55:45.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/80/379e685099841f8501a19fb58b496512ef432331fed38276c3938ab09d8e/bytecode-0.17.0-py3-none-any.whl", hash = "sha256:64fb10cde1db7ef5cc39bd414ecebd54ba3b40e1c4cf8121ca5e72f170916ff8", size = 43045, upload-time = "2025-09-03T19:55:43.879Z" },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
 ]
 
 [[package]]
@@ -561,7 +684,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -704,6 +827,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -765,6 +900,67 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/fd/655c8a773d728bc3c93fb4713ae4bf79ffc75996f86fb78b2974c8e1dfbd/grpcio-1.83.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fba099b716e73512d61b97f71ea3c31a72abb36904036e316bf4dd148ca8dcc8", size = 6334247, upload-time = "2026-07-23T15:18:53.099Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9a/1ce5760d35a04a992006dd2f79afff2db548f93ee7426fa95c9f1fc90c61/grpcio-1.83.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6755ed67cc3e454d51ae9f6e1915b80d3942fa4de956ef48dacd45ab7f40b727", size = 12168650, upload-time = "2026-07-23T15:18:56.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ab/bbcb5be0a1a6cb21f036e2afdd4f7a70147cfb7a7b42648a310d7c43acfc/grpcio-1.83.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5882c1a721b50ce0123ee5e839e1ab059ad72a7ade76cdf2d5bd833b56791acf", size = 6916899, upload-time = "2026-07-23T15:18:58.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/4c27977ecb3b3f9f363b93f570e001cb24ef264a9a907d7fd0f949ed59f0/grpcio-1.83.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4e3eedfc92b6b9f2960115e7e620cf0cbf80bb7849a51ce3820dc54dfd88b6b9", size = 7648761, upload-time = "2026-07-23T15:19:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/23/49/0c823a7627ff2e69a61e4a53c4edf215272892fc2c47c6431f033d46f4cc/grpcio-1.83.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4fcaa7c45c45b4a89e2867d1f1785d9481a788399d915e341ed2eb49aeef9dd4", size = 7074920, upload-time = "2026-07-23T15:19:02.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ce/963f01ff7c789a76909c9691b704112e02ca1e11c10405cd99c2bd7c40f1/grpcio-1.83.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6b6c666a1d5613ff360c9e90f44665e3a88b25a815209ddbc0917eec281931cb", size = 7598046, upload-time = "2026-07-23T15:19:03.921Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/de/1ce6bdefc847a7973040d10cebc8996c653a2a687c0a4da8d05dcab4e397/grpcio-1.83.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6be5c807b717be3dd649446f021301fd7907e376318675d2147823071034112a", size = 8634792, upload-time = "2026-07-23T15:19:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8b/7fe6a73895e3bdd788101d1276e48e0d262ebb165afacec1ec4efebcd785/grpcio-1.83.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c834e86d8fd2f03d7e4db49a027f7c5b89c5b88eed305543a5295bd6fee61e40", size = 8000286, upload-time = "2026-07-23T15:19:07.739Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b0/9a779de2bcda8722501a056fad1bec3d1117977af0c080ab1fc0655fdf35/grpcio-1.83.0-cp310-cp310-win32.whl", hash = "sha256:35a5b1c192496b6c25956eebfa963468935612206fd2543ac3ce981e6a5e0f03", size = 4404616, upload-time = "2026-07-23T15:19:09.988Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8e/ce9a23590cac33a6c24e6386cc0ffc55821cc13212acc822e98f00a67161/grpcio-1.83.0-cp310-cp310-win_amd64.whl", hash = "sha256:8f6c395e493d20c39b29392ca200e9aaeb78d0bc2f04db0c0a7da7ddc939aa57", size = 5162304, upload-time = "2026-07-23T15:19:11.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f6/3b781cd07a715ea5f5125ae264226e7fc4d87603d6d3955022cabfdc5da2/grpcio-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:8ff0b8767ddd62704e0d9571c1890af08d84a3a689ebba1807e62519d0b3277f", size = 6338720, upload-time = "2026-07-23T15:19:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/d14833d15d5984e366f1b027fa78bd038c9b028c66880bffb0f5a4d25ee2/grpcio-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4772402f43517b4824980be4b3b2274a81eec0004a70009473c31b340d43e223", size = 12178773, upload-time = "2026-07-23T15:19:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/8acbb416544e7871132d8e42a07ed70c802d70e6a16c6009e505a34d32a4/grpcio-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f4cee5fc86e84a0cf7ad1574b454c3320e087c07f55b7df5dc0ac6a873fb90c0", size = 6921203, upload-time = "2026-07-23T15:19:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/0fdbfaf4fc54e5c88f6bce4008a065092fe7fbc4460eb5617ae8b20fd505/grpcio-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f5e822a7e7d03282f6ad225e710493c48b9057a353358344a5f7c42b2b37618d", size = 7648508, upload-time = "2026-07-23T15:19:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ea/107b9dbb2ed3ad14dd774fd3dde7d29ff9938a6c198654becb2c3a0e9a6a/grpcio-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5f410d7c2903eabb34789dfd6342eef04af1ad459943936b7e09a9f5bd417b9", size = 7079466, upload-time = "2026-07-23T15:19:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/9fa9941089e6fae83b060b6ce61c1e81053e52decae43197245f45e07d36/grpcio-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee94a4016fdf8699fb1fd8a38652475ff677f1c72074cee44deeeb9a7e95e745", size = 7605583, upload-time = "2026-07-23T15:19:23.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/f10fb56062dc2771c630827a82d9ad0ecd05cad572ea3b08d49f6631680a/grpcio-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6444666317338e903093c7c756e6cc88eee59f798cb8dd41e87725bf54e1617", size = 8637810, upload-time = "2026-07-23T15:19:25.536Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/f84927258f6a1b6ea6dea661fdc6de859b35e560c96f3012d15ccd39f85e/grpcio-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aa074041231f03959cb097dd5517b0677b8ea49215bae01d5710a7b69dd59969", size = 8008021, upload-time = "2026-07-23T15:19:27.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/cdf72161397ccd29d4ca2192f641524536c9cf54ad948c9dd0e0e01138fa/grpcio-1.83.0-cp311-cp311-win32.whl", hash = "sha256:cb056f6e171c42639a50460b2929c82241fda51f71cf3dcdd68090fe45095a45", size = 4404376, upload-time = "2026-07-23T15:19:30.137Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ed/e0ffeb4c848699c194dc9fb6a29ab29bcb2b6aac8c416bf18c51bfe8242c/grpcio-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:7416952ca770477990257206276999056f8316d79196f2f25942393e58a20b49", size = 5164469, upload-time = "2026-07-23T15:19:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
+    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -817,18 +1013,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1047,6 +1231,7 @@ name = "market-trends-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aws-opentelemetry-distro" },
     { name = "bedrock-agentcore", extra = ["simulation"] },
     { name = "boto3" },
     { name = "jinja2" },
@@ -1056,6 +1241,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "opentelemetry-instrumentation-langchain" },
     { name = "playwright" },
+    { name = "strands-agents", extra = ["otel"] },
     { name = "wrapt" },
 ]
 
@@ -1077,7 +1263,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bedrock-agentcore", extras = ["simulation"], specifier = ">=1.7.0" },
+    { name = "aws-opentelemetry-distro", specifier = "==0.19.0" },
+    { name = "bedrock-agentcore", extras = ["simulation"], specifier = "==1.8.0" },
     { name = "black", marker = "extra == 'dev'" },
     { name = "boto3", specifier = ">=1.42.0" },
     { name = "flake8", marker = "extra == 'dev'" },
@@ -1090,6 +1277,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-langchain" },
     { name = "playwright" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "strands-agents", extras = ["otel"], specifier = "==1.38.0" },
     { name = "wrapt", specifier = "<1.16.0" },
 ]
 provides-extras = ["dev"]
@@ -1436,7 +1624,8 @@ name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
@@ -1471,7 +1660,9 @@ name = "numpy"
 version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/7d/3fec4199c5ffb892bed55cff901e4f39a58c81df9c44c280499e92cad264/numpy-2.3.2.tar.gz", hash = "sha256:e0486a11ec30cdecb53f184d496d1c6a20786c81e55e41640270130056f8ee48", size = 20489306, upload-time = "2025-07-24T21:32:07.553Z" }
 wheels = [
@@ -1552,20 +1743,81 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-distro"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/61/29e94c78299b173486e6e3b10d63e89cbe340745743c6ed6ae2055433743/opentelemetry_distro-0.65b0.tar.gz", hash = "sha256:e2fef26fdf72978ab172530c13338aff367edae41ae8d90b7f6133efedde10ab", size = 2334, upload-time = "2026-07-16T15:25:47.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/d5/603a29962542152331c6e37a121129a26e24917daa4298ca00bea97571bb/opentelemetry_distro-0.65b0-py3-none-any.whl", hash = "sha256:0e15bb1a54c638e6c361bc66bc43e9de9ead442e1ae06f8099a2c1d27b6ef845", size = 2775, upload-time = "2026-07-16T15:24:47.562Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.62b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1573,9 +1825,329 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aio-pika"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ef/506a5227242ddc8b4493f8982f2ee1fb690fd9ba86668246528c096a383e/opentelemetry_instrumentation_aio_pika-0.65b0.tar.gz", hash = "sha256:4ff8414933d0e03daeb22f4c16f1153fbe7f0410d1b69bfeb903d522a693377d", size = 10193, upload-time = "2026-07-16T15:25:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/7b/2e7e6ad3f07061d7addd97756d48ec679c0a4fde6813d9078a41a6b50af8/opentelemetry_instrumentation_aio_pika-0.65b0-py3-none-any.whl", hash = "sha256:6699602585103683512da7cfe499786f1537beaa6af0565bf01fc0e84ee8cefd", size = 11676, upload-time = "2026-07-16T15:24:52.456Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/33/3ff7230b035e8b696db6be54f5c52dfa409829d634d91431c076ad789820/opentelemetry_instrumentation_aiohttp_client-0.65b0.tar.gz", hash = "sha256:85906a2806ee5641756b5c33274e9aa75c3cc2441e3b830aa5804cf0e1fa9dd1", size = 19042, upload-time = "2026-07-16T15:25:51.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/f9/5c8459224f175829601cabbcffaeab0f9041903c086e4a0368f9971093a5/opentelemetry_instrumentation_aiohttp_client-0.65b0-py3-none-any.whl", hash = "sha256:3a060efa53fa44d02ba7372a7ed2b42cdfa6be6df81b089845067ad840e25729", size = 13677, upload-time = "2026-07-16T15:24:53.361Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiokafka"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/2a/6bcc9ea1dfc2d5f0320f7d0b4e461058238ff9feab2d6a6304f4fd938227/opentelemetry_instrumentation_aiokafka-0.65b0.tar.gz", hash = "sha256:5261119a9f23755b617b3998331ef1ed408f929f686b5d780431c8ec385f91ff", size = 14327, upload-time = "2026-07-16T15:25:52.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/24/e539afc684c14d76a114953b870713a903f81ef704286b64bab2311f98b1/opentelemetry_instrumentation_aiokafka-0.65b0-py3-none-any.whl", hash = "sha256:dd391f559273b5779fbaea24cd56ea256599242933c5328f152d63d3597faf24", size = 12745, upload-time = "2026-07-16T15:24:55.311Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiopg"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/0f/01e6dc47ba6974ebc5a4a7c5d0e39b55e4ada6834f135ecc2c4a82c7a07b/opentelemetry_instrumentation_aiopg-0.65b0.tar.gz", hash = "sha256:9a0935a673dcd43ed1d0639d439581d334454d3403b496190408e0bc2547c178", size = 12565, upload-time = "2026-07-16T15:25:53.796Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/bd/801fdbdb0ee1f9197c841c12601546a1fc8ee84febfede3b2a6e6d6b97f9/opentelemetry_instrumentation_aiopg-0.65b0-py3-none-any.whl", hash = "sha256:c6a60910b80b42cb7d47f40986ca565962bc09aec55c0b51dea5a4309843827f", size = 11565, upload-time = "2026-07-16T15:24:56.236Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asyncpg"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/de/21b57f84a41385d7055547c03b491b0de0531b0fa5a03cd4a6499a57a8f8/opentelemetry_instrumentation_asyncpg-0.65b0.tar.gz", hash = "sha256:0b14338886f17c18a9899d6764117a4c163a9826f6ed1577f68ee773f95ebbc2", size = 11202, upload-time = "2026-07-16T15:25:57.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/18/c021ac484e447fd185a968cf3b134b67c30bfbda6f0add347da1d7c109e2/opentelemetry_instrumentation_asyncpg-0.65b0-py3-none-any.whl", hash = "sha256:9156d2501021b968da0f317eb508d3efb3e7506bf50e00ee477ce0636a12772a", size = 9744, upload-time = "2026-07-16T15:25:00.172Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aws-lambda"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/71/88439b60cb4b74ee4bf19897628fc9a0a2be5586a6498f6cc180f0f77ebd/opentelemetry_instrumentation_aws_lambda-0.65b0.tar.gz", hash = "sha256:70b9d96d94816ad3f43531a30d65a033f43534b68bcdd340d7fe96ab4c7ace74", size = 22431, upload-time = "2026-07-16T15:25:58.041Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/20/432a7e6aaf4244087ab7d200097478275743549257c2966587024ed75ab8/opentelemetry_instrumentation_aws_lambda-0.65b0-py3-none-any.whl", hash = "sha256:3667b9b1ba7947d565a83dd8fa8e2eaa39d2b670bece9553b2e9648a150658d7", size = 14026, upload-time = "2026-07-16T15:25:01.305Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-boto3sqs"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/6e/2b7216089e447d2e41de827e7e690fb5708fe8e089be73cb9fbfafd22d93/opentelemetry_instrumentation_boto3sqs-0.65b0.tar.gz", hash = "sha256:009ef38ff341b7e7a2c33eb28aff281f40892b0fbc8b0ebeb072dac4b04ac377", size = 12030, upload-time = "2026-07-16T15:25:58.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/28/48c7eb993d1af8332fca2104202cf42a5fe612dc3cca7886dd56d2221055/opentelemetry_instrumentation_boto3sqs-0.65b0-py3-none-any.whl", hash = "sha256:154b4204f8a5b56d6b364cc30a679d5982c7c1b7cd249b155c08319f1626a215", size = 10813, upload-time = "2026-07-16T15:25:02.377Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-botocore"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/03/a0c6a0f34ba3cacda527317e7f2a5a1fcfd21c9911eee3e6fc2be63d0a93/opentelemetry_instrumentation_botocore-0.65b0.tar.gz", hash = "sha256:64987326ac98a47a85821606a981f5058864de0e98b43c8de892eb0fe625b04e", size = 125099, upload-time = "2026-07-16T15:25:59.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/59/0b51f55d9fb96949674efe895d330506b7b8c1b13a6401f0eec49d1196af/opentelemetry_instrumentation_botocore-0.65b0-py3-none-any.whl", hash = "sha256:a5e80b9423f8369c9bbc27a64b31f02cc44218633028ad8d1ace0a2a7fc8f4cd", size = 36242, upload-time = "2026-07-16T15:25:03.377Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-cassandra"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/30/adb0b1000d65404f7c4a03f1ede73d04fbbce7f10bce169fb9afb516cf74/opentelemetry_instrumentation_cassandra-0.65b0.tar.gz", hash = "sha256:4de7383d21e93e3b1e7eda98dfc606ed143ee4e3f2fec0472a2d2277dbdbd4d6", size = 8932, upload-time = "2026-07-16T15:26:00.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/4a/c488ebaf40f04035915b57498275b4937c108f170dae4dd527fa431732e4/opentelemetry_instrumentation_cassandra-0.65b0-py3-none-any.whl", hash = "sha256:beb7464de896ad22ff571d3927ab3098bba8b1eeed5b36c3400e78093f8f6421", size = 8444, upload-time = "2026-07-16T15:25:04.509Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ba/c4ef088927a6bf1b75916b3bfca93552526f0e3e85d19557666f858fc5b6/opentelemetry_instrumentation_celery-0.65b0.tar.gz", hash = "sha256:ff4d192b6371cfe06969005862dc558cc8b79b03b0bbdfbf65b9a59e4dcd7fee", size = 16071, upload-time = "2026-07-16T15:26:00.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/3a/3a53db4c82bd42f67a16c846aa972aef75043557e26e9d6a4ca8ffac9699/opentelemetry_instrumentation_celery-0.65b0-py3-none-any.whl", hash = "sha256:8510357a6a9e2cb1a6485fe98642a39f06c2970eb58656de06260b922ffe7888", size = 13556, upload-time = "2026-07-16T15:25:05.427Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-confluent-kafka"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/d9/7f3bc64982b65f56163fe0161fd8c4bc2dfef2c52a19337d41326343de08/opentelemetry_instrumentation_confluent_kafka-0.65b0.tar.gz", hash = "sha256:48637af517ddf368c5d9589f71b3d78dae1a2fe7c026fc43c23307ab2d98ee52", size = 13089, upload-time = "2026-07-16T15:26:02.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/40/f1bf142a5c82592a6e40dcc09bf4a79ed472e6acfc0d6b463e42119c91b0/opentelemetry_instrumentation_confluent_kafka-0.65b0-py3-none-any.whl", hash = "sha256:aa92e49402b0dda65f8a24b2bf9d4558043309b9c0e494041616c479183748b2", size = 12858, upload-time = "2026-07-16T15:25:07.345Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/97/b2e0ae6951cbf93c0c211910077cb50f9478fb4b7e89a402800b9a98151c/opentelemetry_instrumentation_dbapi-0.65b0.tar.gz", hash = "sha256:da048bb683347ddad2f47344bacfe1e111bf7bfb2e5a39796b1083679ad4f0f3", size = 20247, upload-time = "2026-07-16T15:26:02.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/e3/106953cea1d7f9318a4b56827ad10839fda3d033ecea2db717c051bf6a60/opentelemetry_instrumentation_dbapi-0.65b0-py3-none-any.whl", hash = "sha256:50b662578a6903b028e09b73f604de687752f5f904aa0ca032969157b29d60f2", size = 14815, upload-time = "2026-07-16T15:25:08.361Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/91/2ce18c8ace56c846a094bce126b8248f3820e366c157e7ca367679715552/opentelemetry_instrumentation_django-0.65b0.tar.gz", hash = "sha256:f79914e03ccf7f34a4dfd257ea9fa1236a6568cd1756e5f969dc026252fad6e9", size = 25386, upload-time = "2026-07-16T15:26:03.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/e4/f458cc6acc5b130ecf91da50ade9c04ff8b93d374a8f6ee7538f0fb10be2/opentelemetry_instrumentation_django-0.65b0-py3-none-any.whl", hash = "sha256:915117536c421c3e61e34dadbd373fc404447c7a786303e02f732bc8860e3ba0", size = 18936, upload-time = "2026-07-16T15:25:09.343Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-falcon"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/3c/8f603bc9574c78dace9e4f3bc0016223e1be64a69c670cdfa2a15c12ed07/opentelemetry_instrumentation_falcon-0.65b0.tar.gz", hash = "sha256:494e45cff0cd6e64a35200644715de09e970c66ff8709133e17f87112935a2c9", size = 16828, upload-time = "2026-07-16T15:26:05.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/0f/12f02ea958c7ec482f3e589ed8f9916228edd611cd4f6da9aca195f5ab22/opentelemetry_instrumentation_falcon-0.65b0-py3-none-any.whl", hash = "sha256:e4b1a0da28580f66b0d3bcf338c8ab315414d925c57a08abc3efd92571cada70", size = 13290, upload-time = "2026-07-16T15:25:11.462Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-flask"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/45/7ddc536b91d133ad9e40fb0adc9f48d619400e47d8b3b936cb9d41443e04/opentelemetry_instrumentation_flask-0.65b0.tar.gz", hash = "sha256:887de3a97c09953da09ae713fbb777172900f33b2924d85dad314a033156ef66", size = 24149, upload-time = "2026-07-16T15:26:06.676Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/4f/0fc0c3f78323b0c3cdb8d3e2bde68c2a8a98e4cabdd9c41076c6e02d0825/opentelemetry_instrumentation_flask-0.65b0-py3-none-any.whl", hash = "sha256:d5337dac3b2af7f658fbc11c879667c9978910e38744b9706508f0b9908f7841", size = 15081, upload-time = "2026-07-16T15:25:13.494Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-grpc"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/80/0006818bfb54d5e3abb138607beff63561c2c920393ec8d18cc7e3d33810/opentelemetry_instrumentation_grpc-0.65b0.tar.gz", hash = "sha256:b05b3a1f476f350fdb12514ca1ebaed0d596095f91188c2efd26b3e6e2a4cc82", size = 31971, upload-time = "2026-07-16T15:26:07.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/857ecc989566b09dde5bbfaf7dce4955095416d64b2e9231d1d9d6681d56/opentelemetry_instrumentation_grpc-0.65b0-py3-none-any.whl", hash = "sha256:d4d884439ddee9e68ebd45586eaa243d982351b1ec6a5ce9916eccfd20e66805", size = 24370, upload-time = "2026-07-16T15:25:14.63Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/03/a529140241addd4d0acc73bafbd6f74691651b92fc0ae9b4513cf80f07fa/opentelemetry_instrumentation_httpx-0.65b0.tar.gz", hash = "sha256:4627aa9c6bb99bf4462c8b565b0ef6aeb9ffad95c6c92868be1ef7895de112ee", size = 26309, upload-time = "2026-07-16T15:26:07.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/0f/c6144096b4914bbf44b43ba21c962e8f333ff045770b50a3e79ed8bd455f/opentelemetry_instrumentation_httpx-0.65b0-py3-none-any.whl", hash = "sha256:400f1b78afa4ee2332b5debe58e1ed1b317913d58812c952576be76660aeadb1", size = 17436, upload-time = "2026-07-16T15:25:15.772Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-jinja2"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/fe/bcd4cfb710a69fd806bf747900b7a555384bd3a14245942d95282396b7ab/opentelemetry_instrumentation_jinja2-0.65b0.tar.gz", hash = "sha256:6aad5e4189423ed5d6ede83123b0aa8ff21434c0efd734b34736bd11cefc7432", size = 8350, upload-time = "2026-07-16T15:26:08.628Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/f3/9e0dcc92238fde63c28cad29d3aad964bc0c36e17df3627f0ae3c59eb6f6/opentelemetry_instrumentation_jinja2-0.65b0-py3-none-any.whl", hash = "sha256:1ed49d337139263f57f08034f293c43051530bdf0706420cddd151a381e07cd8", size = 8567, upload-time = "2026-07-16T15:25:16.993Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-kafka-python"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b3/df0e5625043d3af431583194c1b892a6b2a11528dc1c2ea3779b34d5122f/opentelemetry_instrumentation_kafka_python-0.65b0.tar.gz", hash = "sha256:e909be2bfacfd5d271bb3249b3f393348bbe4ebbc57e87983345cb253d419c4b", size = 10540, upload-time = "2026-07-16T15:26:09.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/94/9ea58a8777bc2e742e889342dcf34ac2dd853d1030cfbd0a6c71985bd4a7/opentelemetry_instrumentation_kafka_python-0.65b0-py3-none-any.whl", hash = "sha256:fd835f48acf84d5b2be0da88861ac2e027d38de5d78ebd5904ce03e2dade5bc9", size = 10748, upload-time = "2026-07-16T15:25:17.88Z" },
 ]
 
 [[package]]
@@ -1594,44 +2166,459 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/0a/b70a9cddbc7b314a783e62739dbb1184f8538c1f85e8ded6d340142b9b54/opentelemetry_instrumentation_logging-0.65b0.tar.gz", hash = "sha256:c0a50cade5d54db6c6af12e2c69227ecd26f2b3b779e99ff850561d3d8dd77e3", size = 19783, upload-time = "2026-07-16T15:26:09.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/8e/7577914681d77b180f8d6dcbac435be8e4ca6add6315da2d01ac4289eaa3/opentelemetry_instrumentation_logging-0.65b0-py3-none-any.whl", hash = "sha256:68365b31755c844f1e85f07dcd217839ff92f2d278a214bdf02d4dc806f9d915", size = 15727, upload-time = "2026-07-16T15:25:18.774Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-mysql"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/e8/d6c6101a74e7fa1e37849cfa1bdb67ad059d9b4d3febb106c8e4805007b5/opentelemetry_instrumentation_mysql-0.65b0.tar.gz", hash = "sha256:54f7f6897aa92378c34c2df330fb3817afe98179ec7b8c1f6c7deefd8f19379c", size = 10150, upload-time = "2026-07-16T15:26:10.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5b/713940ae00a53f495e6edbcb14bdc4275230cb64a1e423b4b36db09953ac/opentelemetry_instrumentation_mysql-0.65b0-py3-none-any.whl", hash = "sha256:8aa7bae9ddf457692570714b6b44d545b3cbdbbcb7dfbe88c49697267e11db09", size = 9846, upload-time = "2026-07-16T15:25:19.705Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-mysqlclient"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/c4/1659aefdbe60ce73bffa55fa2d320532faad2ad33544c17a469a3dc79724/opentelemetry_instrumentation_mysqlclient-0.65b0.tar.gz", hash = "sha256:ee7184a3dc2107d35725e16c3f2c06de8f84bc8037718a6801c2397ead672973", size = 9781, upload-time = "2026-07-16T15:26:11.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/b0/773fd7f88624f48d457803920ca3e0cebf4472f3d114ea513b3a9539e7ca/opentelemetry_instrumentation_mysqlclient-0.65b0-py3-none-any.whl", hash = "sha256:d48a3665cacafbe651156667832b1e7b7ccac4f78f15b36f3014ef16ce4f2b91", size = 9736, upload-time = "2026-07-16T15:25:20.591Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-openai-agents-v2"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/15/b6a303454d2800d772cdebc490c1d598d06d0e541619db80195eb9ea85c6/opentelemetry_instrumentation_openai_agents_v2-0.1.0.tar.gz", hash = "sha256:1033f4b261ce07f65d197ac0e9c499302c805eae987a6cc4e7f99bb279363477", size = 22423, upload-time = "2025-10-15T19:04:59.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/0a/b6f47734e1d7f936cbc52ef8e673d3e08d9c3c8a13d9549c03f978758076/opentelemetry_instrumentation_openai_agents_v2-0.1.0-py3-none-any.whl", hash = "sha256:e4e3dfba32bd6eeee0624eca9be54341ab7cc4f7a3bb895354f2f9d6f7afe2f3", size = 25002, upload-time = "2025-10-15T19:04:58.562Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pika"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/7b/257984119da6b408c8415443327d8c8f05c0d5cb44f323ad068cb35eaa47/opentelemetry_instrumentation_pika-0.65b0.tar.gz", hash = "sha256:2d902e6e8733547d9c2a303455f3a253bcc5213506e56568fb0468e76dd03080", size = 14211, upload-time = "2026-07-16T15:26:12.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/41/acaa5abebd85f976f4b69258748c29b5bca98b300362f726792001b7d5c7/opentelemetry_instrumentation_pika-0.65b0-py3-none-any.whl", hash = "sha256:24f4666cbf7d6a659d1eeb05199a81a3961d95a47b9194144cfdf1d9b8e34838", size = 12682, upload-time = "2026-07-16T15:25:21.482Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg2"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/98/9593c81b7bec220b9de8e72802eabcc9e0623b34edbb331c8a5d9d7a8955/opentelemetry_instrumentation_psycopg2-0.65b0.tar.gz", hash = "sha256:4eba60bef5f25d163a098109c2960773f3753e0b7e39824b9f398ba49ffab783", size = 12065, upload-time = "2026-07-16T15:26:13.788Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/40/51f948b7953aefc506d866a862de90c960e6d5e2117850e2900c9220e3ef/opentelemetry_instrumentation_psycopg2-0.65b0-py3-none-any.whl", hash = "sha256:91880c7dbcd2b9cc62694894abed7f69fdad4bae472d1d3664a82650294f9836", size = 10787, upload-time = "2026-07-16T15:25:23.367Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pymemcache"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/b2/3091bb0ec8fe8be6f9395dfbd694031eac7c569ebd69f1e1f11ffca984ef/opentelemetry_instrumentation_pymemcache-0.65b0.tar.gz", hash = "sha256:b147ef3cbbcff6f330798854ab3e912da9f2e90d5c13cedeecf641d5874663ec", size = 11132, upload-time = "2026-07-16T15:26:14.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/edb3220882d6c3ef48bd63e8726cc82a348b0db4708f6a5a71720f6cbe03/opentelemetry_instrumentation_pymemcache-0.65b0-py3-none-any.whl", hash = "sha256:1c226e6d41f05caf5b276c02644c6547c86490d3b3420a6e64a1d332d45e3809", size = 9032, upload-time = "2026-07-16T15:25:24.354Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pymongo"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/06/73315a138049c5894bafa18569fd5c9949cf4c9a972ed7151d16900af49d/opentelemetry_instrumentation_pymongo-0.65b0.tar.gz", hash = "sha256:8a43f368f7dd101622d2b5929b0c12c4099a0c4a072284b86d18b75dfee10007", size = 11312, upload-time = "2026-07-16T15:26:14.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/46/a4c918ac6b778adf967fd8b65b714a565d76c61a31be3e86a18fffd69b2c/opentelemetry_instrumentation_pymongo-0.65b0-py3-none-any.whl", hash = "sha256:c714006d3075b0d9cd1a5e8091dce139cb58ee1fbc5a23d5c8f8576e9ae14e53", size = 10638, upload-time = "2026-07-16T15:25:25.302Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pymysql"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/e5/0479f2da3b87b912b2d52b666cd6fd70dfecbd8abdde303dc411bbb6b1a6/opentelemetry_instrumentation_pymysql-0.65b0.tar.gz", hash = "sha256:8262bded9d678d05e585ab11a62867c6fdf6599a9c2bec2a2387ec6c5e749e14", size = 9732, upload-time = "2026-07-16T15:26:16.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/16037d165939e0cb9a839e8bc077feb4036a89419abcaa5348798110fa53/opentelemetry_instrumentation_pymysql-0.65b0-py3-none-any.whl", hash = "sha256:a94a756090ae9b422c5fbe425e8a0884e8fda5633c226a04532d603bdf8fbec1", size = 9720, upload-time = "2026-07-16T15:25:27.265Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pyramid"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/03/9fac83b165494441d9df9da1bb2a0a980b987e4f1af2e70c200c42007d99/opentelemetry_instrumentation_pyramid-0.65b0.tar.gz", hash = "sha256:cb9f86cf25814700ad3246b81cf2f79a05fc011921896970f650ec5dbabd4a84", size = 16999, upload-time = "2026-07-16T15:26:16.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/63/efeab78ae11f55831d89d4acde3ecfa1b63eb3c2dda7e4394b5072570444/opentelemetry_instrumentation_pyramid-0.65b0-py3-none-any.whl", hash = "sha256:12835b3e572d46e1545a93fcad6e17eed8d6913ad75958ac10d9c62c19a84158", size = 13654, upload-time = "2026-07-16T15:25:28.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/e5/b369897a9ff902eb028f1f999c9f9a4602f0b30fe1e97298d2c15fe5b8b0/opentelemetry_instrumentation_redis-0.65b0.tar.gz", hash = "sha256:f16409f189092984ff922f26939e7be79509365f5c9d202308c13fddf1368147", size = 17218, upload-time = "2026-07-16T15:26:17.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/5b874bf8824e7cb995b22e1e61e1b5bc42810023d81612c44edbfd2c48a3/opentelemetry_instrumentation_redis-0.65b0-py3-none-any.whl", hash = "sha256:7d135f61db9d72416e1f382012fbc13de6f5e726491bebd0344a9c42a60e6769", size = 14658, upload-time = "2026-07-16T15:25:29.146Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-remoulade"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b9/bca38817abbc4e6103dc47bbb9f58bf974d70a50b953dbcdeed38c732c79/opentelemetry_instrumentation_remoulade-0.65b0.tar.gz", hash = "sha256:c12458db8b0ce1ebcf9e4e347cfd659c5af4e5beab835861d717dc98463ca49d", size = 8081, upload-time = "2026-07-16T15:26:17.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/a7/7091753157a359ae3e817ddc4b33960642762dfdad54f4f13470736cafc2/opentelemetry_instrumentation_remoulade-0.65b0-py3-none-any.whl", hash = "sha256:632170c23af708b9ea59fdbd0ae1618d729460a7227d94cc4717254c802b9fcd", size = 8997, upload-time = "2026-07-16T15:25:30.124Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/84/f46bf7976a81827419b085c9ed14562410c7599e07509786e9f6eb3c5438/opentelemetry_instrumentation_requests-0.65b0.tar.gz", hash = "sha256:1d601548f89236d5ab373c7208a2e1e162a8d6462b5b972f9ad8fb0ed82d7438", size = 18107, upload-time = "2026-07-16T15:26:18.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/45/6201afe846263d775cd4fc8d6a87dc8c15eb7921cdade4dca1e1227b04b6/opentelemetry_instrumentation_requests-0.65b0-py3-none-any.whl", hash = "sha256:91688ec0d4d1fed75ea8d026ef2c66274ed9868c22b6be211ef85d832d16f957", size = 13386, upload-time = "2026-07-16T15:25:31.093Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-sqlalchemy"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/9d/72af21527ce6f286ac78dc2c75ce44b76cc45343a28f0bcbb13f213421fc/opentelemetry_instrumentation_sqlalchemy-0.65b0.tar.gz", hash = "sha256:8ec2e79f1e00808c5dc639ab5b2cfcdf9dcdef55efd6442c6019707fe2894028", size = 18007, upload-time = "2026-07-16T15:26:19.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/94/3eb3195a60b894cc1852a5657a2b64764a998085c50d7fb3452148af8f18/opentelemetry_instrumentation_sqlalchemy-0.65b0-py3-none-any.whl", hash = "sha256:4d8a2e5afc7b505a48d05cb1fb6db5f8b31681814c1d7767bd6d4b5bdd3a3047", size = 14410, upload-time = "2026-07-16T15:25:32.04Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-sqlite3"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/93/3716b653b0dd8f7122afe5228d77604309478378afbd4f92699a68f686e8/opentelemetry_instrumentation_sqlite3-0.65b0.tar.gz", hash = "sha256:f11fb91d159724037cadf970d5b612da720b38bd67d1c25d48c5ae09116eacc6", size = 8419, upload-time = "2026-07-16T15:26:19.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/c9/636d87853b46228e1714063fb0c4f4fc69d85f9e06febce65620d60d3505/opentelemetry_instrumentation_sqlite3-0.65b0-py3-none-any.whl", hash = "sha256:d9ca2e3a5ab0e9f8ee1c55f4713e1b1bb626dfd57e57950e228cbd0aa9381ae1", size = 8525, upload-time = "2026-07-16T15:25:33.01Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-starlette"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/87/60df780aa0c80f7bbd5707754e9f240174b56ea115e43508da5939472336/opentelemetry_instrumentation_starlette-0.65b0.tar.gz", hash = "sha256:2ec3269c684617bdaaba06ec90fc3f3bfd5e90f51dae3f62f014fd15e488a81a", size = 14382, upload-time = "2026-07-16T15:26:20.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/31/3fdc98cc902162511a3e48f358477c4cb8f58f63deefe00ce1b3e78788f9/opentelemetry_instrumentation_starlette-0.65b0-py3-none-any.whl", hash = "sha256:365539afdc4d379b54a8be9aad07989e686dadaf9c0e356400d584991a0e4c5c", size = 11106, upload-time = "2026-07-16T15:25:33.957Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-system-metrics"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/8f/d4be5113ec220a49e7c5c37b450cdc4008709500526a43e2c0d2826fe3f0/opentelemetry_instrumentation_system_metrics-0.65b0.tar.gz", hash = "sha256:c8b82821ccc95c5f2c516bb72356f75673ced51364eed583a14bf3b85fa6a0c7", size = 17414, upload-time = "2026-07-16T15:26:21.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/9e/90c142f60d91c80b725b5830cf02d1ab91344611e857427fec048695579f/opentelemetry_instrumentation_system_metrics-0.65b0-py3-none-any.whl", hash = "sha256:48ef6c8f5924f391d07c073a40c7018874046703477e538fbe64ff37af196cf0", size = 14005, upload-time = "2026-07-16T15:25:36.329Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-threading"
-version = "0.62b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/00/8e391f8ad0f34ffa94c45bceda5e6d2aeb540a995befa3cb8aaeb54db25a/opentelemetry_instrumentation_threading-0.62b0.tar.gz", hash = "sha256:a03e96976acbce6c2049cd1c0490190e42bcc7ce93cde14761626bc3e9bba831", size = 9182, upload-time = "2026-04-09T14:40:52.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/62/626ee68e07e38f792e741db351087fb7c40888e861097029faae595d91fe/opentelemetry_instrumentation_threading-0.65b0.tar.gz", hash = "sha256:aefd23eb16c5e7a7c6c6eacdcb6c6f269ed8ed3a1b458bf5dd555b878bf58937", size = 9080, upload-time = "2026-07-16T15:26:22.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/d1/08d6d42b0a36c0d16a51604097768827445241768f00b4f6823beabd1b33/opentelemetry_instrumentation_threading-0.62b0-py3-none-any.whl", hash = "sha256:5e3958c478f4c089d9a36afe857e89a5df8eedb11ba0ae11d2f316def968e596", size = 9337, upload-time = "2026-04-09T14:40:08.205Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8d/387b69572f81f9b78c2b0d3a98acfcd43c5ef4ce16ea903f1a90c1dd1d04/opentelemetry_instrumentation_threading-0.65b0-py3-none-any.whl", hash = "sha256:d8a1a1f35418a32769d469ef2d7e8401935e097a8553abcfba833da9c74736ce", size = 8484, upload-time = "2026-07-16T15:25:37.422Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-tornado"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/fe/b87880ba9cb40f5b9cf2aa4bb836b2c2627590aac62e295753515c53d7e5/opentelemetry_instrumentation_tornado-0.65b0.tar.gz", hash = "sha256:3178e163086eeafd534b87c7a932a797aefc21b17254463ecdd8b827b78826f5", size = 24185, upload-time = "2026-07-16T15:26:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/3e/2d9a785658fd7675af7bb9572fa729ae13ded2f64bc2821c2b2af6889d03/opentelemetry_instrumentation_tornado-0.65b0-py3-none-any.whl", hash = "sha256:41bf6f48e48f6aa0191d071e86441c17f6a7205a56c0771ad45c3482391dc4e8", size = 17959, upload-time = "2026-07-16T15:25:38.357Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-tortoiseorm"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/12/9e06ccac038be2c0934449d49e76a5b609df6eeca006c0002ab9ead669b2/opentelemetry_instrumentation_tortoiseorm-0.65b0.tar.gz", hash = "sha256:1bb16665189b46861eaa547f018c412219298e710da0d035ea54a19c7fea7615", size = 9466, upload-time = "2026-07-16T15:26:23.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/70/a8f21de41f0224e590fa897f8c76b1122581e77ec21cad228b987a136624/opentelemetry_instrumentation_tortoiseorm-0.65b0-py3-none-any.whl", hash = "sha256:f36f34e378aaf53d888a6388e3e7f103a9a9185ef1a905011cad698945a219bb", size = 9480, upload-time = "2026-07-16T15:25:39.683Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/d4/8379f5b5967eee7c94ab9125991e76d16869d788afdddce093be1997db23/opentelemetry_instrumentation_urllib-0.65b0.tar.gz", hash = "sha256:8e7d1ada475296136815763bdabe683460969d09d93752c4f11ef0175598151c", size = 16666, upload-time = "2026-07-16T15:26:24.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/37/9b8a61d5493865319a27a0de06eaa2f3da4f8df24cc2903b32eb901db227/opentelemetry_instrumentation_urllib-0.65b0-py3-none-any.whl", hash = "sha256:df1b79e50d6d59f4248acc659bbed0ada8ccc8a028ee915d3fdeaf9140672b87", size = 13137, upload-time = "2026-07-16T15:25:40.931Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib3"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/62/b0bb0b4952720640e9627eeaa185d6948ea9d1528e16f6828372b2d4a8ca/opentelemetry_instrumentation_urllib3-0.65b0.tar.gz", hash = "sha256:6345f5c38785801e1a112895967eabec4e1076e30ecc7e9bd2af87dffc541bf9", size = 18949, upload-time = "2026-07-16T15:26:24.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/c5/e8aed121604c378b6a196568cef166a976a274231cee2ffc7a3b5f29f14e/opentelemetry_instrumentation_urllib3-0.65b0-py3-none-any.whl", hash = "sha256:696f3a59f153f23771dfadc826b03c548a2a308984987da9a094aeae23d609ca", size = 13516, upload-time = "2026-07-16T15:25:41.924Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/f7/bfe74ba3baea8c61290c3ab1d692f841b695ccb6e40faf5ad55fd5412cf2/opentelemetry_instrumentation_wsgi-0.65b0.tar.gz", hash = "sha256:d4a62ae98667ddfe04fe538c3c54abad538feb8c9c7a407ba19f016e1ce4a89a", size = 19666, upload-time = "2026-07-16T15:26:25.485Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/af/9dfe500d3b816e4bd65f467c6275688744ed8186894c73223f7e3d6d9745/opentelemetry_instrumentation_wsgi-0.65b0-py3-none-any.whl", hash = "sha256:af23e6686c7cd2abcd7d14ac03fb7e3b438273eb2d54a8f8dc401dc71bc52a9f", size = 13787, upload-time = "2026-07-16T15:25:42.876Z" },
+]
+
+[[package]]
+name = "opentelemetry-processor-baggage"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/b3/870c377673c44dcf716e78006ec8bbdb5e14ca9b1c2290bb6711534a3828/opentelemetry_processor_baggage-0.65b0.tar.gz", hash = "sha256:a1007c778e2737e28bae4b1e8b5d135907d03182ad40dfc1558416548209e491", size = 8834, upload-time = "2026-07-16T15:26:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0c/6bd5aa64157053acb5c0c908a79e09ece449371b6d70d28eb45753d1e49d/opentelemetry_processor_baggage-0.65b0-py3-none-any.whl", hash = "sha256:eef686d03220c6969f56c02e7763f3200392fb6af4b797732e3e80bbd024ba66", size = 9485, upload-time = "2026-07-16T15:25:43.851Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-aws-xray"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/31/40004e9e55b1e5694ef3a7526f0b7637df44196fc68a8b7d248a3684680f/opentelemetry_propagator_aws_xray-1.0.2.tar.gz", hash = "sha256:6b2cee5479d2ef0172307b66ed2ed151f598a0fd29b3c01133ac87ca06326260", size = 10994, upload-time = "2024-08-05T17:45:57.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/89/849a0847871fd9745315896ad9e23d6479db84d90b8b36c4c26dc46e92b8/opentelemetry_propagator_aws_xray-1.0.2-py3-none-any.whl", hash = "sha256:1c99181ee228e99bddb638a0c911a297fa21f1c3a0af951f841e79919b5f1934", size = 10856, upload-time = "2024-08-05T17:45:56.492Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-b3"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/1c/c4cc2240caced529f8b40e72e59459ea6246e730c008c7bbb439b4fdefe4/opentelemetry_propagator_b3-1.44.0.tar.gz", hash = "sha256:93c94885fd75429121bb3d5c496c9bbd1b36199e194a0a6876867d7bf3999300", size = 9514, upload-time = "2026-07-16T15:25:43.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/2c/aa831025e6a9f9d7c459c9cbf0ef990137edd35669249b1571447179d2b1/opentelemetry_propagator_b3-1.44.0-py3-none-any.whl", hash = "sha256:18649bc511c550d2744da1d887bdce0d1a6bbe6a052f8721f3adac5d9f51b20e", size = 8352, upload-time = "2026-07-16T15:25:26.612Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-jaeger"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/019d7fe417689fe5c60f868a73607ed2d9bd3fa5826695f49d402aec1fe4/opentelemetry_propagator_jaeger-1.44.0.tar.gz", hash = "sha256:0fba4127600f5eca1d5ce31f208f4e13bdd80050a236f3953f6f244c197178b7", size = 8462, upload-time = "2026-07-16T15:25:44.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/81/17be11764d562eddd6543b80db66929927b3e118a37e4c3cf133b5bb7f60/opentelemetry_propagator_jaeger-1.44.0-py3-none-any.whl", hash = "sha256:f0367847159e4c7efc19b6490d602f335ecbf568fda8eb4c8fa990ed5eed788d", size = 8186, upload-time = "2026-07-16T15:25:27.586Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-ot-trace"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b7/97c22b541acb30691b07c50311e106bedae6c46343f52957c43980c2f0b1/opentelemetry_propagator_ot_trace-0.65b0.tar.gz", hash = "sha256:9362d01ef33cab108f7debd91f5f1293192144b1e3549ddd38b28bef3fe797df", size = 4772, upload-time = "2026-07-16T15:26:26.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/804a3dc2ee79e3718c71536a4539f0667b42e8c98dda9a134bca177b6402/opentelemetry_propagator_ot_trace-0.65b0-py3-none-any.whl", hash = "sha256:582cbc877d7ccebc43f595790fcc29cdc9265ddeee30a7494ebf40bf923300e3", size = 4198, upload-time = "2026-07-16T15:25:44.703Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk-extension-aws"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/b3/825c93fe4c238845f1356297abea33d03b2adaafb5ae98fc257b394de124/opentelemetry_sdk_extension_aws-2.1.0.tar.gz", hash = "sha256:ff68ddecc1910f62c019d22ec0f7461713ead7f662d6a2304d4089c1a0b20416", size = 16334, upload-time = "2024-12-24T15:01:57.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/61/47a6a43b7935d54b5734fbf3fb0357dd5a7d0dfaa9677b7318518fe8d507/opentelemetry_sdk_extension_aws-2.1.0-py3-none-any.whl", hash = "sha256:c7cf6efc275d2c24108a468d954287ce5aab9733bac816a080cfb3117374e63a", size = 18776, upload-time = "2024-12-24T15:01:56.053Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.62b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -1645,6 +2632,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/22/41fb05f1dc5fda2c468e05a41814c20859016c85117b66c8a257cae814f6/opentelemetry_semantic_conventions_ai-0.5.1-py3-none-any.whl", hash = "sha256:25aeb22bd261543b4898a73824026d96770e5351209c7d07a0b1314762b1f6e4", size = 11250, upload-time = "2026-03-26T14:20:37.108Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-genai"
+version = "1.0b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/1f/c667b221dcb84a8fcb5e3324753e1dfb295938cb71e10c979588605bd66d/opentelemetry_util_genai-1.0b0.tar.gz", hash = "sha256:d5f2ab950d08b965f4f090c415eca6f0b02a87a0f07814534c38ff9bdb407c11", size = 53584, upload-time = "2026-07-09T21:36:24.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/47/a512818b21940a99124432c2ba44c77b20505ef2b716b7bb426a9bdec7da/opentelemetry_util_genai-1.0b0-py3-none-any.whl", hash = "sha256:e6d27cb630bd99a265474a7bf3a91942ef701217906fc3b72aaf6a29526c0cc7", size = 42266, upload-time = "2026-07-09T21:36:23.539Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]
@@ -2044,6 +3055,49 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2296,46 +3350,66 @@ wheels = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.2"
+version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
-    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
-    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
-    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
-    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -2622,6 +3696,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/06/de8d8ab14a2e92dcb0fa82db0a4cb102418a1eda139412bbe5b5725e28df/strands_agents-1.38.0-py3-none-any.whl", hash = "sha256:9dc3de17e25d70e367d37f9151f2a4c7b3ac8fc9f6237e9e1f34d00bfbfd001b", size = 422354, upload-time = "2026-04-30T16:57:41.094Z" },
 ]
 
+[package.optional-dependencies]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+
 [[package]]
 name = "strands-agents-evals"
 version = "0.1.16"
@@ -2763,11 +3842,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -3133,15 +4212,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add four native Strands AgentSkills workflows to the Market Trends use case
- evaluate skill selection and instruction following with AWS managed evaluators
- demonstrate EvaluationClient and BatchEvaluationRunner using only the unified runtime telemetry log group
- add isolated deployment instructions and a Mermaid evaluation-flow diagram

## Validation
- uv sync --locked
- Ruff check and format check
- mypy and Python compileall
- deployed the current runtime package to AgentCore Runtime in us-west-2
- EvaluationClient: all four selections Yes/1.0; instruction following 1.0, 0.75, 1.0, 0.75; no-skill control returned no results
- BatchEvaluationRunner: COMPLETED, 4/4 sessions, 0 failures; selection average 1.0, instruction-following average 0.88