### PR TITLE
fix(customer-support): move test tools to dev dependencies

### DIFF
--- a/05-blueprints/customer-support-agent-with-agentcore/pyproject.toml
+++ b/05-blueprints/customer-support-agent-with-agentcore/pyproject.toml
@@ -13,8 +13,6 @@ dependencies = [
     "botocore[crt]",
     "mcp >= 1.19.0",
     "pyjwt>=2.11.0",
-    "pytest >= 7.0.0",
-    "pytest-asyncio >= 0.21.0",
     "chardet >= 3.0.2, < 6.0.0",
     "requests >= 2.32.5",
     "strands-agents >= 1.25.0",
@@ -24,4 +22,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "bedrock-agentcore-starter-toolkit>=0.3.2",
+    "pytest >= 7.0.0",
+    "pytest-asyncio >= 0.21.0",
 ]

--- a/05-blueprints/customer-support-agent-with-agentcore/uv.lock
+++ b/05-blueprints/customer-support-agent-with-agentcore/uv.lock
@@ -2306,8 +2306,6 @@ dependencies = [
     { name = "chardet" },
     { name = "mcp" },
     { name = "pyjwt" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "requests" },
     { name = "strands-agents" },
     { name = "strands-agents-tools" },
@@ -2316,6 +2314,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "bedrock-agentcore-starter-toolkit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -2325,15 +2325,17 @@ requires-dist = [
     { name = "chardet", specifier = ">=3.0.2,<6.0.0" },
     { name = "mcp", specifier = ">=1.19.0" },
     { name = "pyjwt", specifier = ">=2.11.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "strands-agents", specifier = ">=1.25.0" },
     { name = "strands-agents-tools", specifier = ">=0.2.20" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "bedrock-agentcore-starter-toolkit", specifier = ">=0.3.2" }]
+dev = [
+    { name = "bedrock-agentcore-starter-toolkit", specifier = ">=0.3.2" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+]
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

**Issue number**: Fixes #2011

### Concise description of the PR

Moves `pytest` and `pytest-asyncio` from the customer support sample's production dependencies into its existing `dev` dependency group, because the production Dockerfile installs `[project].dependencies` directly.

The lock file is regenerated so both tools remain available to contributors without becoming runtime image dependencies.

### User experience

Before this change, `uv pip install -r pyproject.toml` resolves 82 production packages and includes pytest, pytest-asyncio, iniconfig, and pluggy.

After this change, the same Python 3.13 production resolution contains 78 packages. Those four packages are removed, with no additions. A default development sync still installs pytest and pytest-asyncio.

## Validation

- `uv pip compile pyproject.toml --python-version 3.13`: 82 → 78 packages
- Exact removals: `pytest`, `pytest-asyncio`, `iniconfig`, `pluggy`; no additions
- `uv lock --check`: passed
- Dev environment imports: pytest 9.0.2 and pytest-asyncio 1.3.0
- Built wheel metadata: no pytest `Requires-Dist`
- `test/test_main.py` currently contains only commented test code and collects 0 tests; no passing test suite is claimed

## Checklist

* [x] I have reviewed the contributing guidelines
* [ ] Add your name to CONTRIBUTORS.md (not changed; this PR is limited to dependency metadata)
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] Are you uploading a dataset? (not applicable)
* [ ] Have you documented Introduction, Architecture Diagram, Prerequisites, Usage, Sample Prompts, and Clean Up steps in your example README? (not applicable; no sample behavior changed)
* [ ] I agree to resolve any issues created for this example in the future
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented (not applicable; user-facing behavior is unchanged)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/LICENSE).
