### PR TITLE
fix: resolve runtime/setup issues in six 01-features samples

### DIFF
--- a/01-features/02-host-your-agent/01-runtime/01-hosting-agents/01-http-protocol/03-strands-openai/agent.py
+++ b/01-features/02-host-your-agent/01-runtime/01-hosting-agents/01-http-protocol/03-strands-openai/agent.py
@@ -1,14 +1,26 @@
-from strands import Agent, tool
-from strands_tools import calculator  # Import the calculator tool
-from strands.models.litellm import LiteLLMModel
 import os
+import sys
+
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent, tool
+from strands.models.litellm import LiteLLMModel
+from strands_tools import calculator  # Import the calculator tool
 
 app = BedrockAgentCoreApp()
 
-os.environ["AZURE_API_KEY"] = "<YOUR_API_KEY>"
-os.environ["AZURE_API_BASE"] = "<YOUR_API_BASE>"
-os.environ["AZURE_API_VERSION"] = "<YOUR_API_VERSION>"
+# Azure OpenAI credentials are read from the environment. Set these before running:
+#   export AZURE_API_KEY=...        # your Azure OpenAI key
+#   export AZURE_API_BASE=...       # e.g. https://<resource>.openai.azure.com
+#   export AZURE_API_VERSION=...    # e.g. 2024-08-01-preview
+_required = ["AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION"]
+_missing = [v for v in _required if not os.environ.get(v)]
+if _missing:
+    sys.exit(
+        "Missing required environment variable(s): "
+        + ", ".join(_missing)
+        + "\nSet AZURE_API_KEY, AZURE_API_BASE, and AZURE_API_VERSION before running "
+        "(LiteLLM's azure provider reads these directly)."
+    )
 
 
 # Create a custom tool

--- a/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
+++ b/01-features/04-manage-context-of-your-agent/memory/00-getting-started/04-quickstart-boto3.py
@@ -67,7 +67,7 @@ control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 data = boto3.client("bedrock-agentcore", region_name=REGION)
 
 resp = control.create_memory(
-    name="QuickstartMemory",
+    name=f"QuickstartMemory_{int(time.time()) % 100000}",
     description="Getting-started memory resource",
     eventExpiryDuration=30,
     memoryExecutionRoleArn=MEMORY_ROLE_ARN,

--- a/01-features/04-manage-context-of-your-agent/memory/00-getting-started/05-quickstart-agentcore-sdk.py
+++ b/01-features/04-manage-context-of-your-agent/memory/00-getting-started/05-quickstart-agentcore-sdk.py
@@ -1,17 +1,70 @@
+import json as _json
 import os
 import time
 
+import boto3
 from bedrock_agentcore.memory import MemoryClient
 
 REGION = os.getenv("AWS_REGION", "us-east-1")
-MEMORY_ROLE_ARN = os.environ["MEMORY_EXECUTION_ROLE_ARN"]
+
+# Get or create a minimal IAM role for AgentCore Memory execution (mirrors
+# 04-quickstart-boto3.py so this script also runs without a pre-provisioned role).
+_iam = boto3.client("iam", region_name=REGION)
+_sts = boto3.client("sts", region_name=REGION)
+_account_id = _sts.get_caller_identity()["Account"]
+_role_name = "AgentCoreMemoryExecutionRole"
+MEMORY_ROLE_ARN = os.getenv(
+    "MEMORY_EXECUTION_ROLE_ARN",
+    f"arn:aws:iam::{_account_id}:role/{_role_name}",
+)
+try:
+    _iam.get_role(RoleName=_role_name)
+except _iam.exceptions.NoSuchEntityException:
+    _iam.create_role(
+        RoleName=_role_name,
+        AssumeRolePolicyDocument=_json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        ),
+        Description="Execution role for AgentCore Memory",
+    )
+    _iam.put_role_policy(
+        RoleName=_role_name,
+        PolicyName="BedrockAccess",
+        PolicyDocument=_json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "bedrock:InvokeModel",
+                            "bedrock:InvokeModelWithResponseStream",
+                        ],
+                        "Resource": "*",
+                    }
+                ],
+            }
+        ),
+    )
+    # IAM is eventually consistent: give the new role time to propagate before use.
+    time.sleep(10)
+
 ACTOR_ID = "user-42"
 SESSION_ID = f"sess-{int(time.time())}"
 
 client = MemoryClient(region_name=REGION)
 
 memory = client.create_memory_and_wait(
-    name="QuickstartMemorySdk",
+    name=f"QuickstartMemorySdk_{int(time.time()) % 100000}",
     description="Getting-started memory resource (SDK)",
     strategies=[],
     event_expiry_days=30,

--- a/01-features/05-authenticate-and-authorize/02-outbound-auth/04-outbound-auth-self-hosted/self_hosted_agent_oauth.py
+++ b/01-features/05-authenticate-and-authorize/02-outbound-auth/04-outbound-auth-self-hosted/self_hosted_agent_oauth.py
@@ -66,6 +66,7 @@ def create_cognito_user_pool() -> dict:
         ["bash", "create_cognito.sh"],
         capture_output=True,
         text=True,
+        check=False,  # returncode is handled explicitly below
         env={**os.environ, "AWS_REGION": REGION},
     )
     if result.returncode != 0:
@@ -74,6 +75,40 @@ def create_cognito_user_pool() -> dict:
     print(result.stdout)
     print("  Cognito user pool created. Copy the values above and set as env vars.")
     return {}
+
+
+def auto_setup_cognito() -> None:
+    """Run create_cognito.sh and inject its exported values into the environment.
+
+    Resolves the script relative to THIS file (so it works regardless of the
+    caller's working directory), runs it, parses the `export KEY='value'` lines
+    it prints, and sets them in os.environ so the rest of the flow can proceed
+    without a manual copy-paste step.
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "create_cognito.sh")
+    if not os.path.exists(script_path):
+        raise FileNotFoundError(f"create_cognito.sh not found at {script_path}")
+
+    print("  No OAuth env vars set — running create_cognito.sh automatically...")
+    result = subprocess.run(
+        ["bash", script_path],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, "AWS_REGION": REGION},
+    )
+    print(result.stdout)
+
+    injected = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("export ") and "=" in line:
+            key, value = line[len("export ") :].split("=", 1)
+            os.environ[key.strip()] = value.strip().strip("'\"")
+            injected.append(key.strip())
+    if not all(os.environ.get(k) for k in ("ISSUER_URL", "CLIENT_ID", "CLIENT_SECRET")):
+        raise RuntimeError("create_cognito.sh ran but did not produce ISSUER_URL/CLIENT_ID/CLIENT_SECRET")
+    print(f"  Injected into environment: {', '.join(injected)} ✓")
 
 
 # ── Step 2: Create Credential Provider ────────────────────────────────────────
@@ -221,7 +256,7 @@ def run_agent():
     """
     agent_user_id = os.environ.get("AGENT_USER_ID", "quickstart-user")
 
-    env = {  # noqa: F841
+    env = {
         **os.environ,
         "CREDENTIAL_PROVIDER_NAME": CREDENTIAL_PROVIDER_NAME,
         "AWS_REGION": REGION,
@@ -231,7 +266,7 @@ def run_agent():
     print(f"\n  Running agent with workload: {WORKLOAD_NAME}")
     print(f"  Credential provider: {CREDENTIAL_PROVIDER_NAME}")
     print(f"  User ID: {agent_user_id}")
-    print("")
+    print()
     print("  Command:")
     print(f"  CREDENTIAL_PROVIDER_NAME={CREDENTIAL_PROVIDER_NAME} \\")
     print(f"  WORKLOAD_NAME={WORKLOAD_NAME} \\")
@@ -250,13 +285,13 @@ def cleanup():
     try:
         control.delete_workload_identity(name=WORKLOAD_NAME)
         print(f"  Deleted workload identity: {WORKLOAD_NAME} ✓")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Workload delete error: {e}")
 
     try:
         control.delete_oauth2_credential_provider(name=CREDENTIAL_PROVIDER_NAME)
         print(f"  Deleted credential provider: {CREDENTIAL_PROVIDER_NAME} ✓")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Credential provider delete error: {e}")
 
     user_pool_id = os.environ.get("USER_POOL_ID")
@@ -268,7 +303,7 @@ def cleanup():
                 cognito.delete_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)
             cognito.delete_user_pool(UserPoolId=user_pool_id)
             print(f"  Deleted Cognito pool: {user_pool_id} ✓")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"  Cognito delete error: {e}")
 
 
@@ -311,6 +346,15 @@ def main():
         print("  export COGNITO_PASSWORD=...")
         return
 
+    # ── 1b. Auto-provision Cognito if OAuth env vars are not set ──────────────
+    # Lets the sample run end-to-end without a manual create_cognito.sh + copy-paste
+    # step. Set ISSUER_URL/CLIENT_ID/CLIENT_SECRET yourself (or use your own OAuth
+    # server) to skip this.
+    if not all(os.environ.get(v) for v in ("ISSUER_URL", "CLIENT_ID", "CLIENT_SECRET")):
+        print("=== Step 1: Auto-provisioning Cognito User Pool ===")
+        auto_setup_cognito()
+        print()
+
     # ── 2. Create credential provider ────────────────────────────────────────
     print("=== Step 2: Creating CustomOauth2 Credential Provider ===")
     provider_info = create_credential_provider()
@@ -331,10 +375,10 @@ def main():
     print(f"  Credential provider: {CREDENTIAL_PROVIDER_NAME}")
     print(f"  Workload identity: {WORKLOAD_NAME}")
     print(f"  Callback URL: {CALLBACK_URL}")
-    print("")
+    print()
     print("  To run the agent:")
     print(f"  CREDENTIAL_PROVIDER_NAME={CREDENTIAL_PROVIDER_NAME} WORKLOAD_NAME={WORKLOAD_NAME} python3 agent.py")
-    print("")
+    print()
     print("  To clean up:")
     print("  python self_hosted_agent_oauth.py --cleanup")
 

--- a/01-features/06-observe-evaluate-optimize-your-agent/01-observe/data_protection.py
+++ b/01-features/06-observe-evaluate-optimize-your-agent/01-observe/data_protection.py
@@ -262,7 +262,7 @@ def deploy_agent(guardrail_id: str, guardrail_version: str) -> dict:
         s3.create_bucket(Bucket=S3_BUCKET) if REGION == "us-east-1" else s3.create_bucket(
             Bucket=S3_BUCKET, CreateBucketConfiguration={"LocationConstraint": REGION}
         )
-    except Exception:
+    except Exception:  # noqa: BLE001, S110
         pass
     s3.upload_file("dp_deploy.zip", S3_BUCKET, f"{AGENT_NAME}/dp.zip")
     os.remove("dp_deploy.zip")
@@ -324,7 +324,7 @@ CW_DATA_PROTECTION_POLICY = {
             "Sid": "AuditPolicy",
             "DataIdentifier": [
                 "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-                "arn:aws:dataprotection::aws:data-identifier/PhoneNumber",
+                "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US",
                 "arn:aws:dataprotection::aws:data-identifier/Name",
             ],
             "Operation": {"Audit": {"FindingsDestination": {}}},
@@ -333,7 +333,7 @@ CW_DATA_PROTECTION_POLICY = {
             "Sid": "DeidentifyPolicy",
             "DataIdentifier": [
                 "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-                "arn:aws:dataprotection::aws:data-identifier/PhoneNumber",
+                "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US",
                 "arn:aws:dataprotection::aws:data-identifier/Name",
             ],
             "Operation": {"Deidentify": {"MaskConfig": {}}},
@@ -355,7 +355,7 @@ def apply_cw_data_protection(runtime_id: str):
         )
         print("  Data protection policy applied.")
         print("  Sensitive data in logs will now be masked as ****.")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Warning: {e}")
 
 
@@ -397,14 +397,14 @@ def cleanup(state: dict):
         try:
             bedrock.delete_guardrail(guardrailIdentifier=state["guardrail_id"])
             print("Deleted guardrail")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Warning: {e}")
 
     if state.get("runtime_id"):
         try:
             control.delete_agent_runtime(agentRuntimeId=state["runtime_id"])
             print(f"Deleted runtime {state['runtime_id']}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Warning: {e}")
 
     if state.get("role_name"):
@@ -413,7 +413,7 @@ def cleanup(state: dict):
                 iam.delete_role_policy(RoleName=state["role_name"], PolicyName=p)
             iam.delete_role(RoleName=state["role_name"])
             print(f"Deleted role {state['role_name']}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Warning: {e}")
 
     shutil.rmtree("_dp_agent", ignore_errors=True)

--- a/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/waf/deploy.py
+++ b/01-features/07-centralize-and-govern-your-ai-infrastructure/01-gateway/gatewaylabproject/scripts/waf/deploy.py
@@ -196,8 +196,21 @@ def main():
 
     # --- 3. Associate the web ACL with the gateway ---
     print("\n--- Associating web ACL with gateway ---")
-    wafv2.associate_web_acl(WebACLArn=web_acl_arn, ResourceArn=gateway_arn)
-    print("  Associated.")
+    # The gateway resource is not always immediately visible to WAF right after
+    # target creation (AWS eventual consistency), so associate_web_acl can raise
+    # WAFUnavailableEntityException. Retry with backoff before giving up.
+    for attempt in range(6):
+        try:
+            wafv2.associate_web_acl(WebACLArn=web_acl_arn, ResourceArn=gateway_arn)
+            print("  Associated.")
+            break
+        except wafv2.exceptions.WAFUnavailableEntityException:
+            if attempt == 5:
+                raise
+            print(
+                f"  Gateway not yet visible to WAF; retrying in 10s ({attempt + 1}/6)..."
+            )
+            time.sleep(10)
 
     print("\n  Saved target + web ACL details to .env")
     print("\nNext: uv run python scripts/waf/invoke.py")


### PR DESCRIPTION
## Summary
Six `01-features/` samples had code-level issues that prevented them from running cleanly. Each fix is applied and the touched file is gate-clean (`ruff check` + `ruff format --check` under the repo-root config, `py_compile` clean). Complements #1998 (CI-clean doc/CLI fixes) and #1999 (docstring + arity fixes) — no file overlap.

## Fixes
| # | File | Problem | Fix |
|---|------|---------|-----|
| 1 | `02-host/.../03-strands-openai/agent.py` | Hardcoded `<YOUR_API_KEY>`/`<YOUR_API_BASE>`/`<YOUR_API_VERSION>` → opaque Azure auth failure | Read from env (`AZURE_API_KEY`/`AZURE_API_BASE`/`AZURE_API_VERSION`); fail fast with a clear message if unset |
| 2 | `04-manage-context/memory/00-getting-started/04-quickstart-boto3.py` | Hardcoded `QuickstartMemory` → `ValidationException` on re-run | Timestamp suffix `QuickstartMemory_{int(time.time()) % 100000}` (underscore per the `[a-zA-Z][a-zA-Z0-9_]{0,47}` regex) |
| 3 | `06-observe/.../01-observe/data_protection.py` | `data-identifier/PhoneNumber` is not a valid managed identifier → policy fails | Corrected to `PhoneNumber-US` in both the audit and de-identify statements |
| 4 | `05-auth/.../04-outbound-auth-self-hosted/self_hosted_agent_oauth.py` | Required manual `create_cognito.sh` run + copy 6 env vars; script path not resolved relative to itself | Auto-run `create_cognito.sh` (resolved relative to `__file__`), parse its exported values, inject into the environment when the OAuth vars are unset; `--create-cognito` still works |
| 5 | `07-centralize/.../gatewaylabproject/scripts/waf/deploy.py` | `associate_web_acl` fails with `WAFUnavailableEntityException` (gateway eventual consistency) | Retry loop (up to 6× with 10s backoff) around the associate call, catching that specific exception |
| 6 | `04-manage-context/memory/00-getting-started/05-quickstart-agentcore-sdk.py` | Required `MEMORY_EXECUTION_ROLE_ARN` set manually; hardcoded name fails on re-run | Auto-create the execution role if missing (mirrors the boto3 quickstart) + unique memory name per run |

## Lint cleanup (no behavior change)
Each touched file also carried pre-existing whole-file ruff debt that the `python-lint` gate lints on any change. Cleaned it: import sort (I001), explicit `check=False` on a pre-existing `subprocess.run` that already handles `returncode` (PLW1510), and `# noqa` on intentional demo-style broad-`except` handlers (BLE001/S110) — consistent with the repo's tutorial-code philosophy (root config already relaxes E722).

## Testing
- `python3 -m py_compile` clean on all six files.
- `uvx ruff@0.16.4 check --config pyproject.toml` → **All checks passed**; `ruff@0.16.4 format --check` → **6 files already formatted** (repo-root config, as CI uses).
- Note on verification fidelity: fixes are source-verified + gate-verified here (not each live-deployed in this session). Fixes 1 (env-var fail-fast) and 4 (auto-cognito) are the highest-confidence structurally; 5 (WAF retry) and 6 (auto-role) exercise runtime branches worth a live confirmation before merge if desired.