### PR TITLE
docs/fix: correct docstring model defaults + fix Auth0 client arity crash in 01-features

### DIFF
--- a/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
+++ b/01-features/01-harness/02-use-cases/04-weather-agent/weather_agent.py
@@ -11,9 +11,9 @@ assistant that provides current conditions, UV index, wind, and sun/moon data:
   Part 5: Evaluations — on-demand scoring with built-in + custom evaluators
   Part 6: Cleanup
 
-The Gateway proxies to Open-Meteo (free weather API, no key required) via
-an MCP target, giving the agent access to real-time weather data with
-centralized auth and observability on the tool traffic.
+The Gateway proxies to Exa's hosted MCP server (https://mcp.exa.ai/mcp) via
+an MCP target, giving the agent web-search access to real-time weather data
+with centralized auth and observability on the tool traffic.
 
 Usage:
     python weather_agent.py
@@ -45,13 +45,11 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from utils.client import get_agentcore_client, get_agentcore_control_client
 from utils.iam import create_harness_role, delete_harness_role
-from utils.client import get_agentcore_control_client, get_agentcore_client
 
 # -- CLI -----------------------------------------------------------------------
-parser = argparse.ArgumentParser(
-    description="Weather Agent — Harness + Evals + Gateway + Observability"
-)
+parser = argparse.ArgumentParser(description="Weather Agent — Harness + Evals + Gateway + Observability")
 parser.add_argument("--skip-evals", action="store_true", help="Skip evaluation step")
 parser.add_argument("--skip-guardrail", action="store_true", help="Skip guardrail creation")
 parser.add_argument("--skip-cleanup", action="store_true", help="Keep resources after demo")
@@ -88,12 +86,12 @@ def poll_status(get_fn, extract_fn, target="READY", timeout=120, interval=5):
 
 def stream_response(harness_arn, session_id, message, tools=None):
     """Invoke harness and stream the response. Returns accumulated text."""
-    kwargs = dict(
-        harnessArn=harness_arn,
-        runtimeSessionId=session_id,
-        messages=[{"role": "user", "content": [{"text": message}]}],
-        model={"bedrockModelConfig": {"modelId": MODEL_ID}},
-    )
+    kwargs = {
+        "harnessArn": harness_arn,
+        "runtimeSessionId": session_id,
+        "messages": [{"role": "user", "content": [{"text": message}]}],
+        "model": {"bedrockModelConfig": {"modelId": MODEL_ID}},
+    }
     if tools:
         kwargs["tools"] = tools
 
@@ -169,9 +167,7 @@ try:
     print(f"  Target ID: {target_id}")
 
     poll_status(
-        lambda: gw_control.get_gateway_target(
-            gatewayIdentifier=gateway_id, targetId=target_id
-        ),
+        lambda: gw_control.get_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id),
         lambda r: r["status"],
     )
     print("  Gateway ready with Exa MCP target")
@@ -261,8 +257,7 @@ try:
     turn2_response = stream_response(
         harness_arn,
         session_id,
-        "What about the wind conditions in Paris right now? "
-        "Give me wind speed, direction, and gust information.",
+        "What about the wind conditions in Paris right now? Give me wind speed, direction, and gust information.",
         tools=tools,
     )
 
@@ -306,10 +301,12 @@ try:
         rules = xray.get_indexing_rules()
         sampling = rules["IndexingRules"][0]["Rule"]["Probabilistic"]["DesiredSamplingPercentage"]
         print(f"  Transaction Search sampling: {sampling}%")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Transaction Search check: {e}")
         print("  Enable Transaction Search for full trace visibility:")
-        print("  https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search-getting-started.html")
+        print(
+            "  https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search-getting-started.html"
+        )
 
     # Query recent traces for our harness
     print(f"\n  Querying traces for harness: {harness_id[:20]}...")
@@ -318,6 +315,7 @@ try:
         start_time = end_time - 300  # Last 5 minutes
 
         from datetime import datetime, timezone
+
         trace_resp = xray.get_trace_summaries(
             StartTime=datetime.fromtimestamp(start_time, tz=timezone.utc),
             EndTime=datetime.fromtimestamp(end_time, tz=timezone.utc),
@@ -332,7 +330,7 @@ try:
                 has_error = trace.get("HasError", False)
                 status_icon = "x" if has_error else "ok"
                 print(f"    Trace {i}: duration={duration:.2f}s status={status_icon}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Trace query: {e}")
         print("  (Traces may take 1-2 minutes to appear after invocation)")
 
@@ -366,7 +364,9 @@ try:
             log_group = groups[0]["logGroupName"]
             log_group_basename = log_group.split("/")[-1]
             parts = log_group_basename.rsplit("-", 2)
-            service_name = f"{parts[0]}.DEFAULT" if len(parts) >= 3 else log_group_basename.replace("-DEFAULT", ".DEFAULT")
+            service_name = (
+                f"{parts[0]}.DEFAULT" if len(parts) >= 3 else log_group_basename.replace("-DEFAULT", ".DEFAULT")
+            )
 
             print(f"  Log group: {log_group}")
             print(f"  Service:   {service_name}")
@@ -426,7 +426,7 @@ try:
                 else:
                     print(f"  Evaluation ended with status: {status}")
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"  Evaluation error: {e}")
 
     # ==========================================================================
@@ -461,31 +461,29 @@ finally:
             try:
                 control.delete_harness(harnessId=harness_id)
                 print(f"  Deleted harness: {harness_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"  Warning (harness): {e}")
 
         if gateway_id and target_id:
             try:
-                gw_control.delete_gateway_target(
-                    gatewayIdentifier=gateway_id, targetId=target_id
-                )
+                gw_control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=target_id)
                 print(f"  Deleted target: {target_id}")
                 time.sleep(10)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"  Warning (target): {e}")
 
         if gateway_id:
             try:
                 gw_control.delete_gateway(gatewayIdentifier=gateway_id)
                 print(f"  Deleted gateway: {gateway_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"  Warning (gateway): {e}")
 
         if guardrail_id:
             try:
                 bedrock.delete_guardrail(guardrailIdentifier=guardrail_id)
                 print(f"  Deleted guardrail: {guardrail_id}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"  Warning (guardrail): {e}")
 
         # Delete batch evaluations created by this run
@@ -498,9 +496,9 @@ finally:
                     try:
                         client.delete_batch_evaluation(batchEvaluationId=ev_id)
                         print(f"  Deleted batch evaluation: {ev_name}")
-                    except Exception:
+                    except Exception:  # noqa: BLE001, S110
                         pass
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"  Warning (batch evals): {e}")
 
         delete_harness_role()

--- a/01-features/02-host-your-agent/01-runtime/03-advanced/10-mcp-dynamic-client-registration/mcp_auth0_client.py
+++ b/01-features/02-host-your-agent/01-runtime/03-advanced/10-mcp-dynamic-client-registration/mcp_auth0_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import httpx
 import os
 import threading
 import time
@@ -8,6 +7,8 @@ from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import httpx
 
 # Patch httpx at the request level to inject User-Agent header
 # This ensures ALL HTTP requests have the User-Agent header, including OAuth discovery calls
@@ -39,11 +40,11 @@ def _patched_httpx_request_init(self, method, url, *args, **kwargs):
 httpx.Request.__init__ = _patched_httpx_request_init
 
 # Now import MCP modules - they will use patched httpx
-from mcp.client.auth import OAuthClientProvider, TokenStorage  # noqa: E402
-from mcp.client.session import ClientSession  # noqa: E402
-from mcp.client.sse import sse_client  # noqa: E402
-from mcp.client.streamable_http import streamablehttp_client  # noqa: E402
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken  # noqa: E402
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
 
 class InMemoryTokenStorage(TokenStorage):
@@ -117,7 +118,6 @@ class CallbackHandler(BaseHTTPRequestHandler):
 
     def log_message(self, format, *args):
         """Suppress default logging."""
-        pass
 
 
 class CallbackServer:
@@ -162,9 +162,9 @@ class CallbackServer:
             if self.callback_data["authorization_code"]:
                 return self.callback_data["authorization_code"]
             elif self.callback_data["error"]:
-                raise Exception(f"OAuth error: {self.callback_data['error']}")
+                raise Exception(f"OAuth error: {self.callback_data['error']}")  # noqa: TRY002
             time.sleep(0.1)
-        raise Exception("Timeout waiting for OAuth callback")
+        raise Exception("Timeout waiting for OAuth callback")  # noqa: TRY002
 
     def get_state(self):
         """Get the received state parameter."""
@@ -292,7 +292,7 @@ class SimpleAuthClient:
                 ) as (read_stream, write_stream, get_session_id):
                     await self._run_session(read_stream, write_stream, get_session_id)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"❌ Failed to connect: {e}")
             import traceback
 
@@ -334,7 +334,7 @@ class SimpleAuthClient:
                     print()
             else:
                 print("No tools available")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"❌ Failed to list tools: {e}")
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None = None):
@@ -354,7 +354,7 @@ class SimpleAuthClient:
                         print(content)
             else:
                 print(result)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"❌ Failed to call tool '{tool_name}': {e}")
 
     async def invoke_mcp_server(self):
@@ -413,8 +413,25 @@ async def main(agent_arn, base_endpoint, auth0_audience):
 
 
 def run_test():
-    """CLI entry point for uv script."""
-    asyncio.run(main())
+    """CLI entry point for uv script.
+
+    Reads the configuration the README and invoke.py document as environment
+    variables (AGENT_ARN, AUTH0_AUDIENCE) and derives the AgentCore data-plane
+    endpoint from the ARN's region, then hands them to main().
+    """
+    agent_arn = os.getenv("AGENT_ARN", "")
+    auth0_audience = os.getenv("AUTH0_AUDIENCE", "")
+
+    # Derive the data-plane endpoint from the ARN region:
+    # arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>
+    base_endpoint = os.getenv("MCP_BASE_ENDPOINT", "")
+    if not base_endpoint and agent_arn:
+        parts = agent_arn.split(":")
+        region = parts[3] if len(parts) > 3 else ""
+        if region:
+            base_endpoint = f"https://bedrock-agentcore.{region}.amazonaws.com"
+
+    asyncio.run(main(agent_arn, base_endpoint, auth0_audience))
 
 
 if __name__ == "__main__":

--- a/01-features/03-connect-your-agent-to-anything/03-web-search/03-langchain-agent/web_search_langchain.py
+++ b/01-features/03-connect-your-agent-to-anything/03-web-search/03-langchain-agent/web_search_langchain.py
@@ -20,7 +20,7 @@ Environment variables required:
     COGNITO_CLIENT_SECRET  — Cognito app client secret
     COGNITO_SCOPE          — OAuth scope string
     BEDROCK_MODEL_ID       — (optional) Bedrock inference profile ID or ARN;
-                             defaults to us.anthropic.claude-sonnet-4-5-20250514-v1:0
+                             defaults to global.anthropic.claude-sonnet-4-6
 
 IAM permissions required:
     bedrock:InvokeModel (for Claude Sonnet 4)
@@ -36,11 +36,10 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from utils.gateway_auth import get_oauth_token
-
+from langchain.agents import create_agent
 from langchain_aws import ChatBedrockConverse
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain.agents import create_agent
+from utils.gateway_auth import get_oauth_token
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 

--- a/01-features/03-connect-your-agent-to-anything/03-web-search/utils/web_search_agent.py
+++ b/01-features/03-connect-your-agent-to-anything/03-web-search/utils/web_search_agent.py
@@ -10,9 +10,9 @@ the MCP tools/list endpoint.
 
 Environment variables:
     BEDROCK_MODEL_ID  — (optional) Bedrock inference profile ID or ARN;
-                        must be a cross-region inference profile (e.g. us.*, eu.*, ap.*)
+                        must be a cross-region inference profile (e.g. global.*, us.*, eu.*, ap.*)
                         or an inference profile ARN — on-demand model IDs are not supported.
-                        Defaults to us.anthropic.claude-sonnet-4-5-20250514-v1:0
+                        Defaults to global.anthropic.claude-sonnet-4-6
     AWS_DEFAULT_REGION — AWS region (default: us-east-1)
 """
 


### PR DESCRIPTION
## Summary
A second batch of `01-features/` accuracy fixes, separated from #1998 because each touched file also carried pre-existing whole-file ruff debt that the `python-lint` gate would otherwise flag. This PR fixes the defects **and** cleans the pre-existing findings in exactly those files (no behavior change) so the gate passes.

## Fixes
- **04-weather-agent/weather_agent.py** — module docstring said the Gateway proxies to *Open-Meteo*, but the code targets **Exa** (`https://mcp.exa.ai/mcp` in both this file and `resources.py`); the README body already says Exa. Corrected the docstring.
- **03-web-search/utils/web_search_agent.py** + **03-langchain-agent/web_search_langchain.py** — docstrings claimed the default model is `us.anthropic.claude-sonnet-4-5-20250514-v1:0`, but the code default is `global.anthropic.claude-sonnet-4-6`. Corrected the default (and the stale prefix guidance that omitted `global.*`).
- **10-mcp-dynamic-client-registration/mcp_auth0_client.py** — **runtime bug**: `run_test()` called `main()` with no arguments, but `main(agent_arn, base_endpoint, auth0_audience)` requires three, so the documented `python mcp_auth0_client.py` command crashed immediately with `TypeError`. `run_test()` now reads `AGENT_ARN`/`AUTH0_AUDIENCE` from the environment (as the README and `invoke.py` document) and derives the data-plane endpoint from the ARN's region.

## Lint cleanup (no behavior change)
To keep the whole-file `python-lint` gate green on the touched files: import-block sorting (I001), one `dict()`→literal (C408), removed now-redundant `# noqa: E402` (RUF100, since the root config already ignores E402), and explicit `# noqa` on the intentional demo-style broad-`except`/`raise` handlers (BLE001/S110/TRY002) — consistent with the repo's stated tutorial-code philosophy.

## Testing
- `python3 -m py_compile` clean on all four files.
- `uvx ruff@0.16.4 check --config pyproject.toml` → **All checks passed**; `ruff@0.16.4 format --check` → **all formatted**, using the repo-root ruff config the CI uses.