### PR TITLE
Add attenu-guard authorization sample for Strands on AgentCore Runtime

### DIFF
--- a/03-integrations/agentic-frameworks/strands-agents/authorization/README.md
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/README.md
@@ -1,0 +1,261 @@
+# Strands sub-agent permissions with AgentCore Runtime
+
+| Information | Details |
+|---|---|
+| Agent type | Synchronous |
+| Agentic framework | Strands (agents as tools) |
+| LLM model | Whatever the Runtime is configured with; the offline run uses a scripted model |
+| Components | AgentCore Runtime |
+| Example complexity | Easy |
+| SDK used | Amazon BedrockAgentCore Python SDK |
+
+An `operations_assistant` orchestrator hands a log investigation to a
+`log_analyst` sub-agent, reached through Strands' agents-as-tools
+pattern. The orchestrator may export findings to an external
+destination. The sub-agent may not: it is delegated read access to logs
+and nothing else. When it calls `export_findings` anyway, the call is
+cancelled at the hook and the function is never entered.
+
+The enforcement comes from [attenu-guard](https://github.com/attenu-io/attenu-guard),
+an Apache-2.0 library (not part of the AWS SDKs). It ships a Strands
+hook provider, `attenu_guard.adapters.strands.DelegationGuard`,
+registered on each agent. Strands is unmodified, and nothing is
+monkeypatched.
+
+## Architecture
+
+```
+                    task
+                     |
+                     v
+ caller ----> operations_assistant (holds: logs.read, logs.export,
+              |         |            oncall.page, agent.delegate)
+              |         |
+              |         v  (Strands agents-as-tools)
+              |     log_analyst (delegated: logs.read only,
+              |         |        computed from the orchestrator's
+              |         |        authority at hand-off time)
+              |         |
+              |         +--> read_logs()          allowed, runs
+              |         +--> export_findings()     DENIED before the
+              |                                    tool body runs
+              v
+   hash-chained ledger  ->  signed evidence bundle  ->  verified offline
+   (attenu_guard.AuditLog)     (attenu_guard.evidence)   (no AWS, no network)
+```
+
+## What this sample shows
+
+- **A sub-agent's permissions are computed from its parent's.** The
+  child receives the meet of what it requests and what the parent holds,
+  so a hand-off can only ever narrow. Requesting `iam.admin` from a
+  parent that does not hold it yields nothing.
+- **Refusal happens before the tool body runs.** The adapter sets
+  `event.cancel_tool` on Strands' `BeforeToolCallEvent`, which makes the
+  executor skip the body and hand the model an error result. Each tool in
+  `agents.py` records its own entry as its first statement, which is how
+  the tests tell "refused" apart from "ran, then reported".
+- **Undeclared means denied.** A sub-agent with no entry in `SUB_AGENTS`
+  cannot be delegated to; a tool with no entry in `SCOPE_FOR` resolves to
+  `tool.<name>`, which no permission set grants. Both fail closed, and
+  both land in the ledger with a reason code.
+- **One permission model, two run paths.** `agents.py` and
+  `permissions.py` import nothing from AWS. The Runtime entrypoint and
+  the offline run both build their session from them, so what the tests
+  exercise is what gets deployed.
+- **A session per invocation.** The ledger, the delegation graph and the
+  time-to-live belong to a single run. Sharing them across callers would
+  blur whose decision was whose, so the entrypoint builds a fresh session
+  each time.
+- **The run leaves evidence.** Decisions append to a hash-chained
+  ledger. `local_run.py` exports a signed bundle and verifies it with the
+  packaged `attenu-guard verify` command — integrity, child-within-parent
+  and containment — with no service and no network involved. The ledger
+  is tamper-evident, not tamper-proof: a verifier detects an edit, it
+  does not prevent one.
+
+## Prerequisites
+
+- Python 3.11 or newer
+- [uv](https://github.com/astral-sh/uv)
+- Nothing else for the offline run: no AWS account, no model access, no
+  credentials.
+- For the deploy path: an AWS account with Bedrock AgentCore access, and
+  credentials in your environment.
+
+## Setup
+
+```bash
+uv venv
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
+uv pip install -r requirements-dev.txt
+```
+
+## Run it offline
+
+```bash
+python local_run.py
+```
+
+`ScriptedModel` is a `strands.models.Model` subclass that emits the
+Bedrock-shaped stream events `strands.event_loop.streaming` consumes.
+Strands' agent loop, hooks and tool executor are all the real ones; only
+the model is substituted, so the run is deterministic, free and safe for
+CI.
+
+Tests:
+
+```bash
+python -m pytest
+```
+
+## Expected output
+
+Abridged; the run prints the whole thing.
+
+```text
+2. what each agent holds
+    operations_assistant: scopes=['agent.delegate', 'logs.export', 'logs.read', 'oncall.page']
+    log_analyst: scopes=['logs.read']
+    sub-agent is narrower than orchestrator: True
+
+3. the refusal
+    tool bodies that ran: [('read_logs', 1500)]
+    DENIED {'agent': 'log_analyst', 'tool': 'export_findings',
+            'scope': 'logs.export', 'reason': 'scope_not_granted'}
+    nothing was written to s3://not-our-bucket/findings.json: True
+
+5. the ledger, checked without this process
+    5 events, hash chain: True
+    integrity=True monotonicity=True containment=True anchor=verified
+    OK
+
+RESULT: OK
+```
+
+`export_findings` is absent from the list of tool bodies that ran.
+
+## Understanding the entrypoint
+
+`strands_attenu_guard.py` is the file you hand to `agentcore configure`.
+It builds a session per invocation and returns the answer together with
+the decisions from that run, so a caller sees what was refused without
+reading the container's logs.
+
+```python
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+from agents import build_session, denials, reset
+
+app = BedrockAgentCoreApp()
+
+
+@app.entrypoint
+def agent_invocation(payload, context):
+    prompt = payload.get("prompt", DEFAULT_PROMPT)
+
+    reset()
+    orchestrator, _analyst, guard = build_session(
+        task=prompt, audit_path=LEDGER_PATH
+    )
+    result = orchestrator(prompt)
+
+    return {
+        "result": str(result.message),
+        "denials": denials(guard),
+        "ledger_events": len(guard.root_guard.audit_log().entries),
+    }
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+`build_session(...)` with no models leaves Strands on its Bedrock
+default, which is what the Runtime provides. The offline run passes
+scripted models to the same function.
+
+`ATTENU_GUARD_LEDGER` sets where the ledger is written inside the
+container; it defaults to a path under `/tmp`. Point it at a mounted
+volume, or export the bundle onward, if the record needs to outlive the
+session.
+
+## Deploy to AgentCore Runtime
+
+```bash
+agentcore configure -e strands_attenu_guard.py
+agentcore launch
+agentcore invoke '{"prompt": "Investigate the 5xx spike overnight."}'
+```
+
+`input.json` holds the same payload if you prefer to pass a file.
+
+These three commands are the standard Runtime flow and are written from
+the SDK's documented shape. They have **not** been executed for this
+sample: it was built and checked without an AWS account, so the offline
+run, the tests and the entrypoint's handler contract are verified, and
+the deployed round trip is not. Expect to adjust the IAM role and the
+region for your own account.
+
+## Clean up
+
+The offline run and the tests create nothing outside a temp directory
+under your system's temp folder — there is nothing to tear down. If you
+run the deploy path above, remove the resources `agentcore launch`
+created (the AgentCore Runtime endpoint and its IAM role) from your AWS
+account when you're done, e.g. via the AWS console or `agentcore
+destroy` if your toolkit version provides it.
+
+## Trust boundary
+
+The adversary this addresses is the agent itself — a sub-agent steered by
+a poisoned log line, a confused plan, or a misleading tool description
+into asking for something outside its remit. The enforcement point runs
+in-process, inside the same container as the agent, and holds:
+
+- as long as the hook is registered on every agent. `build_session()`
+  does that and then calls `require_guard()`, which turns a mis-wired
+  guard into a startup failure rather than a run nobody was checking.
+- for anything routed through Strands' tool executor. Code that reaches
+  a side effect without going through a tool call is outside the checked
+  path.
+- against permissions, not against content. The library takes no view on
+  whether exporting the findings is a good idea; it holds the analyst to
+  what it was delegated.
+
+It does not defend against an attacker with code execution in the
+container, who can edit `permissions.py` before it is loaded. Exported
+evidence is verified against a public key, so a bundle altered after
+export fails verification with the key alone.
+
+Writing the permission model is your job, deliberately: `permissions.py`
+is a short, reviewable file, and the library enforces exactly what it
+says.
+
+## Files
+
+| Path | What it holds |
+|---|---|
+| `permissions.py` | The three declarations: what the orchestrator holds, what the sub-agent may request, what each tool needs |
+| `agents.py` | The agents, the tools, `build_session()`, `require_guard()` |
+| `strands_attenu_guard.py` | The AgentCore Runtime entrypoint |
+| `local_run.py` | The scripted-model run, the evidence export, the offline verification |
+| `input.json` | A sample payload for `agentcore invoke` |
+| `tests/` | Enforcement assertions plus the entrypoint's handler contract |
+
+Versions this was checked against: `strands-agents` 1.54.0,
+`bedrock-agentcore` 1.22.0, `attenu-guard` 0.8.0, Python 3.14.6. The
+`bedrock-agentcore-starter-toolkit` (0.3.12) provides the `agentcore`
+CLI and was not exercised.
+
+## Disclaimer
+
+The examples provided in this repository are for experimental and
+educational purposes only. They demonstrate concepts and techniques but
+are not intended for direct use in production environments. Make sure to
+have Amazon Bedrock Guardrails in place to protect against [prompt
+injection](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-injection.html).
+
+## Licence
+
+Apache-2.0, matching this repository and the [attenu-guard](https://github.com/attenu-io/attenu-guard) library.

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/agents.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/agents.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""The agents, their tools, and the guard that binds them.
+
+Nothing here imports `bedrock_agentcore`. The AgentCore entrypoint
+(`strands_attenu_guard.py`) and the offline local run (`local_run.py`)
+both build their session from this module, so the same permission model
+is exercised on the laptop and on the Runtime.
+"""
+
+from typing import Any
+
+from attenu_guard import Guard
+from attenu_guard.adapters.strands import DelegationGuard
+from permissions import (
+    ANALYST_NAME,
+    ORCHESTRATOR,
+    ORCHESTRATOR_NAME,
+    SCOPE_FOR,
+    authority_for,
+)
+from strands import Agent, tool
+
+# (tool_name, notable_argument) for every tool body that actually ran.
+# The proof that a refusal happened *before* execution rather than after
+# it. Demo scaffolding; drop it when you adapt this to your own tools.
+EXECUTED: list[tuple[str, Any]] = []
+
+# Bounds and lookups each tool checks against its own arguments below.
+# attenu-guard decides whether an agent may call a tool at all, and under
+# which ceilings (row limits, egress rank), before the body ever runs; it
+# takes no view on whether a value the model supplied *within* that
+# ceiling is itself well-formed. That's this file's job, same as it would
+# be with no guard in front of it.
+MAX_ROWS = 10_000
+ALLOWED_ONCALL_CHANNELS = frozenset({"primary-oncall", "secondary-oncall", "escalation"})
+
+
+def reset() -> None:
+    EXECUTED.clear()
+
+
+@tool
+def read_logs(rows: int) -> str:
+    """Read recent application log lines.
+
+    Args:
+        rows: how many lines to read.
+    """
+    EXECUTED.append(("read_logs", rows))
+    if not isinstance(rows, int) or not (1 <= rows <= MAX_ROWS):
+        return f"rejected: rows must be an integer between 1 and {MAX_ROWS}"
+    return f"read {rows} lines: 3 spikes in 5xx between 02:10 and 02:40 UTC, all from the checkout service"
+
+
+@tool
+def export_findings(destination: str) -> str:
+    """Write the findings to an external destination.
+
+    Args:
+        destination: where to write them, e.g. an S3 URI.
+    """
+    EXECUTED.append(("export_findings", destination))
+    if not isinstance(destination, str) or not destination.startswith("s3://"):
+        return "rejected: destination must be an s3:// URI"
+    if len(destination) <= len("s3://"):
+        return "rejected: destination must be an s3:// URI"
+    return f"exported the findings to {destination}"
+
+
+@tool
+def page_oncall(channel: str, message: str) -> str:
+    """Page the on-call engineer.
+
+    Args:
+        channel: which rota to page.
+        message: what to tell them.
+    """
+    EXECUTED.append(("page_oncall", channel))
+    if channel not in ALLOWED_ONCALL_CHANNELS:
+        return f"rejected: unknown channel {channel!r}"
+    if not isinstance(message, str) or not message.strip():
+        return "rejected: message must be a non-empty string"
+    return f"paged {channel}"
+
+
+def build_session(
+    orchestrator_model: Any = None,
+    analyst_model: Any = None,
+    *,
+    task: str = "investigate the 5xx spike",
+    audit_path: str | None = None,
+) -> tuple[Agent, Agent, DelegationGuard]:
+    """One orchestrator, one sub-agent reached as a tool, one guard.
+
+    Build this per invocation, not once at import: the ledger, the
+    delegation graph and the time-to-live all belong to a single run.
+
+    `orchestrator_model` / `analyst_model` are `None` on the Runtime, so
+    Strands uses its Bedrock default. The offline run passes a scripted
+    model in their place.
+    """
+    analyst = Agent(
+        name=ANALYST_NAME,
+        description="Reads logs and explains what they show.",
+        model=analyst_model,
+        tools=[read_logs, export_findings, page_oncall],
+        callback_handler=None,
+    )
+    orchestrator = Agent(
+        name=ORCHESTRATOR_NAME,
+        description="Handles operational questions end to end.",
+        model=orchestrator_model,
+        tools=[analyst.as_tool(name=ANALYST_NAME)],
+        callback_handler=None,
+    )
+
+    guard = DelegationGuard(
+        root_guard=Guard.issue(
+            ORCHESTRATOR_NAME,
+            ORCHESTRATOR,
+            task=task,
+            audit_path=audit_path,
+        ),
+        root_agent=orchestrator,
+        scope_for=SCOPE_FOR,
+        authority_for=authority_for,
+    )
+    # The guard is one hook provider, registered on every agent. The
+    # sub-agent's own permissions do not exist yet: they are minted at the
+    # moment of the hand-off, from the orchestrator's. Were the hook
+    # missing from the sub-agent, its tool calls would go unchecked, so
+    # registering it on every agent in the tree is not optional.
+    for agent in (orchestrator, analyst):
+        agent.hooks.add_hook(guard)
+
+    require_guard(orchestrator, guard=guard)
+    return orchestrator, analyst, guard
+
+
+def require_guard(entry_agent: Agent, *, guard: DelegationGuard) -> None:
+    """Refuse to run an entry agent the root permissions are not bound
+    to. Cheap, and it turns a mis-wired guard into a startup failure
+    rather than a run nobody was checking."""
+    if guard.guard_for(entry_agent) is None:
+        raise RuntimeError(f"attenu-guard holds no permissions for {entry_agent.name!r} — refusing to run unguarded")
+
+
+def denials(guard: DelegationGuard) -> list[dict]:
+    """The refusals in this run, read back off the ledger.
+
+    Ledger entries name the chain node, not the agent, so the node names
+    are recovered from the `root` and `spawn` events.
+    """
+    entries = guard.root_guard.audit_log().entries
+    agent_of = {entry["node"]: entry["agent"] for entry in entries if entry["event"] in ("root", "spawn")}
+    return [
+        {
+            "agent": agent_of.get(entry.get("node"), entry.get("node")),
+            "tool": entry.get("tool"),
+            "scope": entry.get("scope"),
+            "reason": entry.get("reason"),
+            "disposition": entry.get("disposition"),
+        }
+        for entry in entries
+        if entry["event"] == "deny"
+    ]

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/input.json
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/input.json
@@ -1,0 +1,1 @@
+{"prompt": "Investigate the 5xx spike overnight and write it up."}

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/local_run.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/local_run.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Run the same session the Runtime would, offline.
+
+    python local_run.py
+
+`ScriptedModel` is a `strands.models.Model` subclass that emits the
+Bedrock-shaped stream events `strands.event_loop.streaming` consumes, so
+this needs no AWS credentials, no model access and no network. Strands'
+own agent loop, hooks and tool executor are the real ones; only the model
+is substituted.
+
+Exit code 0 if every expectation held, 1 otherwise.
+"""
+
+import json
+import sys
+import tempfile
+import uuid
+from collections.abc import AsyncIterable
+from pathlib import Path
+from typing import Any
+
+import agents
+from agents import build_session, denials
+from attenu_guard import AuditLog, evidence
+from attenu_guard.cli import main as attenu_guard_cli
+from attenu_guard.wire import Ed25519Signer
+from permissions import (
+    ANALYST_NAME,
+    GREEDY_REQUEST,
+    ORCHESTRATOR,
+    ORCHESTRATOR_NAME,
+)
+from strands.models import Model
+
+QUESTION = "Investigate the 5xx spike overnight and write it up."
+
+EXFIL_DESTINATION = "s3://not-our-bucket/findings.json"
+
+
+class ScriptedModel(Model):
+    """Replays a fixed script. Each step is ("tool", name, args) or
+    ("text", body)."""
+
+    def __init__(self, script: list[tuple]) -> None:
+        self._script = list(script)
+        self._i = 0
+
+    def update_config(self, **model_config: Any) -> None:
+        return None
+
+    def get_config(self) -> dict:
+        return {}
+
+    async def structured_output(self, output_model, prompt, system_prompt=None, **kwargs):
+        raise NotImplementedError("ScriptedModel has no structured output")
+        yield  # makes this an async generator
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs) -> AsyncIterable[dict]:
+        step = self._script[self._i] if self._i < len(self._script) else ("text", "(script exhausted)")
+        self._i += 1
+
+        yield {"messageStart": {"role": "assistant"}}
+        if step[0] == "tool":
+            _, name, args = step
+            yield {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": f"tu-{uuid.uuid4().hex[:8]}",
+                            "name": name,
+                        }
+                    }
+                }
+            }
+            yield {"contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": step[1]}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+def orchestrator_script() -> list[tuple]:
+    return [
+        ("tool", ANALYST_NAME, {"input": QUESTION}),
+        ("text", "The analyst could not publish the findings."),
+    ]
+
+
+def analyst_script() -> list[tuple]:
+    """A read it was delegated, then an export it was not."""
+    return [
+        ("tool", "read_logs", {"rows": 1500}),
+        ("tool", "export_findings", {"destination": EXFIL_DESTINATION}),
+        ("text", "5xx spike traced to the checkout service."),
+    ]
+
+
+def run(*, audit_path: str | None = None):
+    """One invocation. Returns (result, guard, executed)."""
+    agents.reset()
+    orchestrator, _analyst, guard = build_session(
+        ScriptedModel(orchestrator_script()),
+        ScriptedModel(analyst_script()),
+        task=QUESTION,
+        audit_path=audit_path,
+    )
+    result = orchestrator(QUESTION)
+    return result, guard, list(agents.EXECUTED)
+
+
+def main() -> int:
+    workdir = Path(tempfile.mkdtemp(prefix="attenu-guard-agentcore-"))
+    ledger = workdir / "ledger.jsonl"
+
+    print("1. one invocation: orchestrator -> log_analyst")
+    _result, guard, executed = run(audit_path=str(ledger))
+
+    orchestrator_guard = guard.guard_for_name(ORCHESTRATOR_NAME)
+    analyst_guard = guard.guard_for_name(ANALYST_NAME)
+
+    print("\n2. what each agent holds")
+    print(f"    {ORCHESTRATOR_NAME}: {orchestrator_guard.authority}")
+    print(f"    {ANALYST_NAME}: {analyst_guard.authority}")
+    narrower = analyst_guard.is_narrower_than(orchestrator_guard)
+    print(f"    sub-agent is narrower than orchestrator: {narrower}")
+
+    print("\n3. the refusal")
+    print(f"    tool bodies that ran: {executed}")
+    for entry in denials(guard):
+        print(f"    DENIED {entry}")
+    body_ran = any(name == "export_findings" for name, _ in executed)
+    refused = any(d["scope"] == "logs.export" for d in denials(guard))
+    print(f"    nothing was written to {EXFIL_DESTINATION}: {not body_ran}")
+
+    print("\n4. asking for more does not produce more")
+    granted = ORCHESTRATOR.meet(GREEDY_REQUEST)
+    print(f"    requested: {GREEDY_REQUEST}")
+    print(f"    granted  : {granted}")
+    met_down = granted.is_narrower_than(ORCHESTRATOR)
+    print(f"    granted is narrower than orchestrator: {met_down}")
+
+    print("\n5. the ledger, checked without this process")
+    entries = guard.root_guard.audit_log().entries
+    chain_ok, chain_err = AuditLog.verify(entries)
+    print(f"    {len(entries)} events, hash chain: {chain_ok}")
+    if not chain_ok:
+        print(f"    {chain_err}")
+
+    signer = Ed25519Signer.generate(kid="agentcore-sample")
+    pubkey = signer.public_bytes_raw().hex()
+    bundle_path = workdir / "evidence-bundle.json"
+    bundle = evidence.export_bundle(guard.root_guard.audit_log(), signer)
+    bundle_path.write_text(json.dumps(bundle, indent=2))
+
+    print(f"    bundle: {bundle_path}")
+    print("    verifying it with the packaged command:")
+    print(f"      attenu-guard verify {bundle_path.name} --pubkey {pubkey[:16]}…")
+    print("    ", end="")
+    verify_rc = attenu_guard_cli(["verify", str(bundle_path), "--pubkey", pubkey])
+
+    ok = refused and not body_ran and narrower and met_down and chain_ok and verify_rc == 0
+    print("\nRESULT:", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/permissions.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/permissions.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""The permission model for this sample — written by hand, on purpose.
+
+attenu-guard does not decide what a task needs. You declare three things
+and it enforces them:
+
+1. `ORCHESTRATOR`   — what the entry agent holds.
+2. `SUB_AGENTS`     — what each sub-agent may *request*. The child gets
+   the meet of the request and the parent, so a request can only ever
+   shrink the child, never widen it.
+3. `SCOPE_FOR`      — the scope, and the quantities the ceilings are
+   measured against, that each tool call needs.
+
+A sub-agent missing from `SUB_AGENTS` cannot be delegated to at all. A
+tool missing from `SCOPE_FOR` resolves to `tool.<name>`, which no
+permission set grants. Both fail closed.
+"""
+
+from attenu_guard import Authority, EgressRank, RowLimit
+from attenu_guard.adapters.strands import ScopeRequest, scope_map
+
+ORCHESTRATOR_NAME = "operations_assistant"
+ANALYST_NAME = "log_analyst"
+
+# --------------------------------------------------------------------
+# 1. What the entry agent holds: read logs, export findings, page the
+#    on-call engineer, and hand work to a sub-agent.
+# --------------------------------------------------------------------
+ORCHESTRATOR = Authority(
+    scopes={"logs.read", "logs.export", "oncall.page", "agent.delegate"},
+    ceilings=[RowLimit(50_000), EgressRank("any")],
+    ttl=3600,
+)
+
+# --------------------------------------------------------------------
+# 2. What the sub-agent may request: reads, bounded, no egress, and no
+#    onward hand-off.
+# --------------------------------------------------------------------
+SUB_AGENTS = {
+    ANALYST_NAME: Authority(
+        scopes={"logs.read"},
+        ceilings=[RowLimit(2_000), EgressRank("none")],
+        ttl=900,
+    ),
+}
+
+# A deliberately greedy request, used by the local run to show that
+# asking for more than the parent holds does not produce more.
+GREEDY_REQUEST = Authority(
+    scopes={"logs.*", "iam.admin"},
+    ceilings=[RowLimit(1_000_000), EgressRank("any")],
+    ttl=999_999,
+)
+
+
+def authority_for(child_name: str, task: str) -> "Authority | None":
+    """(sub-agent, task) -> the permissions it may request, or None to
+    refuse the hand-off outright. Whatever this returns is only ever an
+    input to the meet, so it cannot widen the child."""
+    return SUB_AGENTS.get(child_name)
+
+
+# --------------------------------------------------------------------
+# 3. What each tool call needs. `unmapped="deny"` is what makes an
+#    undeclared tool fail closed through the ordinary path, with a
+#    reason code in the ledger, rather than as a special case in code.
+# --------------------------------------------------------------------
+SCOPE_FOR = scope_map(
+    {
+        "read_logs": lambda i: ScopeRequest("logs.read", {"rows": int(i["rows"])}),
+        "export_findings": lambda i: ScopeRequest("logs.export", {"egress": "any"}),
+        "page_oncall": lambda i: ScopeRequest("oncall.page", {"egress": "internal"}),
+        # Calling the sub-agent IS the hand-off, so it is checked too.
+        ANALYST_NAME: "agent.delegate",
+    },
+    unmapped="deny",
+)

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/requirements-dev.txt
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/requirements.txt
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/requirements.txt
@@ -1,0 +1,4 @@
+strands-agents>=1.52
+attenu-guard[strands,crypto]>=0.8,<0.9
+bedrock-agentcore
+bedrock-agentcore-starter-toolkit

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/strands_attenu_guard.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/strands_attenu_guard.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""The AgentCore Runtime entrypoint.
+
+    agentcore configure -e strands_attenu_guard.py
+    agentcore launch
+    agentcore invoke '{"prompt": "Investigate the 5xx spike overnight."}'
+
+The agents, the tools and the permission model all live in `agents.py`
+and `permissions.py`, which import nothing from AWS. `local_run.py`
+builds the same session with a scripted model, so the enforcement path
+this file deploys is the one the offline run and the tests exercise.
+
+The response carries the run's decisions alongside the answer, so a
+caller sees what was refused without reading the container's logs.
+"""
+
+import os
+
+from agents import build_session, denials, reset
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+app = BedrockAgentCoreApp()
+
+DEFAULT_PROMPT = 'No prompt found in the payload. Send a JSON object with a "prompt" key.'
+
+# Where the ledger is written inside the container. AgentCore Runtime
+# gives you a writable /tmp; point this at a mounted volume or ship the
+# exported bundle onward if you need the record to outlive the session.
+LEDGER_PATH = os.getenv("ATTENU_GUARD_LEDGER", "/tmp/attenu-guard.jsonl")
+
+
+@app.entrypoint
+def agent_invocation(payload, context):
+    """Handler for agent invocation.
+
+    A fresh session per invocation, on purpose: the ledger, the
+    delegation graph and the time-to-live all belong to a single run, and
+    sharing them across callers would blur whose decision was whose.
+    """
+    prompt = payload.get("prompt", DEFAULT_PROMPT)
+
+    reset()
+    orchestrator, _analyst, guard = build_session(task=prompt, audit_path=LEDGER_PATH)
+    result = orchestrator(prompt)
+
+    return {
+        "result": str(result.message),
+        "denials": denials(guard),
+        "ledger_events": len(guard.root_guard.audit_log().entries),
+    }
+
+
+if __name__ == "__main__":
+    app.run()

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/tests/__init__.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/tests/test_enforcement.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/tests/test_enforcement.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""What the sample claims, asserted. Offline: no AWS, no network."""
+
+import local_run
+import pytest
+from agents import build_session, denials, require_guard
+from attenu_guard import AuditLog, Guard, evidence
+from attenu_guard.adapters.strands import DelegationGuard
+from attenu_guard.wire import Ed25519Signer
+from permissions import (
+    ANALYST_NAME,
+    GREEDY_REQUEST,
+    ORCHESTRATOR,
+    ORCHESTRATOR_NAME,
+    SCOPE_FOR,
+    authority_for,
+)
+from strands import Agent
+
+
+@pytest.fixture(scope="module")
+def run():
+    _result, guard, executed = local_run.run()
+    return guard, executed
+
+
+def test_the_read_the_sub_agent_was_delegated_goes_through(run):
+    _guard, executed = run
+    assert ("read_logs", 1500) in executed
+
+
+def test_the_export_is_refused_before_the_tool_body_runs(run):
+    guard, executed = run
+    refusals = denials(guard)
+
+    assert [d["scope"] for d in refusals] == ["logs.export"]
+    assert refusals[0]["agent"] == ANALYST_NAME
+    assert refusals[0]["tool"] == "export_findings"
+    # The tool body appends to EXECUTED as its first statement, so its
+    # absence is the proof the call never reached the function.
+    assert not any(name == "export_findings" for name, _ in executed)
+
+
+def test_the_sub_agent_holds_less_than_the_orchestrator(run):
+    guard, _executed = run
+    orchestrator = guard.guard_for_name(ORCHESTRATOR_NAME)
+    analyst = guard.guard_for_name(ANALYST_NAME)
+
+    assert analyst.is_narrower_than(orchestrator)
+    assert not orchestrator.is_narrower_than(analyst)
+    assert "logs.export" not in analyst.authority.scopes
+
+
+def test_a_request_for_more_than_the_parent_holds_is_met_down():
+    granted = ORCHESTRATOR.meet(GREEDY_REQUEST)
+
+    assert granted.is_narrower_than(ORCHESTRATOR)
+    assert "iam.admin" not in granted.scopes
+
+
+def test_an_undeclared_sub_agent_cannot_be_delegated_to():
+    assert authority_for("somebody_else", "any task") is None
+
+
+def test_an_undeclared_tool_resolves_to_a_scope_nobody_grants():
+    request = SCOPE_FOR({"name": "delete_bucket", "input": {}})
+
+    assert request.scope == "tool.delete_bucket"
+    assert not ORCHESTRATOR.permits(request.scope)
+
+
+def test_the_ledger_verifies_and_names_the_refusal(run):
+    guard, _executed = run
+    entries = guard.root_guard.audit_log().entries
+
+    ok, err = AuditLog.verify(entries)
+    assert ok, err
+    assert [e["reason"] for e in entries if e["event"] == "deny"] == ["scope_not_granted"]
+
+
+def test_a_tampered_ledger_does_not_verify(run):
+    guard, _executed = run
+    entries = [dict(e) for e in guard.root_guard.audit_log().entries]
+
+    for entry in entries:
+        if entry["event"] == "deny":
+            entry["event"] = "allow"
+            break
+
+    ok, _err = AuditLog.verify(entries)
+    assert not ok
+
+
+def test_the_evidence_bundle_verifies_on_its_own(run):
+    guard, _executed = run
+    signer = Ed25519Signer.generate(kid="agentcore-test")
+
+    bundle = evidence.export_bundle(guard.root_guard.audit_log(), signer)
+    report = evidence.verify_bundle(bundle, signer)
+
+    assert report["ok"]
+    assert report["checks"]["integrity"]
+    assert report["checks"]["monotonicity"]
+    assert report["checks"]["containment"]
+
+
+def test_an_unbound_entry_agent_refuses_to_start():
+    stranger = Agent(name="stranger", callback_handler=None)
+    guard = DelegationGuard(
+        root_guard=Guard.issue(ORCHESTRATOR_NAME, ORCHESTRATOR),
+        root_agent_name=ORCHESTRATOR_NAME,
+        scope_for=SCOPE_FOR,
+        authority_for=authority_for,
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to run unguarded"):
+        require_guard(stranger, guard=guard)
+
+
+def test_the_session_is_built_per_invocation():
+    """Two sessions must not share a ledger: one caller's decisions are
+    not another's evidence."""
+    _o1, _a1, first = build_session(local_run.ScriptedModel([("text", "one")]))
+    _o2, _a2, second = build_session(local_run.ScriptedModel([("text", "two")]))
+
+    assert first.root_guard is not second.root_guard
+    assert first.root_guard.audit_log() is not second.root_guard.audit_log()

--- a/03-integrations/agentic-frameworks/strands-agents/authorization/tests/test_entrypoint.py
+++ b/03-integrations/agentic-frameworks/strands-agents/authorization/tests/test_entrypoint.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Attenu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""The AgentCore packaging shape, exercised without AWS.
+
+The Runtime is not started here and no model is called: the entrypoint
+function is invoked directly with a payload, and `build_session` is
+substituted for one that supplies the scripted models. That covers the
+handler contract — payload in, JSON-serialisable dict out — and leaves
+the deployed path itself unverified, which the README says plainly.
+"""
+
+import json
+
+import local_run
+import pytest
+import strands_attenu_guard
+from agents import build_session
+from permissions import ANALYST_NAME
+
+
+@pytest.fixture
+def scripted_entrypoint(monkeypatch, tmp_path):
+    def scripted(*_args, **kwargs):
+        return build_session(
+            local_run.ScriptedModel(local_run.orchestrator_script()),
+            local_run.ScriptedModel(local_run.analyst_script()),
+            **kwargs,
+        )
+
+    monkeypatch.setattr(strands_attenu_guard, "build_session", scripted)
+    monkeypatch.setattr(
+        strands_attenu_guard,
+        "LEDGER_PATH",
+        str(tmp_path / "ledger.jsonl"),
+    )
+    return strands_attenu_guard.agent_invocation
+
+
+def test_the_entrypoint_is_registered_on_the_runtime_app():
+    assert strands_attenu_guard.app is not None
+    assert callable(strands_attenu_guard.agent_invocation)
+
+
+def test_the_entrypoint_returns_the_answer_and_the_decisions(
+    scripted_entrypoint,
+):
+    response = scripted_entrypoint({"prompt": "Investigate the 5xx spike overnight."}, None)
+
+    assert "result" in response
+    assert response["ledger_events"] > 0
+    assert [d["scope"] for d in response["denials"]] == ["logs.export"]
+    assert response["denials"][0]["agent"] == ANALYST_NAME
+    # The Runtime serialises whatever the handler returns.
+    json.dumps(response)
+
+
+def test_a_payload_without_a_prompt_is_handled(scripted_entrypoint):
+    response = scripted_entrypoint({}, None)
+
+    assert "result" in response

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,3 +133,4 @@
 - ach1ntya
 - Shruthi Rajoli (rajolishruthi)
 - ratnopam
+- Rafael Asor (rafaelasor)


### PR DESCRIPTION
Adds `03-integrations/agentic-frameworks/strands-agents/authorization/`, a
Strands + AgentCore Runtime sample showing:
- an orchestrator delegating to a sub-agent (agents-as-tools) whose permissions
  are computed as the meet of its request and the parent's authority, so a
  hand-off can only ever narrow
- an out-of-authority tool call cancelled before the tool body runs, via
  Strands' `BeforeToolCallEvent` hook (no monkeypatching)
- the run's decisions recorded in a hash-chained, offline-verifiable audit log

Enforcement comes from `attenu-guard` (Apache-2.0, not part of the AWS SDKs).

How to run: `uv venv && uv pip install -r requirements-dev.txt`, then
`python local_run.py` (offline, scripted model, no AWS account) and
`python -m pytest`. The AgentCore deploy commands (`agentcore configure` /
`launch` / `invoke`) are documented in the README but not executed as part
of this PR.

What the reader sees: the sub-agent reads logs (permitted), then tries to
export findings to an external destination (not permitted) — the call is
denied before the tool body runs, and the offline run prints the denial plus
a verified evidence bundle.

Refs #2013 (opened first per CONTRIBUTING).

Disclosure: I maintain attenu-guard.