### PR TITLE
fix: add missing AWS SDK dependencies to TypeScript agent package.json

### DIFF
--- a/01-features/02-host-your-agent/01-runtime/01-hosting-agents/07-typescript-agents/07-direct-code-deploy-typescript/package.json
+++ b/01-features/02-host-your-agent/01-runtime/01-hosting-agents/07-typescript-agents/07-direct-code-deploy-typescript/package.json
@@ -8,6 +8,8 @@
     "dev": "tsx app.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
     "@strands-agents/sdk": "^1.0.0-rc.5",
     "express": "^5.2.1",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary
- Add `@aws-sdk/client-bedrock-runtime` and `@aws-sdk/client-s3` to `package.json` dependencies
- `@strands-agents/sdk` requires these as peer dependencies but they weren't listed, so `npm install && npm run build` fails out of the box

## Root cause
esbuild bundles all imports (no `--external` flag in the build script). Without these packages installed, the build fails:
```
✘ [ERROR] Could not resolve "@aws-sdk/client-s3"
```

If you work around the build by adding `--external:@aws-sdk/*`, the deployed runtime crashes at startup:
```
Error: Cannot find module '@aws-sdk/client-bedrock-runtime'
```

## Verification
Deployed to AgentCore Runtime (NODE_22) in us-west-2:
- **Without fix:** build fails, or runtime crashes with `Cannot find module`
- **With fix:** `npm install && npm run build` succeeds, agent responds correctly

```
$ bash runtime.sh invoke <arn> "What is 25 * 17 + 42?"
→ "The answer is **467**."

$ bash runtime.sh invoke <arn> "Divide 100 by 7"
→ "100 divided by 7 equals approximately **14.29**"
```

## Test plan
- [x] `npm install && npm run build` succeeds without manual intervention
- [x] Deploy to AgentCore Runtime → status READY
- [x] Invoke with calculator prompts → correct answers
- [x] Cleanup → runtime deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)