### PR TITLE
Increase skills evaluation telemetry wait

### DIFF
--- a/01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/README.md
+++ b/01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/README.md
@@ -119,7 +119,7 @@ Run one PTO prompt instead of the three built-in scenarios:
 python evaluate.py \
   --prompt "I am EMP-001. Can I take September 14 through September 16, 2026 off? Submit it using the pto-planning skill." \
   --expected-skill pto-planning \
-  --wait 150
+  --wait 180
 ```
 
 The script prints the agent response, waits for its telemetry, then runs both built-in evaluators. Change only the quoted prompt to try other PTO wording. Use `--expected-skill benefits-advisor` for a benefits prompt or `--expected-skill none` when the prompt should not load a skill.
@@ -157,7 +157,7 @@ Skills  : benefits-advisor, pto-planning
   [no-skill-control] session=skill-eval-<uuid>
   Response: Here is your pay stub for January 2026 ...
 
-[2/4] Waiting 150s for AgentCore telemetry ingestion ...
+[2/4] Waiting 180s for AgentCore telemetry ingestion ...
 
 [3/4] EvaluationClient — per-session on-demand evaluation ...
 

--- a/01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/evaluate.py
+++ b/01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/evaluate.py
@@ -70,7 +70,7 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the built-in AgentCore skill evaluators")
     parser.add_argument("--region", default=None, help="AWS region (defaults to the deployment config)")
     parser.add_argument("--config", default=str(_DEFAULT_CONFIG), help="Path to the skill-enabled agent config")
-    parser.add_argument("--wait", type=int, default=150, help="Seconds to wait for telemetry (default: 150)")
+    parser.add_argument("--wait", type=int, default=180, help="Seconds to wait for telemetry (default: 180)")
     parser.add_argument("--prompt", default=None, help="Run one custom prompt instead of the built-in scenarios")
     parser.add_argument(
         "--expected-skill",


### PR DESCRIPTION
## Summary
- increase the Agent Skills evaluation telemetry wait default from 150 to 180 seconds
- apply the same value to on-demand evaluation and BatchEvaluationRunner ingestion delay
- update the README command and expected output

This adds margin for asynchronous CloudWatch ingestion and aligns with the 180-second HR and Market Trends evaluation conventions.

## Validation
- `python3 -m py_compile 01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/evaluate.py`
- `python3 01-features/06-observe-evaluate-optimize-your-agent/02-evaluate/skills-evaluation/evaluate.py --help`
- `git diff upstream/main...HEAD --check`