### PR TITLE
fix(mcp-hosting): make the MCP hosting samples deployable and stop them reporting false success

### DIFF
--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/README.md
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Create and deploy a basic MCP server with tools to AgentCore runtime. Once deployed, any MCP-compatible client (Claude Desktop, Cursor, Kiro, or your own agent) can discover and call your tools.
+Create and deploy a basic MCP server with tools to AgentCore runtime. Once deployed, the tools are reachable through the `invoke_agent_runtime` API, which is what `invoke.py` here uses.
 
 ![MCP server on AgentCore runtime](images/hosting_mcp_server.png)
 
@@ -17,16 +17,29 @@ Create and deploy a basic MCP server with tools to AgentCore runtime. Once deplo
                                         └──────────────────────────┘
 ```
 
+> **Note on clients**: a deployed runtime is reached with SigV4-signed AWS API calls, so an off-the-shelf MCP client (Claude Desktop, Cursor, Kiro) cannot point at it directly without something to sign requests on its behalf. See [03-advanced/10-mcp-dynamic-client-registration](../../03-advanced/10-mcp-dynamic-client-registration/) for inbound auth.
+
+## Prerequisites
+
+See the [Prerequisites in the runtime README](../../README.md) — Python 3.12+, `uv` on PATH (for building arm64 packages), AWS credentials, and `boto3`. `deploy.py` also shells out to `zip`.
+
+AgentCore is regional and there is no default region, so set one:
+
+```bash
+export AWS_REGION=us-west-2
+```
+
 ## Step 1: Write the MCP Server (`mcp_server.py`)
 
-Use the `mcp` Python SDK's `FastMCP` class to define tools. The `bedrock-agentcore` SDK wraps it for AgentCore runtime:
+An MCP server on AgentCore is a plain [`FastMCP`](https://github.com/modelcontextprotocol/python-sdk) server. It is **not** a `BedrockAgentCoreApp`: that class serves an HTTP agent on `POST /invocations`, whereas an MCP server speaks JSON-RPC over the MCP streamable-HTTP transport. The `bedrock-agentcore` SDK is not involved at all, and is not a dependency of this sample.
 
 ```python
-from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from typing import Literal
+
 from mcp.server.fastmcp import FastMCP
 
-# Create the MCP server
-mcp = FastMCP("basic-tools")
+# host, port, path and stateless_http are the runtime's service contract, not preferences.
+mcp = FastMCP("basic-tools", host="0.0.0.0", port=8000, stateless_http=True, json_response=True)
 
 @mcp.tool()
 def add_numbers(a: float, b: float) -> float:
@@ -34,23 +47,37 @@ def add_numbers(a: float, b: float) -> float:
     return a + b
 
 @mcp.tool()
-def greet(name: str, language: str = "english") -> str:
-    """Generate a greeting message."""
-    greetings = {"english": f"Hello, {name}!", "spanish": f"¡Hola, {name}!"}
-    return greetings.get(language, f"Hello, {name}!")
-
-# Wrap with AgentCore SDK
-app = BedrockAgentCoreApp()
-app.mcp_app = mcp  # ← assign the MCP server to the app
+def greet(name: str, language: Literal["english", "spanish", "french"] = "english") -> str:
+    """Greet someone in English, Spanish or French."""
+    greetings = {
+        "english": f"Hello, {name}!",
+        "spanish": f"¡Hola, {name}!",
+        "french": f"Bonjour, {name}!",
+    }
+    return greetings[language]
 
 if __name__ == "__main__":
-    app.run()
+    mcp.run(transport="streamable-http")
 ```
 
+What the runtime requires, and what is your choice:
+
+| Setting | Why |
+|:--------|:----|
+| `port=8000` | Fixed by the runtime for MCP (HTTP agents use 8080, A2A uses 9000). |
+| `host="0.0.0.0"` | The runtime's health check has to reach the server; `127.0.0.1` fails. |
+| `stateless_http=True` | Two requests in a session are not guaranteed to reach the same process. FastMCP's stateful default fails with "Missing session ID". |
+| path `/mcp` | FastMCP's streamable-http default, which is what the runtime expects. |
+| `json_response=True` | **Your choice, not a requirement.** It makes every reply a plain JSON body so `invoke.py` can `json.loads()` it. The runtime accepts `text/event-stream` too. Trade-off: in JSON mode anything that is not a response or error is dropped, so progress notifications and server-initiated requests (sampling, elicitation) never reach the client. |
+
 Key differences from hosting an agent:
-- Use `app.mcp_app = mcp` instead of `@app.entrypoint`
-- The MCP server listens on port **8000** at path `/mcp` (not port 8080)
+- Use a `FastMCP` server and `mcp.run(transport="streamable-http")`, not `BedrockAgentCoreApp` and `@app.entrypoint`
+- The MCP server listens on port **8000** at path `/mcp` (not port 8080 at `/invocations`)
 - Communication uses **JSON-RPC** (MCP protocol), not free-form JSON
+
+Tool authoring notes worth copying:
+- Keep docstrings to one line. FastMCP publishes the whole docstring as the tool's `description`, so `Args:`/`Returns:` blocks are sent to every client on every `tools/list`, duplicating the generated `inputSchema`.
+- Use `Literal[...]` for closed sets of values. It puts an `enum` in the schema; a bare `str` tells the model nothing and lets an unknown value fall through silently.
 
 ## Step 2: Deploy with MCP Protocol
 
@@ -58,10 +85,10 @@ The deployment is the same as agents, with one key difference — `serverProtoco
 
 ```python
 control.create_agent_runtime(
-    agentRuntimeName="basic-mcp-server",
+    agentRuntimeName="basic_mcp_server",  # must match [a-zA-Z][a-zA-Z0-9_]{0,47} — no hyphens
     agentRuntimeArtifact={
         "codeConfiguration": {
-            "code": {"s3": {"bucket": bucket, "prefix": "basic-mcp-server/code.zip"}},
+            "code": {"s3": {"bucket": bucket, "prefix": "basic_mcp_server/code.zip"}},
             "runtime": "PYTHON_3_12",
             "entryPoint": ["mcp_server.py"],  # ← your MCP server file
         }
@@ -72,18 +99,23 @@ control.create_agent_runtime(
 )
 ```
 
-> **IAM note**: MCP tool servers typically don't call Bedrock models, so the IAM role only needs CloudWatch logging permissions. If your tools call AWS services (DynamoDB, S3, etc.), add those permissions too.
+No `create_agent_runtime_endpoint` call is needed: AgentCore provisions a `DEFAULT` endpoint along with the runtime, and that is the one an invoke with no `qualifier` reaches. Creating a second endpoint just adds a resource and its own log group.
+
+> **Verify the deployment, don't assume it.** AgentCore does not execute your entry point when it creates the runtime, so a server that crashes on import still reports `READY`. `deploy.py` therefore ends with a `tools/list` smoke test — without one, a broken server looks like a successful deploy and only fails later, at invoke time.
+
+> **IAM note**: MCP tool servers don't call Bedrock models, so no `bedrock:InvokeModel` is needed. The role still needs the runtime's observability permissions (CloudWatch Logs, X-Ray, and `cloudwatch:PutMetricData`) — with logging alone the runtime serves traffic but silently emits no traces and no metrics. If your tools call AWS services (DynamoDB, S3, etc.), add those permissions too.
 
 ## Step 3: Invoke with MCP JSON-RPC Messages
 
-MCP uses [JSON-RPC 2.0](https://www.jsonrpc.org/specification). The `invoke_agent_runtime` payload is passed through directly to your MCP server. Here's the typical flow:
+MCP uses [JSON-RPC 2.0](https://www.jsonrpc.org/specification). The `invoke_agent_runtime` payload is passed through directly to your MCP server.
+
+Always pass both `contentType` and `accept`. The streamable-HTTP transport rejects a request whose `Accept` does not include `application/json` or `text/event-stream` with **HTTP 406**, and one without a JSON `Content-Type` with **HTTP 400**.
 
 ### Initialize the session
 
 ```python
 client = boto3.client("bedrock-agentcore")
 
-# Every MCP session starts with an initialize handshake
 init_msg = {
     "jsonrpc": "2.0",
     "method": "initialize",
@@ -99,10 +131,12 @@ response = client.invoke_agent_runtime(
     agentRuntimeArn=arn,
     payload=json.dumps(init_msg).encode(),
     contentType="application/json",
-    accept="application/json",
+    accept="application/json, text/event-stream",
 )
 # Returns server info and capabilities
 ```
+
+Because this server is stateless, each call stands alone and `tools/list` works without the handshake first. A stateful MCP server would require it.
 
 ### List available tools
 
@@ -112,6 +146,8 @@ list_msg = {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}}
 response = client.invoke_agent_runtime(
     agentRuntimeArn=arn,
     payload=json.dumps(list_msg).encode(),
+    contentType="application/json",
+    accept="application/json, text/event-stream",
 )
 # Returns: {"result": {"tools": [{"name": "add_numbers", "description": "...", "inputSchema": {...}}, ...]}}
 ```
@@ -132,9 +168,30 @@ call_msg = {
 response = client.invoke_agent_runtime(
     agentRuntimeArn=arn,
     payload=json.dumps(call_msg).encode(),
+    contentType="application/json",
+    accept="application/json, text/event-stream",
 )
-# Returns: {"result": {"content": [{"type": "text", "text": "8.0"}]}}
+# Returns: {"result": {"content": [{"type": "text", "text": "8.0"}],
+#                      "structuredContent": {"result": 8.0}, "isError": false}}
 ```
+
+### Always check for errors
+
+A JSON-RPC error comes back with **HTTP 200**, so boto3 does not raise and `result.get("result", {})` would silently return `{}`:
+
+```python
+result = json.loads(response["response"].read().decode())
+if "error" in result:
+    raise RuntimeError(f"{result['error']['code']}: {result['error']['message']}")
+```
+
+This matters: a server that failed to start returns `{"error": {"code": -32010, "message": "Runtime initialization time exceeded..."}}` for every call. Without the check, a completely broken deployment prints empty results and exits 0.
+
+A tool that ran and failed is different — it returns a successful response with `isError: true`, so check that separately.
+
+### Sessions
+
+`runtimeSessionId` is optional, and `invoke.py` omits it. The service then mints a fresh one per request — it comes back as `response["runtimeSessionId"]` — so each call is its own session. Pass your own value instead to group calls into one session you can name and later end with `StopRuntimeSession`. The minimum length is **33 characters**, so a short value like `"my-session"` is rejected by client-side validation before the request is sent.
 
 ### MCP Methods Reference
 
@@ -148,28 +205,43 @@ response = client.invoke_agent_runtime(
 | `prompts/list` | List available prompts | (none) |
 | `prompts/get` | Get a prompt template | `name`, `arguments` |
 
+This sample registers only tools, so `resources/list` and `prompts/list` return empty lists. See [02-mcp-server-features](../02-mcp-server-features/) for resources and prompts.
+
 ## Files
 
 | File | Description |
 |:-----|:------------|
 | `mcp_server.py` | MCP server with `add_numbers`, `multiply_numbers`, and `greet` tools |
-| `requirements.txt` | `mcp`, `boto3`, `bedrock-agentcore` |
-| `deploy.py` | Zips code, uploads to S3, creates runtime with `serverProtocol='MCP'` |
+| `requirements.txt` | Local deps: `boto3`, plus `requirements-server.txt` |
+| `requirements-server.txt` | The server's own deps (`mcp`, pinned `<2.0.0`) — this is what gets vendored into the zip |
+| `deploy.py` | Zips code, uploads to S3, creates runtime with `serverProtocol='MCP'`, smoke-tests it |
 | `invoke.py` | Sends MCP JSON-RPC messages (`initialize`, `tools/list`, `tools/call`) |
-| `cleanup.py` | Deletes runtime, endpoint, S3 artifact, IAM role |
+| `cleanup.py` | Deletes runtime, S3 artifact, log groups, IAM role |
 
 ## Quick Start
 
 ```bash
 pip install -r requirements.txt
+```
 
-# Test locally
+Test locally, in two terminals — `mcp_server.py` runs in the foreground:
+
+```bash
+# Terminal 1: start the server
 python mcp_server.py
+```
+
+```bash
+# Terminal 2: call it. The Accept header is required; without it the server returns 406.
 curl -X POST http://localhost:8000/mcp \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+```
 
-# Deploy and invoke
+Then deploy and invoke:
+
+```bash
 python deploy.py
 python invoke.py
 python cleanup.py

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/cleanup.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/cleanup.py
@@ -1,4 +1,9 @@
-"""Clean up all MCP server resources. Usage: python cleanup.py"""
+"""Clean up all MCP server resources. Usage: python cleanup.py
+
+Every step records its outcome. If anything fails the script exits non-zero and
+keeps runtime_config.json, because agentRuntimeId cannot be reconstructed from
+anything else — losing it means the leftover runtime has to be hunted down by hand.
+"""
 
 import json
 import os
@@ -8,13 +13,62 @@ import time
 import boto3
 from boto3.session import Session
 
+POLL_TIMEOUT_SECONDS = 300
+
+
+def delete_endpoints(control, runtime_id: str) -> None:
+    """Delete customer-created endpoints, then wait for them to disappear.
+
+    DEFAULT is skipped: it is service-managed, is removed together with the runtime,
+    and rejects DeleteAgentRuntimeEndpoint with "Default endpoints are removed when
+    you delete the agent".
+
+    Any *other* endpoint has to be fully gone before DeleteAgentRuntime is accepted —
+    it fails with "This agent has endpoints that must be deleted before the agent can
+    be removed" while one is still present, including while one is still DELETING.
+    This sample's deploy.py no longer creates such an endpoint, but earlier versions
+    made one named "default", so this loop is what lets those deployments be removed.
+    """
+    endpoints = control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", [])
+    names = [e["name"] for e in endpoints if e["name"] != "DEFAULT"]
+    for name in names:
+        print(f"  Deleting endpoint: {name}")
+        control.delete_agent_runtime_endpoint(agentRuntimeId=runtime_id, endpointName=name)
+    if not names:
+        return
+
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        left = [
+            e["name"]
+            for e in control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", [])
+            if e["name"] != "DEFAULT"
+        ]
+        if not left:
+            return
+        time.sleep(10)
+    raise TimeoutError(f"endpoints {left} still present after {POLL_TIMEOUT_SECONDS}s")
+
+
+def wait_for_runtime_deletion(control, runtime_id: str) -> None:
+    """Block until the runtime is really gone, so the caller can report honestly."""
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        try:
+            control.get_agent_runtime(agentRuntimeId=runtime_id)
+        except control.exceptions.ResourceNotFoundException:
+            return
+        time.sleep(10)
+    raise TimeoutError(f"runtime {runtime_id} still present after {POLL_TIMEOUT_SECONDS}s")
+
 
 def main():
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime_config.json")
     try:
-        with open("runtime_config.json") as f:
+        with open(config_path) as f:
             config = json.load(f)
     except FileNotFoundError:
-        print("Error: runtime_config.json not found.")
+        print(f"Error: {config_path} not found.")
         sys.exit(1)
 
     agent_name, runtime_id, region = (
@@ -26,42 +80,86 @@ def main():
 
     control = boto3.client("bedrock-agentcore-control", region_name=region)
     s3 = boto3.client("s3", region_name=region)
+    logs = boto3.client("logs", region_name=region)
 
     print(f"Cleaning up: {agent_name}\n")
 
+    # The runtime is the only resource that bills while idle, so it goes first — and if
+    # it cannot be removed we stop here, leaving the artifact, log groups and role in
+    # place so that re-running this script retries a coherent deployment.
     try:
-        for ep in control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", []):
-            control.delete_agent_runtime_endpoint(agentRuntimeId=runtime_id, endpointName=ep["name"])
-        time.sleep(30)
+        try:
+            control.get_agent_runtime(agentRuntimeId=runtime_id)
+        except control.exceptions.ResourceNotFoundException:
+            # Only a missing *runtime* is benign here. Scoping the check to this one call
+            # keeps a ResourceNotFoundException from the endpoint sweep or the delete
+            # below — where it would mean something else entirely — from being reported
+            # as "already gone" while the runtime is in fact still running.
+            print("  Runtime already gone")
+        else:
+            delete_endpoints(control, runtime_id)
+            print(f"  Deleting runtime: {runtime_id}")
+            control.delete_agent_runtime(agentRuntimeId=runtime_id)
+            wait_for_runtime_deletion(control, runtime_id)
+            print("  Runtime deleted")
     except Exception as e:
-        print(f"  Warning: {e}")
+        print("\n✗ Cleanup INCOMPLETE — the runtime still exists and continues to bill:")
+        print(f"    {e}")
+        print("\n  Left the S3 artifact, log groups and IAM role in place; re-run this script to retry.")
+        print(f"  Keeping {os.path.basename(config_path)} (runtime_id={runtime_id}).")
+        sys.exit(1)
 
-    try:
-        control.delete_agent_runtime(agentRuntimeId=runtime_id)
-        time.sleep(30)
-    except Exception as e:
-        print(f"  Warning: {e}")
+    failures = []
 
-    # Delete S3 code artifact
+    # Delete the code artifact. The bucket itself is left in place: its name is shared
+    # by every sample in this repo, so other deployments may still have objects in it.
     try:
-        bucket = f"agentcore-code-{account_id}-{region}"
-        s3.delete_object(Bucket=bucket, Key=f"{agent_name}/code.zip")
-        print("  Deleted S3 code artifact")
+        s3.delete_object(Bucket=f"agentcore-code-{account_id}-{region}", Key=f"{agent_name}/code.zip")
+        # DeleteObject is idempotent, so this also succeeds when the key was already gone.
+        print("  Removed S3 code artifact")
     except Exception as e:
-        print(f"  Warning: {e}")
+        failures.append(f"S3 object {agent_name}/code.zip: {e}")
+
+    # Delete the runtime's log groups. AgentCore creates these on first invocation with
+    # no retention policy, so left behind they store logs — and bill — forever.
+    try:
+        groups = logs.describe_log_groups(logGroupNamePrefix=f"/aws/bedrock-agentcore/runtimes/{runtime_id}")
+        for g in groups.get("logGroups", []):
+            logs.delete_log_group(logGroupName=g["logGroupName"])
+            print(f"  Deleted log group: {g['logGroupName']}")
+    except Exception as e:
+        failures.append(f"log groups for {runtime_id}: {e}")
 
     role_name = f"agentcore-{agent_name}-role"
     iam = boto3.client("iam", region_name=region)
     try:
-        for p in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
-            iam.delete_role_policy(RoleName=role_name, PolicyName=p)
-        iam.delete_role(RoleName=role_name)
-    except Exception:
-        pass
+        try:
+            iam.get_role(RoleName=role_name)
+        except iam.exceptions.NoSuchEntityException:
+            # Scoped to this one call for the same reason as the runtime check above: a
+            # NoSuchEntity raised by one of the policy calls below must not be reported
+            # as a missing role while the role itself is still there.
+            print(f"  IAM role already gone: {role_name}")
+        else:
+            for p in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
+                iam.delete_role_policy(RoleName=role_name, PolicyName=p)
+            # Managed policies block delete_role too, so detach any added by hand.
+            for p in iam.list_attached_role_policies(RoleName=role_name).get("AttachedPolicies", []):
+                iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
+            iam.delete_role(RoleName=role_name)
+            print(f"  Deleted IAM role: {role_name}")
+    except Exception as e:
+        failures.append(f"IAM role {role_name}: {e}")
 
-    if os.path.exists("runtime_config.json"):
-        os.remove("runtime_config.json")
-    print("✓ Cleanup complete")
+    if failures:
+        print("\n✗ Cleanup INCOMPLETE — the runtime is gone, but these remain:")
+        for f in failures:
+            print(f"    {f}")
+        print(f"\n  Keeping {os.path.basename(config_path)} so you can re-run this script.")
+        sys.exit(1)
+
+    os.remove(config_path)
+    print("\n✓ Cleanup complete")
 
 
 if __name__ == "__main__":

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/cleanup.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/cleanup.py
@@ -102,7 +102,7 @@ def main():
             control.delete_agent_runtime(agentRuntimeId=runtime_id)
             wait_for_runtime_deletion(control, runtime_id)
             print("  Runtime deleted")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print("\n✗ Cleanup INCOMPLETE — the runtime still exists and continues to bill:")
         print(f"    {e}")
         print("\n  Left the S3 artifact, log groups and IAM role in place; re-run this script to retry.")
@@ -117,7 +117,7 @@ def main():
         s3.delete_object(Bucket=f"agentcore-code-{account_id}-{region}", Key=f"{agent_name}/code.zip")
         # DeleteObject is idempotent, so this also succeeds when the key was already gone.
         print("  Removed S3 code artifact")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"S3 object {agent_name}/code.zip: {e}")
 
     # Delete the runtime's log groups. AgentCore creates these on first invocation with
@@ -127,7 +127,7 @@ def main():
         for g in groups.get("logGroups", []):
             logs.delete_log_group(logGroupName=g["logGroupName"])
             print(f"  Deleted log group: {g['logGroupName']}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"log groups for {runtime_id}: {e}")
 
     role_name = f"agentcore-{agent_name}-role"
@@ -148,7 +148,7 @@ def main():
                 iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
             iam.delete_role(RoleName=role_name)
             print(f"  Deleted IAM role: {role_name}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"IAM role {role_name}: {e}")
 
     if failures:

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/deploy.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/deploy.py
@@ -293,7 +293,7 @@ def smoke_test(runtime_arn: str, runtime_id: str) -> None:
         except KeyError:
             # Either an error envelope or a body that is not a tools/list result.
             last_error = body.get("error", body)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             # Throttling and a just-created runtime that is not yet invocable are both
             # transient; anything else (AccessDenied on InvokeAgentRuntime, for example)
             # will simply exhaust the attempts and be reported below.

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/deploy.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/deploy.py
@@ -4,6 +4,8 @@ Deploy an MCP server to AgentCore Runtime.
 Uses direct code deployment (zip to S3) — no Docker required.
 Key difference from agent deployment: serverProtocol is 'MCP'.
 
+Requires `uv` and `zip` on PATH (see the Prerequisites in ../../README.md).
+
 Usage:
     python deploy.py
 """
@@ -20,13 +22,46 @@ AGENT_NAME = "basic_mcp_server"
 PROTOCOL = "MCP"
 PYTHON_RUNTIME = "PYTHON_3_12"
 ENTRY_POINT = "mcp_server.py"
-CODE_FILES = ["mcp_server.py", "requirements.txt"]
+CODE_FILES = ["mcp_server.py"]
+# Only the server's dependencies get vendored into the zip. requirements.txt also
+# carries boto3 for the local scripts, which mcp_server.py never imports.
+SERVER_REQUIREMENTS = "requirements-server.txt"
+# A deployment is normally a couple of minutes; the ceiling just stops the status
+# poll from spinning forever if the runtime never leaves CREATING.
+POLL_TIMEOUT_SECONDS = 900
 
 session = Session()
 REGION = session.region_name
+if not REGION:
+    sys.exit(
+        "No AWS region configured. AgentCore is regional and there is no default.\n"
+        "  export AWS_REGION=us-west-2    # or set `region` in your AWS profile"
+    )
 ACCOUNT_ID = session.client("sts").get_caller_identity()["Account"]
 S3_BUCKET = f"agentcore-code-{ACCOUNT_ID}-{REGION}"
 S3_PREFIX = f"{AGENT_NAME}/code.zip"
+CONFIG_FILE = "runtime_config.json"
+
+
+def save_config(runtime_id: str, runtime_arn: str) -> None:
+    """Record the runtime's identity so cleanup.py can always find it.
+
+    Written as soon as the runtime exists, not at the end of a successful deploy:
+    agentRuntimeId is the one identifier that cannot be reconstructed from the
+    constants in this file, so if we exit before saving it, a created runtime is
+    orphaned and cleanup.py has nothing to work from.
+    """
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(
+            {
+                "agent_name": AGENT_NAME,
+                "runtime_id": runtime_id,
+                "runtime_arn": runtime_arn,
+                "region": REGION,
+            },
+            f,
+            indent=2,
+        )
 
 
 def create_execution_role() -> str:
@@ -45,19 +80,50 @@ def create_execution_role() -> str:
         ],
     }
 
-    # MCP servers typically don't need Bedrock model access
+    # An MCP tool server does not call Bedrock models, so there is no bedrock:InvokeModel
+    # here. Everything below is the runtime's own observability plumbing: without the
+    # X-Ray and CloudWatch metric statements the runtime still serves traffic, but it
+    # silently emits no traces and no metrics — the spans log stream is created and
+    # stays empty, which looks like observability is wired up when it is not.
+    # If your tools call AWS services (DynamoDB, S3, ...), add those permissions too.
+    #
+    # See: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html
     inline_policy = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
+                "Action": ["logs:CreateLogGroup", "logs:DescribeLogStreams"],
+                "Resource": [f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:/aws/bedrock-agentcore/runtimes/*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["logs:DescribeLogGroups"],
+                "Resource": [f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                "Resource": [
+                    f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"
                 ],
-                "Resource": "arn:aws:logs:*:*:*",
-            }
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "xray:PutTraceSegments",
+                    "xray:PutTelemetryRecords",
+                    "xray:GetSamplingRules",
+                    "xray:GetSamplingTargets",
+                ],
+                "Resource": ["*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": "cloudwatch:PutMetricData",
+                "Resource": "*",
+                "Condition": {"StringEquals": {"cloudwatch:namespace": "bedrock-agentcore"}},
+            },
         ],
     }
 
@@ -97,8 +163,12 @@ def zip_and_upload_code():
                 Bucket=S3_BUCKET,
                 CreateBucketConfiguration={"LocationConstraint": REGION},
             )
-    except (s3.exceptions.BucketAlreadyOwnedByYou, s3.exceptions.BucketAlreadyExists):
+    except s3.exceptions.BucketAlreadyOwnedByYou:
         pass
+    except s3.exceptions.BucketAlreadyExists:
+        # The name is globally unique across all of S3, so this means another account
+        # owns it. Uploading would fail with AccessDenied further down; say so here.
+        sys.exit(f"S3 bucket {S3_BUCKET} exists in another AWS account. Rename S3_BUCKET and re-run.")
 
     if os.path.isdir(pkg_dir):
         shutil.rmtree(pkg_dir)
@@ -121,7 +191,7 @@ def zip_and_upload_code():
             "--only-binary",
             ":all:",
             "-r",
-            "requirements.txt",
+            SERVER_REQUIREMENTS,
         ],
         check=True,
     )
@@ -133,15 +203,15 @@ def zip_and_upload_code():
         check=True,
         capture_output=True,
     )
+    # The entry point must sit at the root of the archive, alongside the vendored deps.
     for f in CODE_FILES:
-        if f.endswith(".py"):
-            subprocess.run(["zip", zip_file, f], check=True, capture_output=True)
+        subprocess.run(["zip", zip_file, f], check=True, capture_output=True)
 
     zip_size = os.path.getsize(zip_file) / (1024 * 1024)
     print(f"  Package: {zip_file} ({zip_size:.1f} MB)")
 
     s3.upload_file(zip_file, S3_BUCKET, S3_PREFIX)
-    print(f"\u2713 Code uploaded to s3://{S3_BUCKET}/{S3_PREFIX}")
+    print(f"✓ Code uploaded to s3://{S3_BUCKET}/{S3_PREFIX}")
 
     shutil.rmtree(pkg_dir)
     os.remove(zip_file)
@@ -150,24 +220,34 @@ def zip_and_upload_code():
 def create_runtime(role_arn: str) -> dict:
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
 
-    response = control.create_agent_runtime(
-        agentRuntimeName=AGENT_NAME,
-        agentRuntimeArtifact={
-            "codeConfiguration": {
-                "code": {"s3": {"bucket": S3_BUCKET, "prefix": S3_PREFIX}},
-                "runtime": PYTHON_RUNTIME,
-                "entryPoint": [ENTRY_POINT],
-            }
-        },
-        roleArn=role_arn,
-        networkConfiguration={"networkMode": "PUBLIC"},
-        protocolConfiguration={"serverProtocol": PROTOCOL},
-        description="Basic MCP server with math and greeting tools",
-    )
+    try:
+        response = control.create_agent_runtime(
+            agentRuntimeName=AGENT_NAME,
+            agentRuntimeArtifact={
+                "codeConfiguration": {
+                    "code": {"s3": {"bucket": S3_BUCKET, "prefix": S3_PREFIX}},
+                    "runtime": PYTHON_RUNTIME,
+                    "entryPoint": [ENTRY_POINT],
+                }
+            },
+            roleArn=role_arn,
+            networkConfiguration={"networkMode": "PUBLIC"},
+            protocolConfiguration={"serverProtocol": PROTOCOL},
+            description="Basic MCP server with math and greeting tools",
+        )
+    except control.exceptions.ConflictException:
+        sys.exit(
+            f"A runtime named '{AGENT_NAME}' already exists.\n"
+            f"  Run `python cleanup.py` to remove the previous deployment, or change AGENT_NAME."
+        )
 
     runtime_id = response["agentRuntimeId"]
     runtime_arn = response["agentRuntimeArn"]
+    # Save before polling: the runtime exists now, so cleanup.py must be able to find
+    # it even if the wait below times out or is interrupted.
+    save_config(runtime_id, runtime_arn)
 
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
     while True:
         status_resp = control.get_agent_runtime(agentRuntimeId=runtime_id)
         status = status_resp["status"]
@@ -176,26 +256,59 @@ def create_runtime(role_arn: str) -> dict:
             break
         if "FAILED" in status:
             print(f"  ✗ Failed: {status_resp.get('failureReason')}")
+            print("  Run `python cleanup.py` to remove the created resources.")
+            sys.exit(1)
+        if time.time() > deadline:
+            print(f"  ✗ Timed out after {POLL_TIMEOUT_SECONDS}s in status {status}.")
+            print("  Run `python cleanup.py` to remove the created resources.")
             sys.exit(1)
         time.sleep(15)
 
     return {"runtime_id": runtime_id, "runtime_arn": runtime_arn}
 
 
-def create_endpoint(runtime_id: str):
-    control = boto3.client("bedrock-agentcore-control", region_name=REGION)
-    control.create_agent_runtime_endpoint(agentRuntimeId=runtime_id, name="default")
+def smoke_test(runtime_arn: str, runtime_id: str) -> None:
+    """Call the deployed server once before reporting success.
 
-    while True:
-        eps = control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id)
-        if eps.get("runtimeEndpoints"):
-            status = eps["runtimeEndpoints"][0]["status"]
-            print(f"  Endpoint status: {status}")
-            if status == "READY":
-                return
-            if "FAILED" in status:
-                sys.exit(1)
-        time.sleep(15)
+    AgentCore does not execute the entry point when it creates the runtime, so a
+    server that crashes on import still reaches READY. Without this check, deploy.py
+    prints "Deployment complete" for a runtime that can never answer a request, and
+    the failure only shows up later as an empty result from invoke.py.
+    """
+    data = boto3.client("bedrock-agentcore", region_name=REGION)
+    payload = json.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1}).encode()
+
+    attempts = 5
+    last_error = None
+    for attempt in range(attempts):
+        try:
+            response = data.invoke_agent_runtime(
+                agentRuntimeArn=runtime_arn,
+                payload=payload,
+                contentType="application/json",
+                accept="application/json, text/event-stream",
+            )
+            body = json.loads(response["response"].read().decode("utf-8"))
+            tools = body["result"]["tools"]
+        except KeyError:
+            # Either an error envelope or a body that is not a tools/list result.
+            last_error = body.get("error", body)
+        except Exception as e:
+            # Throttling and a just-created runtime that is not yet invocable are both
+            # transient; anything else (AccessDenied on InvokeAgentRuntime, for example)
+            # will simply exhaust the attempts and be reported below.
+            last_error = f"{type(e).__name__}: {e}"
+        else:
+            print(f"✓ Smoke test passed — tools: {', '.join(t['name'] for t in tools)}")
+            return
+        if attempt < attempts - 1:
+            time.sleep(5 * (attempt + 1))
+
+    print(f"✗ Runtime reports READY but is not serving MCP: {last_error}")
+    print("  This usually means the server failed to start. Check the traceback in:")
+    print(f"    /aws/bedrock-agentcore/runtimes/{runtime_id}-DEFAULT")
+    print("  Then fix the cause, run `python cleanup.py`, and deploy again.")
+    sys.exit(1)
 
 
 def main():
@@ -204,19 +317,10 @@ def main():
     role_arn = create_execution_role()
     zip_and_upload_code()
     runtime = create_runtime(role_arn)
-    create_endpoint(runtime["runtime_id"])
-
-    with open("runtime_config.json", "w") as f:
-        json.dump(
-            {
-                "agent_name": AGENT_NAME,
-                "runtime_id": runtime["runtime_id"],
-                "runtime_arn": runtime["runtime_arn"],
-                "region": REGION,
-            },
-            f,
-            indent=2,
-        )
+    # No create_agent_runtime_endpoint call: AgentCore provisions a DEFAULT endpoint
+    # with the runtime, and that is the one an invoke with no `qualifier` reaches.
+    # Creating a second endpoint adds a redundant resource and its own log group.
+    smoke_test(runtime["runtime_arn"], runtime["runtime_id"])
 
     print("\n✓ Deployment complete! Test with: python invoke.py")
 

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/invoke.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/invoke.py
@@ -10,22 +10,35 @@ Usage:
 """
 
 import json
+import os
 import sys
 
 import boto3
 
 
+class McpError(RuntimeError):
+    """A JSON-RPC error returned by the runtime or the MCP server."""
+
+
 def load_config() -> dict:
+    # Read next to this file, not the current directory, so the script works when
+    # invoked by an absolute path from elsewhere.
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime_config.json")
     try:
-        with open("runtime_config.json") as f:
+        with open(path) as f:
             return json.load(f)
     except FileNotFoundError:
-        print("Error: runtime_config.json not found. Run deploy.py first.")
+        print(f"Error: {path} not found. Run deploy.py first.")
         sys.exit(1)
 
 
 def send_mcp_rpc(runtime_arn: str, method: str, params: dict, region: str, rpc_id: int = 1) -> dict:
-    """Send an MCP JSON-RPC message to the deployed server."""
+    """Send an MCP JSON-RPC message to the deployed server.
+
+    contentType and accept are both required: the MCP streamable-HTTP transport
+    rejects a request that does not accept application/json or text/event-stream,
+    and omitting them here makes the call fail with HTTP 406.
+    """
     client = boto3.client("bedrock-agentcore", region_name=region)
 
     rpc_message = {
@@ -43,7 +56,28 @@ def send_mcp_rpc(runtime_arn: str, method: str, params: dict, region: str, rpc_i
     )
 
     body = response["response"].read().decode("utf-8")
-    return json.loads(body)
+    result = json.loads(body)
+
+    # A JSON-RPC error arrives with HTTP 200, so boto3 does not raise. Without this
+    # check `result.get("result", {})` turns every failure into an empty success —
+    # including "Runtime initialization time exceeded", which is what a server that
+    # crashed on startup returns for every call.
+    if "error" in result:
+        err = result["error"]
+        raise McpError(f"{method} failed [{err.get('code')}]: {err.get('message')}")
+
+    return result
+
+
+def print_tool_result(result: dict) -> bool:
+    """Print a tools/call result and return True if the tool reported a failure."""
+    payload = result.get("result", {})
+    # isError=True is a tool that ran and failed. It arrives inside a successful
+    # JSON-RPC response, so it has to be checked separately from the error envelope.
+    label = "Error " if payload.get("isError") else "Result"
+    text = " | ".join(c.get("text", "") for c in payload.get("content", []))
+    print(f"    {label}: {text}")
+    return bool(payload.get("isError"))
 
 
 def main():
@@ -52,21 +86,29 @@ def main():
     region = config["region"]
 
     print(f"MCP Server: {runtime_arn}\n")
+    failures = 0
 
-    # 1. Initialize the MCP session
+    # 1. Initialize the MCP session.
+    #
+    # This server is stateless (mcp_server.py sets stateless_http=True), so every
+    # request stands alone and tools/list below works without this handshake. It is
+    # here because a stateful MCP server requires it, and because the negotiated
+    # protocol version is worth seeing.
     print("─── Initialize")
     result = send_mcp_rpc(
         runtime_arn,
         "initialize",
         {
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {"name": "tutorial-client", "version": "1.0.0"},
         },
         region,
         rpc_id=1,
     )
-    print(f"    Server: {json.dumps(result.get('result', {}).get('serverInfo', {}))}\n")
+    info = result.get("result", {})
+    print(f"    Server: {json.dumps(info.get('serverInfo', {}))}")
+    print(f"    Protocol: {info.get('protocolVersion')}\n")
 
     # 2. List available tools
     print("─── tools/list")
@@ -77,45 +119,29 @@ def main():
     print()
 
     # 3. Call tools
-    print("─── tools/call: add_numbers(5, 3)")
-    result = send_mcp_rpc(
-        runtime_arn,
-        "tools/call",
-        {
-            "name": "add_numbers",
-            "arguments": {"a": 5, "b": 3},
-        },
-        region,
-        rpc_id=3,
-    )
-    print(f"    Result: {json.dumps(result.get('result', {}))}\n")
+    calls = [
+        ("add_numbers", {"a": 5, "b": 3}),
+        ("multiply_numbers", {"a": 7, "b": 6}),
+        ("greet", {"name": "Alice", "language": "spanish"}),
+    ]
+    for rpc_id, (name, arguments) in enumerate(calls, start=3):
+        args = ", ".join(f"{k}={v!r}" for k, v in arguments.items())
+        print(f"─── tools/call: {name}({args})")
+        result = send_mcp_rpc(runtime_arn, "tools/call", {"name": name, "arguments": arguments}, region, rpc_id=rpc_id)
+        if print_tool_result(result):
+            failures += 1
+        print()
 
-    print("─── tools/call: multiply_numbers(7, 6)")
-    result = send_mcp_rpc(
-        runtime_arn,
-        "tools/call",
-        {
-            "name": "multiply_numbers",
-            "arguments": {"a": 7, "b": 6},
-        },
-        region,
-        rpc_id=4,
-    )
-    print(f"    Result: {json.dumps(result.get('result', {}))}\n")
-
-    print("─── tools/call: greet('Alice', 'spanish')")
-    result = send_mcp_rpc(
-        runtime_arn,
-        "tools/call",
-        {
-            "name": "greet",
-            "arguments": {"name": "Alice", "language": "spanish"},
-        },
-        region,
-        rpc_id=5,
-    )
-    print(f"    Result: {json.dumps(result.get('result', {}))}\n")
+    if failures:
+        print(f"✗ {failures} tool call(s) reported an error")
+        sys.exit(1)
+    print("✓ All calls succeeded")
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except McpError as e:
+        # Exit non-zero so a broken deployment cannot look like a successful run.
+        print(f"\n✗ {e}")
+        sys.exit(1)

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/mcp_server.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/mcp_server.py
@@ -6,61 +6,67 @@ Exposes three tools via the Model Context Protocol:
 - multiply_numbers: multiplies two numbers
 - greet: generates a greeting message
 
-AgentCore Runtime expects the MCP server on 0.0.0.0:8000/mcp
-using stateless streamable HTTP transport.
+This is NOT a BedrockAgentCoreApp. An HTTP agent uses the SDK's app object and
+answers POST /invocations. An MCP server speaks JSON-RPC over the MCP
+streamable-HTTP transport instead, so it is a plain FastMCP server and
+`bedrock_agentcore` is not involved at all.
 """
+
+from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
-# stateless_http=True and json_response=True required for AgentCore Runtime compatibility
-mcp = FastMCP("basic-tools", host="0.0.0.0", stateless_http=True, json_response=True)  # nosec B104
+# host, port, path and stateless_http are the AgentCore Runtime service contract,
+# not preferences:
+#   - Port 8000 is fixed for MCP (HTTP agents use 8080, A2A uses 9000).
+#   - Host 0.0.0.0, or the runtime health check cannot reach the server.
+#   - stateless_http=True, because the runtime does not guarantee that two requests
+#     in a session reach the same process. FastMCP defaults to stateful, which fails
+#     behind a load balancer with "Missing session ID".
+#   - Path /mcp is where FastMCP's streamable-http transport mounts by default.
+#
+# json_response=True is this sample's own choice, NOT a runtime requirement: it makes
+# every reply a plain JSON body so invoke.py can json.loads() it directly. The runtime
+# accepts text/event-stream too, but then the client has to unwrap the event stream.
+# Note the trade-off — in JSON mode anything that is not a response or error is
+# dropped, so progress notifications and server-initiated requests (sampling,
+# elicitation) never reach the client.
+mcp = FastMCP(
+    "basic-tools",
+    host="0.0.0.0",  # nosec B104
+    port=8000,
+    stateless_http=True,
+    json_response=True,
+)
 
 
+# Keep tool docstrings to a single line. FastMCP publishes the whole docstring as the
+# tool's `description`, so Args:/Returns: blocks are sent to every client on every
+# tools/list — duplicating what the generated inputSchema already says.
 @mcp.tool()
 def add_numbers(a: float, b: float) -> float:
-    """Add two numbers together.
-
-    Args:
-        a: First number.
-        b: Second number.
-
-    Returns:
-        The sum of a and b.
-    """
+    """Add two numbers together."""
     return a + b
 
 
 @mcp.tool()
 def multiply_numbers(a: float, b: float) -> float:
-    """Multiply two numbers.
-
-    Args:
-        a: First number.
-        b: Second number.
-
-    Returns:
-        The product of a and b.
-    """
+    """Multiply two numbers."""
     return a * b
 
 
+# `language` is a Literal, not a bare str, so the published inputSchema carries an
+# enum of the accepted values. With a plain `str` the model gets no hint about what
+# is valid and an unknown language silently falls back to English.
 @mcp.tool()
-def greet(name: str, language: str = "english") -> str:
-    """Generate a greeting message.
-
-    Args:
-        name: The name of the person to greet.
-        language: The language for the greeting (english, spanish, french).
-
-    Returns:
-        A greeting message.
-    """
+def greet(name: str, language: Literal["english", "spanish", "french"] = "english") -> str:
+    """Greet someone in English, Spanish or French."""
     greetings = {
         "english": f"Hello, {name}! Welcome!",
         "spanish": f"¡Hola, {name}! ¡Bienvenido!",
         "french": f"Bonjour, {name}! Bienvenue!",
     }
-    return greetings.get(language.lower(), f"Hello, {name}!")
+    return greetings[language]
 
 
 if __name__ == "__main__":

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/requirements-server.txt
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/requirements-server.txt
@@ -1,0 +1,10 @@
+# Dependencies of the MCP server itself. deploy.py vendors this file into the
+# deployment zip, so keep it minimal: every package here is downloaded as an
+# arm64 wheel and shipped to the runtime.
+#
+# Pinned below 2.0 deliberately. mcp 2.0.0 renamed FastMCP to MCPServer and moved
+# it from mcp.server.fastmcp to mcp.server.mcpserver with no compatibility alias,
+# so the import in mcp_server.py fails on 2.x — verified against the 2.1.1 wheel.
+# Without the upper bound a fresh install resolves to 2.x and the deployed runtime
+# dies on its first import, which AgentCore reports only at invoke time.
+mcp>=1.10.0,<2.0.0

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/requirements.txt
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/01-mcp-server-basics/requirements.txt
@@ -1,2 +1,9 @@
-mcp>=1.10.0
+# What to install on your machine to run this sample: deploy.py, invoke.py and
+# cleanup.py, plus mcp so you can start mcp_server.py locally before deploying.
+#
+# The server's own dependencies live in requirements-server.txt (included below,
+# so the mcp pin has a single home). That file — not this one — is what deploy.py
+# vendors into the zip. boto3 stays out of it: mcp_server.py never imports boto3,
+# and shipping it would nearly double the deployment artifact.
+-r requirements-server.txt
 boto3>=1.38.0

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/README.md
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Beyond basic tools, MCP servers can expose **resources** (data sources), **prompts** (reusable templates), and support **sampling** (server-initiated LLM calls). This example demonstrates all three on AgentCore runtime.
+Beyond basic tools, MCP servers can expose **resources** (data sources) and **prompts** (reusable templates). This example demonstrates both on AgentCore runtime.
+
+> MCP also defines **sampling** and **elicitation** (server-initiated requests back to the client). This sample does not implement them: it sets `json_response=True`, which reduces each reply to a single JSON body, so anything that is not a response or an error — progress notifications and server-initiated requests included — is dropped. Demonstrating sampling would mean serving `text/event-stream` and using a client that can hold the stream open.
 
 > **If you're new to MCP on AgentCore**, start with the [MCP Server Basics](../01-mcp-server-basics/) example first.
 
@@ -14,7 +16,7 @@ Tools are the most common MCP feature. They let clients discover and execute fun
 
 ```python
 @mcp.tool()
-def search_documents(query: str, max_results: int = 5) -> str:
+def search_documents(query: str, max_results: Annotated[int, Field(ge=1, le=5)] = 5) -> str:
     """Search a document database."""
     # Your search logic here
     return json.dumps(results)
@@ -79,9 +81,15 @@ def mcp_rpc(client, arn, method, params, rpc_id):
         agentRuntimeArn=arn,
         payload=json.dumps(msg).encode(),
         contentType="application/json",
-        accept="application/json",
+        accept="application/json, text/event-stream",
     )
-    return json.loads(resp["response"].read().decode())
+    result = json.loads(resp["response"].read().decode())
+
+    # A JSON-RPC error arrives with HTTP 200, so boto3 does not raise. Check for it, or a
+    # server that failed to start returns an error for every call and still looks empty.
+    if "error" in result:
+        raise RuntimeError(f"{result['error']['code']}: {result['error']['message']}")
+    return result
 
 # Initialize session
 mcp_rpc(client, arn, "initialize", {...}, 1)
@@ -106,15 +114,30 @@ All MCP JSON-RPC messages are passed through `invoke_agent_runtime` directly to 
 | File | Description |
 |:-----|:------------|
 | `mcp_server.py` | MCP server with tools (`search_documents`, `analyze_sentiment`, `get_timestamp`), resources (`config://app`, `data://system-status`), and prompts (`code_review`, `summarize_document`) |
-| `requirements.txt` | `mcp`, `boto3`, `bedrock-agentcore` |
-| `deploy.py` | Same deployment pattern with `serverProtocol='MCP'` |
+| `requirements.txt` | Local deps: `boto3`, plus `requirements-server.txt` |
+| `requirements-server.txt` | The server's own deps (`mcp`, pinned `<2.0.0`) — this is what gets vendored into the zip |
+| `deploy.py` | Same deployment pattern with `serverProtocol='MCP'`, plus a `tools/list` smoke test |
 | `invoke.py` | Exercises all MCP features: `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get` |
-| `cleanup.py` | Same cleanup pattern |
+| `cleanup.py` | Deletes runtime, S3 artifact, log groups, IAM role |
+
+## Prerequisites
+
+See the [Prerequisites in the runtime README](../../README.md) — Python 3.12+, `uv` on PATH (for building arm64 packages), AWS credentials, and `boto3`. `deploy.py` also shells out to `zip`.
+
+AgentCore is regional and there is no default region, so set one:
+
+```bash
+export AWS_REGION=us-west-2
+```
 
 ## Quick Start
 
 ```bash
-python deploy.py     # Deploy MCP server
+pip install -r requirements.txt
+
+python deploy.py     # Deploy MCP server, then smoke-test it
 python invoke.py     # Exercise all MCP features
 python cleanup.py    # Clean up
 ```
+
+To try the server locally first, run it in one terminal and call it from another — see the [two-terminal example in MCP Server Basics](../01-mcp-server-basics/README.md#quick-start).

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/cleanup.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/cleanup.py
@@ -102,7 +102,7 @@ def main():
             control.delete_agent_runtime(agentRuntimeId=runtime_id)
             wait_for_runtime_deletion(control, runtime_id)
             print("  Runtime deleted")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print("\n✗ Cleanup INCOMPLETE — the runtime still exists and continues to bill:")
         print(f"    {e}")
         print("\n  Left the S3 artifact, log groups and IAM role in place; re-run this script to retry.")
@@ -117,7 +117,7 @@ def main():
         s3.delete_object(Bucket=f"agentcore-code-{account_id}-{region}", Key=f"{agent_name}/code.zip")
         # DeleteObject is idempotent, so this also succeeds when the key was already gone.
         print("  Removed S3 code artifact")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"S3 object {agent_name}/code.zip: {e}")
 
     # Delete the runtime's log groups. AgentCore creates these on first invocation with
@@ -127,7 +127,7 @@ def main():
         for g in groups.get("logGroups", []):
             logs.delete_log_group(logGroupName=g["logGroupName"])
             print(f"  Deleted log group: {g['logGroupName']}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"log groups for {runtime_id}: {e}")
 
     role_name = f"agentcore-{agent_name}-role"
@@ -148,7 +148,7 @@ def main():
                 iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
             iam.delete_role(RoleName=role_name)
             print(f"  Deleted IAM role: {role_name}")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         failures.append(f"IAM role {role_name}: {e}")
 
     if failures:

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/cleanup.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/cleanup.py
@@ -1,4 +1,9 @@
-"""Clean up all resources. Usage: python cleanup.py"""
+"""Clean up all resources. Usage: python cleanup.py
+
+Every step records its outcome. If anything fails the script exits non-zero and
+keeps runtime_config.json, because agentRuntimeId cannot be reconstructed from
+anything else — losing it means the leftover runtime has to be hunted down by hand.
+"""
 
 import json
 import os
@@ -8,13 +13,62 @@ import time
 import boto3
 from boto3.session import Session
 
+POLL_TIMEOUT_SECONDS = 300
+
+
+def delete_endpoints(control, runtime_id: str) -> None:
+    """Delete customer-created endpoints, then wait for them to disappear.
+
+    DEFAULT is skipped: it is service-managed, is removed together with the runtime,
+    and rejects DeleteAgentRuntimeEndpoint with "Default endpoints are removed when
+    you delete the agent".
+
+    Any *other* endpoint has to be fully gone before DeleteAgentRuntime is accepted —
+    it fails with "This agent has endpoints that must be deleted before the agent can
+    be removed" while one is still present, including while one is still DELETING.
+    This sample's deploy.py no longer creates such an endpoint, but earlier versions
+    made one named "default", so this loop is what lets those deployments be removed.
+    """
+    endpoints = control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", [])
+    names = [e["name"] for e in endpoints if e["name"] != "DEFAULT"]
+    for name in names:
+        print(f"  Deleting endpoint: {name}")
+        control.delete_agent_runtime_endpoint(agentRuntimeId=runtime_id, endpointName=name)
+    if not names:
+        return
+
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        left = [
+            e["name"]
+            for e in control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", [])
+            if e["name"] != "DEFAULT"
+        ]
+        if not left:
+            return
+        time.sleep(10)
+    raise TimeoutError(f"endpoints {left} still present after {POLL_TIMEOUT_SECONDS}s")
+
+
+def wait_for_runtime_deletion(control, runtime_id: str) -> None:
+    """Block until the runtime is really gone, so the caller can report honestly."""
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        try:
+            control.get_agent_runtime(agentRuntimeId=runtime_id)
+        except control.exceptions.ResourceNotFoundException:
+            return
+        time.sleep(10)
+    raise TimeoutError(f"runtime {runtime_id} still present after {POLL_TIMEOUT_SECONDS}s")
+
 
 def main():
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime_config.json")
     try:
-        with open("runtime_config.json") as f:
+        with open(config_path) as f:
             config = json.load(f)
     except FileNotFoundError:
-        print("Error: runtime_config.json not found.")
+        print(f"Error: {config_path} not found.")
         sys.exit(1)
 
     agent_name, runtime_id, region = (
@@ -26,39 +80,86 @@ def main():
 
     control = boto3.client("bedrock-agentcore-control", region_name=region)
     s3 = boto3.client("s3", region_name=region)
+    logs = boto3.client("logs", region_name=region)
 
-    try:
-        for ep in control.list_agent_runtime_endpoints(agentRuntimeId=runtime_id).get("runtimeEndpoints", []):
-            control.delete_agent_runtime_endpoint(agentRuntimeId=runtime_id, endpointName=ep["name"])
-        time.sleep(30)
-    except Exception:
-        pass
+    print(f"Cleaning up: {agent_name}\n")
 
+    # The runtime is the only resource that bills while idle, so it goes first — and if
+    # it cannot be removed we stop here, leaving the artifact, log groups and role in
+    # place so that re-running this script retries a coherent deployment.
     try:
-        control.delete_agent_runtime(agentRuntimeId=runtime_id)
-    except Exception:
-        pass
+        try:
+            control.get_agent_runtime(agentRuntimeId=runtime_id)
+        except control.exceptions.ResourceNotFoundException:
+            # Only a missing *runtime* is benign here. Scoping the check to this one call
+            # keeps a ResourceNotFoundException from the endpoint sweep or the delete
+            # below — where it would mean something else entirely — from being reported
+            # as "already gone" while the runtime is in fact still running.
+            print("  Runtime already gone")
+        else:
+            delete_endpoints(control, runtime_id)
+            print(f"  Deleting runtime: {runtime_id}")
+            control.delete_agent_runtime(agentRuntimeId=runtime_id)
+            wait_for_runtime_deletion(control, runtime_id)
+            print("  Runtime deleted")
+    except Exception as e:
+        print("\n✗ Cleanup INCOMPLETE — the runtime still exists and continues to bill:")
+        print(f"    {e}")
+        print("\n  Left the S3 artifact, log groups and IAM role in place; re-run this script to retry.")
+        print(f"  Keeping {os.path.basename(config_path)} (runtime_id={runtime_id}).")
+        sys.exit(1)
 
-    # Delete S3 code artifact
+    failures = []
+
+    # Delete the code artifact. The bucket itself is left in place: its name is shared
+    # by every sample in this repo, so other deployments may still have objects in it.
     try:
-        bucket = f"agentcore-code-{account_id}-{region}"
-        s3.delete_object(Bucket=bucket, Key=f"{agent_name}/code.zip")
-        print("  Deleted S3 code artifact")
-    except Exception:
-        pass
+        s3.delete_object(Bucket=f"agentcore-code-{account_id}-{region}", Key=f"{agent_name}/code.zip")
+        # DeleteObject is idempotent, so this also succeeds when the key was already gone.
+        print("  Removed S3 code artifact")
+    except Exception as e:
+        failures.append(f"S3 object {agent_name}/code.zip: {e}")
+
+    # Delete the runtime's log groups. AgentCore creates these on first invocation with
+    # no retention policy, so left behind they store logs — and bill — forever.
+    try:
+        groups = logs.describe_log_groups(logGroupNamePrefix=f"/aws/bedrock-agentcore/runtimes/{runtime_id}")
+        for g in groups.get("logGroups", []):
+            logs.delete_log_group(logGroupName=g["logGroupName"])
+            print(f"  Deleted log group: {g['logGroupName']}")
+    except Exception as e:
+        failures.append(f"log groups for {runtime_id}: {e}")
 
     role_name = f"agentcore-{agent_name}-role"
     iam = boto3.client("iam", region_name=region)
     try:
-        for p in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
-            iam.delete_role_policy(RoleName=role_name, PolicyName=p)
-        iam.delete_role(RoleName=role_name)
-    except Exception:
-        pass
+        try:
+            iam.get_role(RoleName=role_name)
+        except iam.exceptions.NoSuchEntityException:
+            # Scoped to this one call for the same reason as the runtime check above: a
+            # NoSuchEntity raised by one of the policy calls below must not be reported
+            # as a missing role while the role itself is still there.
+            print(f"  IAM role already gone: {role_name}")
+        else:
+            for p in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
+                iam.delete_role_policy(RoleName=role_name, PolicyName=p)
+            # Managed policies block delete_role too, so detach any added by hand.
+            for p in iam.list_attached_role_policies(RoleName=role_name).get("AttachedPolicies", []):
+                iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
+            iam.delete_role(RoleName=role_name)
+            print(f"  Deleted IAM role: {role_name}")
+    except Exception as e:
+        failures.append(f"IAM role {role_name}: {e}")
 
-    if os.path.exists("runtime_config.json"):
-        os.remove("runtime_config.json")
-    print("✓ Cleanup complete")
+    if failures:
+        print("\n✗ Cleanup INCOMPLETE — the runtime is gone, but these remain:")
+        for f in failures:
+            print(f"    {f}")
+        print(f"\n  Keeping {os.path.basename(config_path)} so you can re-run this script.")
+        sys.exit(1)
+
+    os.remove(config_path)
+    print("\n✓ Cleanup complete")
 
 
 if __name__ == "__main__":

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/deploy.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/deploy.py
@@ -279,7 +279,7 @@ def smoke_test(runtime_arn: str, runtime_id: str) -> None:
         except KeyError:
             # Either an error envelope or a body that is not a tools/list result.
             last_error = body.get("error", body)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             # Throttling and a just-created runtime that is not yet invocable are both
             # transient; anything else (AccessDenied on InvokeAgentRuntime, for example)
             # will simply exhaust the attempts and be reported below.

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/deploy.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/deploy.py
@@ -3,6 +3,8 @@ Deploy the advanced MCP server.
 
 Uses direct code deployment (zip to S3) — no Docker required.
 
+Requires `uv` and `zip` on PATH (see the Prerequisites in ../../README.md).
+
 Usage:
     python deploy.py
 """
@@ -19,13 +21,25 @@ AGENT_NAME = "advanced_mcp_server"
 PROTOCOL = "MCP"
 PYTHON_RUNTIME = "PYTHON_3_12"
 ENTRY_POINT = "mcp_server.py"
-CODE_FILES = ["mcp_server.py", "requirements.txt"]
+CODE_FILES = ["mcp_server.py"]
+# Only the server's dependencies get vendored into the zip. requirements.txt also
+# carries boto3 for the local scripts, which mcp_server.py never imports.
+SERVER_REQUIREMENTS = "requirements-server.txt"
+# Deployments are normally minutes; the ceiling just stops the poll loop from
+# spinning forever if a resource gets stuck.
+POLL_TIMEOUT_SECONDS = 900
 
 session = Session()
 REGION = session.region_name
+if not REGION:
+    sys.exit(
+        "No AWS region configured. AgentCore is regional and there is no default.\n"
+        "  export AWS_REGION=us-west-2    # or set `region` in your AWS profile"
+    )
 ACCOUNT_ID = session.client("sts").get_caller_identity()["Account"]
 S3_BUCKET = f"agentcore-code-{ACCOUNT_ID}-{REGION}"
 S3_PREFIX = f"{AGENT_NAME}/code.zip"
+CONFIG_FILE = "runtime_config.json"
 
 
 def create_execution_role() -> str:
@@ -42,18 +56,48 @@ def create_execution_role() -> str:
             }
         ],
     }
+    # An MCP tool server does not call Bedrock models, so there is no bedrock:InvokeModel
+    # here. Everything below is the runtime's own observability plumbing: without the
+    # X-Ray and CloudWatch metric statements the runtime still serves traffic, but it
+    # silently emits no traces and no metrics.
+    #
+    # See: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html
     policy = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
+                "Action": ["logs:CreateLogGroup", "logs:DescribeLogStreams"],
+                "Resource": [f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:/aws/bedrock-agentcore/runtimes/*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["logs:DescribeLogGroups"],
+                "Resource": [f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                "Resource": [
+                    f"arn:aws:logs:{REGION}:{ACCOUNT_ID}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"
                 ],
-                "Resource": "arn:aws:logs:*:*:*",
-            }
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "xray:PutTraceSegments",
+                    "xray:PutTelemetryRecords",
+                    "xray:GetSamplingRules",
+                    "xray:GetSamplingTargets",
+                ],
+                "Resource": ["*"],
+            },
+            {
+                "Effect": "Allow",
+                "Action": "cloudwatch:PutMetricData",
+                "Resource": "*",
+                "Condition": {"StringEquals": {"cloudwatch:namespace": "bedrock-agentcore"}},
+            },
         ],
     }
 
@@ -89,8 +133,12 @@ def zip_and_upload_code():
                 Bucket=S3_BUCKET,
                 CreateBucketConfiguration={"LocationConstraint": REGION},
             )
-    except (s3.exceptions.BucketAlreadyOwnedByYou, s3.exceptions.BucketAlreadyExists):
+    except s3.exceptions.BucketAlreadyOwnedByYou:
         pass
+    except s3.exceptions.BucketAlreadyExists:
+        # The name is globally unique across all of S3, so this means another account
+        # owns it. Uploading would fail with AccessDenied further down; say so here.
+        sys.exit(f"S3 bucket {S3_BUCKET} exists in another AWS account. Rename S3_BUCKET and re-run.")
 
     if os.path.isdir(pkg_dir):
         shutil.rmtree(pkg_dir)
@@ -113,7 +161,7 @@ def zip_and_upload_code():
             "--only-binary",
             ":all:",
             "-r",
-            "requirements.txt",
+            SERVER_REQUIREMENTS,
         ],
         check=True,
     )
@@ -125,55 +173,128 @@ def zip_and_upload_code():
         check=True,
         capture_output=True,
     )
+    # The entry point must sit at the root of the archive, alongside the vendored deps.
     for f in CODE_FILES:
-        if f.endswith(".py"):
-            subprocess.run(["zip", zip_file, f], check=True, capture_output=True)
+        subprocess.run(["zip", zip_file, f], check=True, capture_output=True)
 
     zip_size = os.path.getsize(zip_file) / (1024 * 1024)
     print(f"  Package: {zip_file} ({zip_size:.1f} MB)")
 
     s3.upload_file(zip_file, S3_BUCKET, S3_PREFIX)
-    print(f"\u2713 Code uploaded to s3://{S3_BUCKET}/{S3_PREFIX}")
+    print(f"✓ Code uploaded to s3://{S3_BUCKET}/{S3_PREFIX}")
 
     shutil.rmtree(pkg_dir)
     os.remove(zip_file)
 
 
+def save_config(runtime_id: str, runtime_arn: str) -> None:
+    """Record the runtime's identity so cleanup.py can always find it.
+
+    Written as soon as the runtime exists, not at the end of a successful deploy:
+    agentRuntimeId is the one identifier that cannot be reconstructed from the
+    constants in this file, so if we exit before saving it, a created runtime is
+    orphaned and cleanup.py has nothing to work from.
+    """
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(
+            {"agent_name": AGENT_NAME, "runtime_id": runtime_id, "runtime_arn": runtime_arn, "region": REGION},
+            f,
+            indent=2,
+        )
+
+
 def deploy_runtime(role_arn: str) -> dict:
     control = boto3.client("bedrock-agentcore-control", region_name=REGION)
-    resp = control.create_agent_runtime(
-        agentRuntimeName=AGENT_NAME,
-        agentRuntimeArtifact={
-            "codeConfiguration": {
-                "code": {"s3": {"bucket": S3_BUCKET, "prefix": S3_PREFIX}},
-                "runtime": PYTHON_RUNTIME,
-                "entryPoint": [ENTRY_POINT],
-            }
-        },
-        roleArn=role_arn,
-        networkConfiguration={"networkMode": "PUBLIC"},
-        protocolConfiguration={"serverProtocol": PROTOCOL},
-        description="Advanced MCP server with tools, resources, and prompts",
-    )
-    rid, rarn = resp["agentRuntimeId"], resp["agentRuntimeArn"]
+    try:
+        resp = control.create_agent_runtime(
+            agentRuntimeName=AGENT_NAME,
+            agentRuntimeArtifact={
+                "codeConfiguration": {
+                    "code": {"s3": {"bucket": S3_BUCKET, "prefix": S3_PREFIX}},
+                    "runtime": PYTHON_RUNTIME,
+                    "entryPoint": [ENTRY_POINT],
+                }
+            },
+            roleArn=role_arn,
+            networkConfiguration={"networkMode": "PUBLIC"},
+            protocolConfiguration={"serverProtocol": PROTOCOL},
+            description="Advanced MCP server with tools, resources, and prompts",
+        )
+    except control.exceptions.ConflictException:
+        sys.exit(
+            f"A runtime named '{AGENT_NAME}' already exists.\n"
+            f"  Run `python cleanup.py` to remove the previous deployment, or change AGENT_NAME."
+        )
 
+    rid, rarn = resp["agentRuntimeId"], resp["agentRuntimeArn"]
+    # Save before polling: the runtime exists now, so cleanup.py must be able to find
+    # it even if the wait below times out or is interrupted.
+    save_config(rid, rarn)
+
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
     while True:
-        s = control.get_agent_runtime(agentRuntimeId=rid)["status"]
+        status_resp = control.get_agent_runtime(agentRuntimeId=rid)
+        s = status_resp["status"]
         print(f"  Runtime: {s}")
         if s == "READY":
             break
         if "FAILED" in s:
+            print(f"  ✗ Failed: {status_resp.get('failureReason')}")
+            print("  Run `python cleanup.py` to remove the created resources.")
+            sys.exit(1)
+        if time.time() > deadline:
+            print(f"  ✗ Timed out after {POLL_TIMEOUT_SECONDS}s in status {s}.")
+            print("  Run `python cleanup.py` to remove the created resources.")
             sys.exit(1)
         time.sleep(15)
 
-    control.create_agent_runtime_endpoint(agentRuntimeId=rid, name="default")
-    while True:
-        eps = control.list_agent_runtime_endpoints(agentRuntimeId=rid)
-        if eps.get("runtimeEndpoints") and eps["runtimeEndpoints"][0]["status"] == "READY":
-            break
-        time.sleep(15)
-
+    # No create_agent_runtime_endpoint call: AgentCore provisions a DEFAULT endpoint with
+    # the runtime, and that is the one an invoke with no `qualifier` reaches. Creating a
+    # second endpoint adds a redundant resource and its own log group.
     return {"runtime_id": rid, "runtime_arn": rarn}
+
+
+def smoke_test(runtime_arn: str, runtime_id: str) -> None:
+    """Call the deployed server once before reporting success.
+
+    AgentCore does not execute the entry point when it creates the runtime, so a
+    server that crashes on import still reaches READY. Without this check, deploy.py
+    reports success for a runtime that can never answer a request.
+    """
+    data = boto3.client("bedrock-agentcore", region_name=REGION)
+    payload = json.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1}).encode()
+
+    attempts = 5
+    last_error = None
+    for attempt in range(attempts):
+        try:
+            response = data.invoke_agent_runtime(
+                agentRuntimeArn=runtime_arn,
+                payload=payload,
+                contentType="application/json",
+                accept="application/json, text/event-stream",
+            )
+            body = json.loads(response["response"].read().decode("utf-8"))
+            tools = body["result"]["tools"]
+        except KeyError:
+            # Either an error envelope or a body that is not a tools/list result.
+            last_error = body.get("error", body)
+        except Exception as e:
+            # Throttling and a just-created runtime that is not yet invocable are both
+            # transient; anything else (AccessDenied on InvokeAgentRuntime, for example)
+            # will simply exhaust the attempts and be reported below.
+            last_error = f"{type(e).__name__}: {e}"
+        else:
+            print(f"✓ Smoke test passed — tools: {', '.join(t['name'] for t in tools)}")
+            return
+        if attempt < attempts - 1:
+            time.sleep(5 * (attempt + 1))
+
+    print(f"✗ Runtime reports READY but is not serving MCP: {last_error}")
+    print("  This usually means the server failed to start. Check the traceback in:")
+    print(f"    /aws/bedrock-agentcore/runtimes/{runtime_id}-DEFAULT")
+    print("  Then fix the cause, run `python cleanup.py`, and deploy again.")
+    sys.exit(1)
 
 
 def main():
@@ -182,8 +303,7 @@ def main():
     role_arn = create_execution_role()
     zip_and_upload_code()
     runtime = deploy_runtime(role_arn)
-    with open("runtime_config.json", "w") as f:
-        json.dump({"agent_name": AGENT_NAME, **runtime, "region": REGION}, f, indent=2)
+    smoke_test(runtime["runtime_arn"], runtime["runtime_id"])
     print("\n✓ Done! Test with: python invoke.py")
 
 

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/invoke.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/invoke.py
@@ -6,17 +6,25 @@ Usage:
 """
 
 import json
+import os
 import sys
 
 import boto3
 
 
+class McpError(RuntimeError):
+    """A JSON-RPC error returned by the runtime or the MCP server."""
+
+
 def load_config() -> dict:
+    # Read next to this file, not the current directory, so the script works when
+    # invoked by an absolute path from elsewhere.
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime_config.json")
     try:
-        with open("runtime_config.json") as f:
+        with open(path) as f:
             return json.load(f)
     except FileNotFoundError:
-        print("Error: runtime_config.json not found. Run deploy.py first.")
+        print(f"Error: {path} not found. Run deploy.py first.")
         sys.exit(1)
 
 
@@ -28,7 +36,30 @@ def mcp_rpc(client, arn: str, method: str, params: dict, rpc_id: int) -> dict:
         contentType="application/json",
         accept="application/json, text/event-stream",
     )
-    return json.loads(resp["response"].read().decode("utf-8"))
+    result = json.loads(resp["response"].read().decode("utf-8"))
+
+    # A JSON-RPC error arrives with HTTP 200, so boto3 does not raise. Without this
+    # check `result.get("result", {})` turns every failure into an empty success —
+    # including "Runtime initialization time exceeded", which is what a server that
+    # crashed on startup returns for every call.
+    if "error" in result:
+        err = result["error"]
+        raise McpError(f"{method} failed [{err.get('code')}]: {err.get('message')}")
+
+    return result
+
+
+def print_tool_result(label: str, result: dict) -> bool:
+    """Print a tools/call result and return True if the tool reported a failure.
+
+    isError=True is a tool that ran and failed. It arrives inside a *successful*
+    JSON-RPC response, so mcp_rpc's error-envelope check cannot catch it.
+    """
+    payload = result.get("result", {})
+    failed = bool(payload.get("isError"))
+    print(f"\n  {label}:{'  [TOOL ERROR]' if failed else ''}")
+    print(f"  {json.dumps(payload, indent=4)}")
+    return failed
 
 
 def main():
@@ -46,7 +77,7 @@ def main():
         arn,
         "initialize",
         {
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {"name": "tutorial", "version": "1.0"},
         },
@@ -71,8 +102,7 @@ def main():
         },
         rpc_id,
     )
-    print("\n  search_documents('machine learning'):")
-    print(f"  {json.dumps(result.get('result', {}), indent=4)}")
+    tool_failures = print_tool_result("search_documents('machine learning')", result)
 
     rpc_id += 1
     result = mcp_rpc(
@@ -85,8 +115,7 @@ def main():
         },
         rpc_id,
     )
-    print("\n  analyze_sentiment(...):")
-    print(f"  {json.dumps(result.get('result', {}), indent=4)}")
+    tool_failures += print_tool_result("analyze_sentiment(...)", result)
 
     # ── Resources ────────────────────────────────────────────────────────
     print("\n═══ RESOURCES ═══")
@@ -123,8 +152,16 @@ def main():
     for msg in messages:
         print(f"  {msg.get('content', {}).get('text', '')[:200]}")
 
+    if tool_failures:
+        print(f"\n✗ {tool_failures} tool call(s) reported an error")
+        sys.exit(1)
     print("\n✓ All MCP features exercised successfully")
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except McpError as e:
+        # Exit non-zero so a broken deployment cannot look like a successful run.
+        print(f"\n✗ {e}")
+        sys.exit(1)

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/mcp_server.py
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/mcp_server.py
@@ -7,27 +7,40 @@ by AgentCore Runtime.
 
 import json
 from datetime import datetime, timezone
+from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
-# stateless_http=True and json_response=True required for AgentCore Runtime compatibility
-mcp = FastMCP("advanced-tools", host="0.0.0.0", stateless_http=True, json_response=True)  # nosec B104
+# host, port, path and stateless_http are the AgentCore Runtime service contract: the
+# runtime fixes the MCP port at 8000, needs 0.0.0.0 for its health check, and gives no
+# session affinity, so the server must keep no transport state between requests.
+#
+# json_response=True is this sample's own choice, NOT a runtime requirement: it makes
+# every reply a plain JSON body so invoke.py can json.loads() it. See the README for the
+# trade-off — in JSON mode progress notifications and server-initiated requests
+# (sampling, elicitation) are dropped, which is why this sample does not demonstrate them.
+mcp = FastMCP(
+    "advanced-tools",
+    host="0.0.0.0",  # nosec B104
+    port=8000,
+    stateless_http=True,
+    json_response=True,
+)
 
 
 # ── Tools ────────────────────────────────────────────────────────────────────
 
 
+# Keep tool docstrings to a single line. FastMCP publishes the whole docstring as the
+# tool's `description`, so Args:/Returns: blocks are sent to every client on every
+# tools/list — duplicating what the generated inputSchema already says.
+#
+# max_results is annotated with its real bound rather than a bare int, so the published
+# schema states the limit instead of silently truncating a larger request.
 @mcp.tool()
-def search_documents(query: str, max_results: int = 5) -> str:
-    """Search a document database.
-
-    Args:
-        query: Search query string.
-        max_results: Maximum number of results to return.
-
-    Returns:
-        JSON string with search results.
-    """
+def search_documents(query: str, max_results: Annotated[int, Field(ge=1, le=5)] = 5) -> str:
+    """Search a document database and return matches as JSON."""
     # Mock search results
     results = [
         {
@@ -35,21 +48,14 @@ def search_documents(query: str, max_results: int = 5) -> str:
             "title": f"Document about {query} (#{i})",
             "score": 0.95 - i * 0.1,
         }
-        for i in range(min(max_results, 5))
+        for i in range(max_results)
     ]
     return json.dumps(results, indent=2)
 
 
 @mcp.tool()
 def analyze_sentiment(text: str) -> str:
-    """Analyze the sentiment of a text.
-
-    Args:
-        text: The text to analyze.
-
-    Returns:
-        JSON with sentiment analysis results.
-    """
+    """Analyze the sentiment of a text and return the result as JSON."""
     # Mock sentiment analysis
     word_count = len(text.split())
     return json.dumps(
@@ -70,7 +76,9 @@ def get_timestamp() -> str:
 # ── Resources ────────────────────────────────────────────────────────────────
 
 
-@mcp.resource("config://app")
+# mime_type matters: both these resources return JSON, and without it FastMCP
+# advertises them as text/plain in resources/list and resources/read.
+@mcp.resource("config://app", mime_type="application/json")
 def get_app_config() -> str:
     """Application configuration settings."""
     return json.dumps(
@@ -87,7 +95,7 @@ def get_app_config() -> str:
     )
 
 
-@mcp.resource("data://system-status")
+@mcp.resource("data://system-status", mime_type="application/json")
 def get_system_status() -> str:
     """Current system status and health metrics."""
     return json.dumps(
@@ -106,12 +114,7 @@ def get_system_status() -> str:
 
 @mcp.prompt()
 def code_review(code: str, language: str = "python") -> str:
-    """Generate a code review prompt for the given code.
-
-    Args:
-        code: The source code to review.
-        language: Programming language of the code.
-    """
+    """Generate a code review prompt for the given source code."""
     return (
         f"Please review the following {language} code for:\n"
         f"1. Correctness and potential bugs\n"
@@ -124,12 +127,7 @@ def code_review(code: str, language: str = "python") -> str:
 
 @mcp.prompt()
 def summarize_document(document: str, max_length: str = "200 words") -> str:
-    """Generate a summarization prompt.
-
-    Args:
-        document: The document text to summarize.
-        max_length: Maximum length for the summary.
-    """
+    """Generate a summarization prompt for the given document."""
     return (
         f"Summarize the following document in {max_length} or less. "
         f"Focus on key points and actionable insights.\n\n"

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/requirements-server.txt
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/requirements-server.txt
@@ -1,0 +1,14 @@
+# Dependencies of the MCP server itself. deploy.py vendors this file into the
+# deployment zip, so keep it minimal: every package here is downloaded as an
+# arm64 wheel and shipped to the runtime.
+#
+# Pinned below 2.0 deliberately. mcp 2.0.0 renamed FastMCP to MCPServer and moved
+# it from mcp.server.fastmcp to mcp.server.mcpserver with no compatibility alias,
+# so the import in mcp_server.py fails on 2.x — verified against the 2.1.1 wheel.
+# Without the upper bound a fresh install resolves to 2.x and the deployed runtime
+# dies on its first import, which AgentCore reports only at invoke time.
+mcp>=1.10.0,<2.0.0
+
+# Arrives as an mcp dependency anyway; listed because mcp_server.py imports Field
+# directly to put a real bound on a tool argument.
+pydantic>=2.0

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/requirements.txt
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/02-mcp-server-features/requirements.txt
@@ -1,2 +1,9 @@
-mcp>=1.10.0
+# What to install on your machine to run this sample: deploy.py, invoke.py and
+# cleanup.py, plus mcp so you can start mcp_server.py locally before deploying.
+#
+# The server's own dependencies live in requirements-server.txt (included below,
+# so the mcp pin has a single home). That file — not this one — is what deploy.py
+# vendors into the zip. boto3 stays out of it: mcp_server.py never imports boto3,
+# and shipping it would nearly double the deployment artifact.
+-r requirements-server.txt
 boto3>=1.38.0

--- a/01-features/02-host-your-agent/01-runtime/02-hosting-tools/README.md
+++ b/01-features/02-host-your-agent/01-runtime/02-hosting-tools/README.md
@@ -9,7 +9,7 @@ AgentCore runtime can host [Model Context Protocol (MCP)](https://modelcontextpr
 | Aspect | Agent (HTTP) | MCP Server |
 |:-------|:-------------|:-----------|
 | `serverProtocol` | `HTTP` | `MCP` |
-| SDK pattern | `@app.entrypoint` | `app.mcp_app = mcp` |
+| SDK pattern | `BedrockAgentCoreApp` + `@app.entrypoint` | `FastMCP` + `mcp.run(transport="streamable-http")` |
 | Port | 8080 | 8000 |
 | Path | `/invocations` | `/mcp` |
 | Communication | Free-form JSON | JSON-RPC 2.0 (MCP spec) |
@@ -17,25 +17,28 @@ AgentCore runtime can host [Model Context Protocol (MCP)](https://modelcontextpr
 
 ## Writing an MCP Server
 
-Use the `mcp` Python SDK's `FastMCP` class and assign it to the `BedrockAgentCoreApp`:
+Use the `mcp` Python SDK's `FastMCP` class and run it with the streamable-HTTP transport. An MCP server is **not** a `BedrockAgentCoreApp` — that class serves an HTTP agent on `POST /invocations`, while an MCP server speaks JSON-RPC over the MCP transport. The `bedrock-agentcore` SDK is not involved:
+
+Pin the SDK below 2.0 (`mcp>=1.10.0,<2.0.0`): mcp 2.0.0 renamed `FastMCP` to `MCPServer` and moved it out of `mcp.server.fastmcp` with no compatibility alias, so the import below fails on 2.x — and because AgentCore does not run your entry point at create time, an unpinned deploy reports `READY` and only fails when you invoke it.
 
 ```python
-from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("my-tools")
+# host, port and stateless_http are the runtime's service contract, not preferences.
+# json_response=True is a choice: it makes every reply a plain JSON body, which is what
+# lets the client below use json.loads(). Drop it and the server answers with SSE.
+mcp = FastMCP("my-tools", host="0.0.0.0", port=8000, stateless_http=True, json_response=True)
 
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers."""
     return a + b
 
-app = BedrockAgentCoreApp()
-app.mcp_app = mcp  # ← this tells the SDK to serve MCP instead of HTTP
-
 if __name__ == "__main__":
-    app.run()
+    mcp.run(transport="streamable-http")
 ```
+
+`stateless_http=True` matters: the runtime does not guarantee that two requests in a session reach the same process, and FastMCP's stateful default fails behind a load balancer with "Missing session ID".
 
 ## Deploying an MCP Server
 
@@ -45,7 +48,7 @@ The deployment is identical to agents — only `serverProtocol` and `entryPoint`
 control = boto3.client("bedrock-agentcore-control")
 
 control.create_agent_runtime(
-    agentRuntimeName="my-mcp-server",
+    agentRuntimeName="my_mcp_server",  # [a-zA-Z][a-zA-Z0-9_]{0,47} — hyphens are rejected
     agentRuntimeArtifact={
         "codeConfiguration": {
             "code": {"s3": {"bucket": "my-bucket", "prefix": "my-server/code.zip"}},
@@ -59,7 +62,7 @@ control.create_agent_runtime(
 )
 ```
 
-> **IAM note**: MCP tool servers typically don't call LLMs, so the IAM role only needs CloudWatch logging permissions. Add permissions for any AWS services your tools access (DynamoDB, S3, etc.).
+> **IAM note**: MCP tool servers typically don't call LLMs, so no `bedrock:InvokeModel` is needed. The role still needs the runtime's observability permissions — CloudWatch Logs, X-Ray, and `cloudwatch:PutMetricData` — because with logging alone the runtime serves traffic but silently emits no traces and no metrics. Add permissions for any AWS services your tools access (DynamoDB, S3, etc.).
 
 ## Invoking an MCP Server
 
@@ -79,9 +82,18 @@ msg = {
 response = data.invoke_agent_runtime(
     agentRuntimeArn=arn,
     payload=json.dumps(msg).encode(),
+    # Both are required: the streamable-HTTP transport rejects a request that does not
+    # accept application/json or text/event-stream, and omitting them fails with HTTP 406.
+    contentType="application/json",
+    accept="application/json, text/event-stream",
 )
 result = json.loads(response["response"].read().decode())
 # {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "8"}]}}
+
+# A JSON-RPC error arrives with HTTP 200, so boto3 does not raise — check for it, or a
+# broken server (which returns an error for every call) looks like an empty success.
+if "error" in result:
+    raise RuntimeError(f"{result['error']['code']}: {result['error']['message']}")
 ```
 
 ## MCP Feature Support on AgentCore runtime
@@ -100,7 +112,7 @@ result = json.loads(response["response"].read().decode())
 
 ## Key Technical Details
 
-- **Transport**: Stateless streamable HTTP — AgentCore provides session isolation via the `Mcp-Session-Id` header automatically
+- **Transport**: Stateless streamable HTTP. Build the server with `stateless_http=True`: the runtime does not guarantee that two requests in a session reach the same process, so the server must keep no transport state between requests. `InvokeAgentRuntime` does carry `Mcp-Session-Id` and `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` headers for grouping calls, but they do not give a stateful server process affinity
 - **Port**: MCP server runs on port `8000` at path `/mcp` (this is the default for most MCP SDKs)
 - **Content types**: Supports both `application/json` and `text/event-stream` responses
 - **Payload passthrough**: The `invoke_agent_runtime` payload is forwarded directly to your MCP server as-is
@@ -111,3 +123,4 @@ result = json.loads(response["response"].read().decode())
 |:---------|:------------------|
 | [01-mcp-server-basics](01-mcp-server-basics/) | Define tools, deploy, invoke with `tools/list` and `tools/call` |
 | [02-mcp-server-features](02-mcp-server-features/) | Resources, prompts, and the full MCP feature set |
+| [03-mcp-ec2-capacity-provider](03-mcp-ec2-capacity-provider/) | Run an MCP server on your own EC2 instances via a CapacityProvider |


### PR DESCRIPTION
### Concise description of the PR

```
Changes to the two MCP hosting samples and their parent README, because the samples
cannot currently be deployed successfully, and when they fail they report success.
```

Three independent defects, all reproduced against a live AgentCore runtime in `us-west-2`:

1. **`requirements.txt` was unpinned (`mcp>=1.10.0`) and now resolves to mcp 2.x**, which
   renamed `FastMCP` to `MCPServer` and removed `mcp.server.fastmcp`. Both samples ship
   code that cannot import. The sibling `03-mcp-ec2-capacity-provider` already carries the
   correct pin and the written rationale; this applies the same fix.

2. **Failure was invisible.** AgentCore does not execute the entry point at
   `CreateAgentRuntime`, so a server that crashes on import still reports `READY`.
   `deploy.py` printed `✓ Deployment complete!`, and because `invoke.py` read
   `result.get("result", {})` it turned the runtime's own JSON-RPC error into `Result: {}`
   and exited 0. A completely broken deployment looked like a successful one.

3. **`cleanup.py` leaked a live runtime while reporting success.** Deleting the
   service-managed `DEFAULT` endpoint raises `ConflictException`, which aborted the loop and
   skipped the wait, so `delete_agent_runtime` then failed on a still-`DELETING` endpoint.
   The script printed `✓ Cleanup complete` and exited 0, leaving a billing runtime and
   deleting `runtime_config.json` — the only copy of `agentRuntimeId`. Reproduced twice,
   identically.

The docs fix (`app.mcp_app = mcp`) belongs to defect 2's family: that attribute has never
existed in **any** `bedrock-agentcore` release (checked 0.1.0 → 1.22.0, zero occurrences).
Assigning it succeeds silently and `app.run()` then serves `/invocations` on
`127.0.0.1:8080` with no `/mcp` route — so the documented program is undeployable as an MCP
server, and fails without an error.

### What changed

**`deploy.py`** (both samples) — ends with a `tools/list` smoke test that exits 1 with the
runtime's error and the log-group path; writes `runtime_config.json` immediately after
`CreateAgentRuntime` so a later failure is still cleanable; guards a missing region
(`session.region_name` is `None` with no region set, which previously surfaced as a
`LocationConstraint: None` `ParamValidationError` after the IAM role had been created);
handles `ConflictException` on re-run instead of raising a traceback; bounds the status
poll; vendors only the server's dependencies; grants the X-Ray and
`cloudwatch:PutMetricData` permissions from the documented reference policy (measured: with
logging alone the runtime works but emits **0** metrics and **0** traces, while creating an
empty `spans` stream that looks wired up); no longer creates a redundant endpoint, since
`DEFAULT` is provisioned with the runtime and is what a qualifier-less invoke reaches.

**`invoke.py`** (both) — raises on the JSON-RPC `error` envelope, checks `isError`
separately (a failed tool returns a *successful* response), and exits non-zero.

**`cleanup.py`** (both) — skips the service-managed `DEFAULT` endpoint, deletes any
customer-created endpoint and waits for it to disappear, waits for the runtime to actually
be gone, deletes the log groups (previously left at never-expire retention, 2 per
deployment), detaches managed policies before `delete_role`, and on any failure reports
what survived, keeps `runtime_config.json`, and exits 1.

**`mcp_server.py`** — one-line tool docstrings (FastMCP publishes the whole docstring as the
tool `description`, so `Args:`/`Returns:` blocks were shipped to every client on every
`tools/list`: 1023 → 678 chars for three trivial tools); `Literal[...]` on `greet`'s
`language` so the schema carries an `enum` instead of silently falling back to English; in
`02`, `Annotated[int, Field(ge=1, le=5)]` on `max_results` (was silently truncating) and
`mime_type="application/json"` on both resources (were advertised as `text/plain`).

**READMEs** — Step 1 now shows the real file and states that an MCP server is *not* a
`BedrockAgentCoreApp`; the `app.mcp_app = mcp` line is removed from both the sample and
parent READMEs; the Quick Start curl gains the `Accept` header it needs (returned **406**
without it) and is split across two terminals (`mcp_server.py` blocks, so every later line
was unreachable); all invoke snippets carry `contentType`/`accept` (omitting them fails
**406** at the API); `agentRuntimeName` uses underscores (`basic-mcp-server` is rejected:
`ValidationException ... [a-zA-Z][a-zA-Z0-9_]{0,47}`); a Sessions section documents the
undocumented 33-character `runtimeSessionId` minimum; `02` gains Prerequisites and a region
note; the parent gains the missing `03-` tutorial row and an mcp-2.x pin warning.

### Testing

Deployed end to end in a real account (`us-west-2`) after each round of changes:

- Both samples: `deploy.py` → `invoke.py` → `cleanup.py`, all exit 0. `02` exercises tools,
  resources and prompts.
- **Regression test**: reintroduced the unpinned `mcp` under a different runtime name and
  confirmed `deploy.py` exits 1 with the diagnostic instead of reporting success.
- **Migration test**: created the legacy `default` endpoint the previous `deploy.py` made,
  and confirmed the new `cleanup.py` removes such a deployment completely. (An earlier draft
  that dropped the endpoint sweep entirely failed this test — that is why the sweep is kept,
  scoped to non-`DEFAULT` endpoints.)
- Exception scoping verified with a stubbed control plane, no AWS calls: an endpoint-level
  `ResourceNotFoundException`, and a `NoSuchEntityException` from a policy delete, both now
  exit 1 and keep the config instead of claiming success.
- `pip install -r requirements.txt` and `uv pip install -r requirements.txt` both resolve
  `mcp 1.29.1` through the `-r requirements-server.txt` include.
- `ruff check` and `ruff format --check` clean on both samples. (`requirements-server.txt` is
  named to match the `**/requirements*.txt` glob in `ash-security-scan.yml`, so it stays
  inside dependency scanning.)
