### PR TITLE
docs(payments): document Coinbase Quick Create CLI flow and marketplace subscription

### DIFF
--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
@@ -180,7 +180,8 @@ agentcore status --type payment
 
 > **Using Coinbase Quick create?** `agentcore deploy` creates the connector in `PENDING_AUTHENTICATION`
 > and prints an `authorizationUrl`. Open it, sign in to Coinbase, and grant access — the connector then
-> moves to `READY`. Re-run `agentcore status --type payment` and confirm `READY` before continuing to Step 3.
+> moves to `READY`. The link is single-use and short-lived; if it expires before you finish, re-run
+> `agentcore deploy` to issue a fresh one. Re-run `agentcore status --type payment` and confirm `READY` before continuing to Step 3.
 > Quick create requires an active [Coinbase Wallets for AgentCore Payments Marketplace subscription](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-marketplace-subscription.html);
 > without it, deploy fails with `SubscriptionRequiredException` (HTTP 403) and the error message includes the listing URL to subscribe.
 

--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/README.md
@@ -108,6 +108,10 @@ python providers/coinbase_cdp_account_setup.py     # Coinbase CDP
 python providers/stripe_privy_account_setup.py     # Stripe (Privy)
 ```
 
+> **Using Coinbase Quick create?** You can skip `coinbase_cdp_account_setup.py` — Quick create provisions
+> the CDP API key and Wallet secret for you in Step 2, so there are no keys to generate or paste. Still set
+> the `.env` values below.
+
 Then set `AWS_REGION`, `CREDENTIAL_PROVIDER_TYPE` (`CoinbaseCDP` or `StripePrivy`), `USER_ID`,
 `LINKED_EMAIL` (a real inbox — used for the wallet and provider OTP), and `NETWORK`
 (`ETHEREUM` or `SOLANA`) in `../.env`.
@@ -130,7 +134,16 @@ agentcore add payment-manager --name MyPaymentManager --auto-payment true --defa
 Add a payment connector for the provider you chose in Step 1 — run **one** of these:
 
 ```bash
-# Coinbase CDP:
+# Coinbase CDP — Quick create (recommended): no keys, you authorize through Coinbase at deploy time
+agentcore add payment-connector \
+  --manager MyPaymentManager \
+  --name MyCoinbaseConnector \
+  --provider CoinbaseCDP \
+  --provision-mode QUICK_CREATE
+```
+
+```bash
+# Coinbase CDP — existing credentials: paste the keys captured in Step 1
 agentcore add payment-connector \
   --manager MyPaymentManager \
   --name MyCoinbaseConnector \
@@ -164,6 +177,12 @@ agentcore deploy -y
 # 4. Read back the created resource ARNs/IDs
 agentcore status --type payment
 ```
+
+> **Using Coinbase Quick create?** `agentcore deploy` creates the connector in `PENDING_AUTHENTICATION`
+> and prints an `authorizationUrl`. Open it, sign in to Coinbase, and grant access — the connector then
+> moves to `READY`. Re-run `agentcore status --type payment` and confirm `READY` before continuing to Step 3.
+> Quick create requires an active [Coinbase Wallets for AgentCore Payments Marketplace subscription](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-marketplace-subscription.html);
+> without it, deploy fails with `SubscriptionRequiredException` (HTTP 403) and the error message includes the listing URL to subscribe.
 
 From the `agentcore status --type payment` output, copy the **Payment Manager ARN** and **Payment
 Connector ID** and export them (you'll pass them to the commands in Step 3):

--- a/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/providers/README.md
+++ b/01-features/08-agents-that-transact/00-getting-started/00-setup-agentcore-payments/providers/README.md
@@ -30,17 +30,27 @@ See the detailed instructions to be followed [here](https://docs.aws.amazon.com/
 
 ## Important Note  
 
-To create a Coinbase payment connector, your account must have an active AWS Marketplace subscription to the Coinbase Wallets for AgentCore Payments listing. With this subscription, your Coinbase wallet usage charges are consolidated into your monthly AWS bill based on Coinbase’s pricing on the Coinbase website. There are no additional charges or obligations for the subscription. If the subscription is missing, CreatePaymentConnector fails with a SubscriptionRequiredException (HTTP 403). This requirement applies only to Coinbase; other providers, such as Stripe (Privy), are not affected. For more information, see Subscribe to Coinbase Wallets for AgentCore Payments in AWS Marketplace.
+To create a Coinbase payment connector, your account must have an active AWS Marketplace subscription to the Coinbase Wallets for AgentCore Payments listing. This is a one-time subscription per account, and the subscribing identity needs the `AWSMarketplaceManageSubscriptions` permission. With this subscription, your Coinbase wallet usage charges are consolidated into your monthly AWS bill based on Coinbase’s pricing on the Coinbase website. There are no additional charges or obligations for the subscription. The requirement applies to Coinbase whether you use Quick create or your own credentials; other providers, such as Stripe (Privy), are not affected. If the subscription is missing, `CreatePaymentConnector` fails with a `SubscriptionRequiredException` (HTTP 403) whose message includes the Marketplace listing URL to subscribe. For more information, see [Subscribe to Coinbase Wallets for AgentCore Payments in AWS Marketplace](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-marketplace-subscription.html).
 
 ## Coinbase CDP Setup Summary
 
 
 If you choose Coinbase, choose how to provide the credentials for the payment auth:
 
-Quick create configurations - recommended — Quick create allows you to link to your Coinbase CDP account and let AgentCore payments create the credentials for you without leaving the AgentCore console. It opens a window to sign up or sign in to your Coinbase CDP account. The service then provisions the Coinbase CDP API key and Wallet secret and stores them as a payment auth on your behalf. You do not generate or paste any keys.
-Quick create does not support linking to an existing project with a Wallet Secret.
+Quick create configurations - recommended — Quick create links your Coinbase CDP account and lets AgentCore payments provision the API key and Wallet secret for you, so you never generate or paste any keys. It is available from the AgentCore console and from the AgentCore CLI:
 
-Watch the detailed video for the steps here in this blog[https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-agentcore-payments-is-now-generally-available-enabling-agents-to-transact-safely-and-autonomously-at-scale/] 
+```bash
+# No credential flags — you authorize through Coinbase at deploy time
+agentcore add payment-connector \
+  --manager MyPaymentManager \
+  --name MyCoinbaseConnector \
+  --provider CoinbaseCDP \
+  --provision-mode QUICK_CREATE
+```
+
+On `agentcore deploy`, the connector is created in `PENDING_AUTHENTICATION` and the deploy prints an `authorizationUrl`. Open it, sign in to Coinbase, and grant access — the connector then moves to `READY` with a service-provisioned credential provider. Quick create does not support linking to an existing project with a Wallet Secret. See Step 2 of the [Tutorial 00 setup guide](../README.md) for the full command sequence.
+
+Watch the detailed walkthrough in the [GA announcement blog](https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-agentcore-payments-is-now-generally-available-enabling-agents-to-transact-safely-and-autonomously-at-scale/).
 
 Use existing configurations — Provide Coinbase CDP credentials that you generated yourself in the Coinbase Developer Platform.
 


### PR DESCRIPTION
## What
Documents the Coinbase Quick Create path in the Tutorial 00 setup using the AgentCore CLI, and completes the AWS Marketplace subscription guidance in the providers README.

## Changes
`00-getting-started/00-setup-agentcore-payments/providers/README.md`
- Link the "Subscribe to Coinbase Wallets for AgentCore Payments" reference to the public documentation.
- State that the Marketplace subscription is a one-time, per-account requirement (needs `AWSMarketplaceManageSubscriptions`) and applies to Coinbase for both Quick Create and self-managed credentials.
- Add the `agentcore add payment-connector --provision-mode QUICK_CREATE` command and the deploy-time authorization flow (`PENDING_AUTHENTICATION` → `authorizationUrl` → consent → `READY`).
- Fix the malformed blog link.

`00-getting-started/00-setup-agentcore-payments/README.md`
- Step 1: note that Quick Create users skip the Coinbase key-capture script.
- Step 2: add the Coinbase Quick Create connector command alongside the credential-based command.
- Add the deploy-time authorization note (including that the authorization link is single-use) and the Marketplace subscription requirement.

## Testing
Verified with AgentCore CLI 0.28.0 in a supported region:
- With the Coinbase Marketplace subscription active: `agentcore add payment-connector --provision-mode QUICK_CREATE` → `agentcore validate` → `agentcore deploy` creates the connector in `PENDING_AUTHENTICATION` and returns an `authorizationUrl`; after Coinbase consent it reaches `READY` with a service-provisioned credential provider.
- Without the subscription: `CreatePaymentConnector` returns `SubscriptionRequiredException` (HTTP 403) with the Marketplace listing URL, matching the documented behavior.
