### PR TITLE
feat(auth/consent-portal): add consent-dashboard sample for auth-code-flow gateway targets

### DIFF
--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/.gitignore
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/.gitignore
@@ -1,0 +1,17 @@
+# Deployment state and secrets. `.env.*` matters as much as `.env`: running a
+# second identity provider side by side puts a full set of client secrets and
+# admin tokens in .env.okta, .env.<anything> and so on. config.example.env is
+# the tracked template and is deliberately not matched by these patterns.
+.env
+.env.*
+
+.venv/
+venv/
+__pycache__/
+*.pyc
+.ruff_cache/
+
+# The AgentCore CLI scaffolds a project folder named after AGENT_RUNTIME_NAME —
+# one per deployment. Generated, so not tracked.
+consentGithubAgent/
+consentGithubOkta/

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/ARCHITECTURE.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/ARCHITECTURE.md
@@ -1,0 +1,222 @@
+# Architecture
+
+Two flows share one identity. Understanding where they meet is the whole design.
+
+## The consent flow (out of band, once per user)
+
+The user opens the portal directly. Nothing in your code participates.
+
+```mermaid
+sequenceDiagram
+    actor U as End user (browser)
+    participant CP as Consent portal<br/>(AWS-managed)
+    participant IdP as Primary IdP<br/>(Entra / Okta)
+    participant ID as AgentCore Identity
+    participant GH as GitHub
+
+    U->>CP: GET / (SPA shell — always 200)
+    U->>CP: Sign in
+    CP->>IdP: /authorize (PKCE S256, state, nonce)
+    IdP-->>U: sign-in page
+    U->>IdP: credentials
+    IdP-->>CP: code → <portalUrl>/callback
+    CP->>IdP: exchange code (server-side)
+    CP->>CP: ask the gateway's authorizer for a verdict
+    CP-->>U: session cookie (HttpOnly, encrypted)
+
+    Note over CP: Connections page = the gateway's<br/>AUTHORIZATION_CODE targets (cached ≤5 min)
+    U->>CP: Connect (GitHub)
+    CP->>ID: GetResourceOauth2Token
+    ID-->>CP: authorization URL + session URI
+    CP-->>U: redirect to GitHub
+    U->>GH: authorize
+    GH-->>ID: code → the AgentCore-vended callback
+    ID-->>U: redirect to <portalUrl>/connect/callback
+    U->>CP: /connect/callback
+    CP->>ID: CompleteResourceTokenAuth(identity, session URI)
+    ID->>GH: exchange code for an access token
+    ID->>ID: store the token against this user
+    CP-->>U: /?connected=github
+```
+
+Two properties fall out of this:
+
+**The browser never holds a token.** The portal is a Backend-For-Frontend: the
+OAuth exchange is server-side and the session lives in an encrypted `HttpOnly`
+cookie. With no token in `localStorage`, injected script has nothing to read —
+with the trade-off that the network tab will not show you the exchange.
+
+**Session binding is why `CompleteResourceTokenAuth` exists.** An authorization
+URL on its own could be forwarded to someone else, who would then grant consent
+and have *their* token stored against *your* request. AgentCore therefore issues
+a session URI alongside the URL and requires both, plus the caller's identity,
+before it will exchange the code. Something has to make that call — without a
+portal, that something is a callback server you write and operate. This is the
+portal's core value.
+
+## The request flow (every invocation)
+
+```mermaid
+sequenceDiagram
+    actor U as End user
+    participant BFF as FastAPI BFF
+    participant RT as Agent<br/>(AgentCore Runtime)
+    participant BR as Bedrock model
+    participant GW as AgentCore Gateway
+    participant ID as AgentCore Identity
+    participant GH as GitHub MCP server
+
+    U->>BFF: prompt
+    BFF->>RT: POST invoke, Authorization: Bearer T_user
+    Note over RT: Runtime's CUSTOM_JWT authorizer<br/>validates T_user before the handler runs
+    RT->>GW: MCP initialize + tools/list, Bearer T_user
+    Note over GW: Same authorizer config,<br/>so the same token is valid
+    GW-->>RT: cached tool schema (no auth needed)
+    RT->>BR: prompt + the tool catalogue
+    BR-->>RT: chooses a tool and its arguments
+    Note over BR: The model never receives a<br/>GitHub credential — only tool schemas
+    RT->>GW: tools/call
+    GW->>ID: token for this user + this provider?
+    alt consent granted earlier
+        ID-->>GW: GitHub access token
+        GW->>GH: MCP call with the user's token
+        GH-->>GW: result
+        GW-->>RT: result
+        RT-->>BFF: answer
+    else no stored consent
+        ID-->>GW: authorization URL (no token)
+        GW-->>RT: JSON-RPC error -32042 + URL-mode elicitation
+        RT-->>BFF: "connect GitHub at <portalUrl>"
+    end
+```
+
+## Passthrough, and why it is enough here
+
+The agent forwards `T_user` to the gateway **unchanged**. The runtime and the
+gateway are configured with the same `discoveryUrl` and the same
+`allowedAudience`, so one token satisfies both authorizers.
+
+The alternative is an OBO token exchange at each hop, where the agent swaps
+`T_user` for a gateway-audienced token, so each hop's token is only usable
+against that hop. That is a real security improvement, and
+[`obo-training/3-examples/02-agent-via-gateway/`](../obo-training/3-examples/02-agent-via-gateway/)
+teaches it properly. It costs a third IdP application, an agent-actor credential
+provider, a workload identity, IAM for the token operations on the runtime role,
+and — under Okta — the token-exchange grant.
+
+Passthrough was chosen here for two reasons:
+
+1. **The subject claim has to match, and passthrough makes that structural.**
+   Consent is stored against the identity the portal authenticated, and looked
+   up against the identity the gateway resolves from the caller's token. Under
+   Entra, `sub` is a *pairwise* identifier keyed on the application a token was
+   issued for — so if those two tokens were issued for different applications,
+   the same human would have two different `sub` values, consent would bind
+   under one and be looked up under the other, and every tool call would
+   re-prompt forever. With one resource application everywhere, the two values
+   are identical by construction rather than by careful configuration.
+2. **The subject of this sample is the consent dashboard.** Adding a second
+   delegation mechanism would double the setup for a concern already covered by
+   a neighbouring sample.
+
+The user-delegated hop is still here, and it is the interesting one: the gateway
+calls GitHub **as the end user**, using a consent that user granted personally.
+
+## The `-32042` elicitation
+
+`tools/list` always works — the target was created with its schema upfront, so
+the gateway serves a cached catalogue and nobody authorizes anything to browse
+it. Only `tools/call` needs the user's GitHub token.
+
+When there is none, the gateway does not fail. It returns a **URL-mode
+elicitation** (MCP `2025-11-25`, which is why `supportedVersions` must include
+it) as a JSON-RPC error on the `tools/call` response:
+
+```json
+{
+  "jsonrpc": "2.0", "id": 3,
+  "error": {
+    "code": -32042,
+    "message": "This request requires more information.",
+    "data": { "elicitations": [ {
+      "mode": "url",
+      "elicitationId": "6c649490-…",
+      "url": "https://bedrock-agentcore.us-east-1.amazonaws.com/identities/oauth2/authorize?request_uri=urn:ietf:params:oauth:request_uri:…",
+      "message": "Please login to this URL for authorization."
+    } ] }
+  }
+}
+```
+
+`agent/agent.py` detects this and replies with the **portal** URL rather than
+the identity URL in that payload. That substitution is deliberate: the portal
+authenticates the user and calls `CompleteResourceTokenAuth` for them, whereas
+following the raw URL leaves the session binding to whoever is holding it.
+
+Detection is defensive because the elicitation's exact propagation path through
+the MCP client is not a public contract. The agent checks both places it can
+arrive — a `toolResult` recorded with `status: "error"` on the Strands message
+history, and a raised exception — and matches on the error code plus a few
+wording variants. False positives are guarded against by requiring an *error*
+status; a successful result that merely mentions the code does not trip it.
+
+If you would rather the elicitation itself carried the portal URL — so any MCP
+client, not just this agent, is driven to the portal — there is a Lambda
+RESPONSE interceptor that rewrites it at the gateway:
+[`consent-portal/README.md`](../../07-centralize-and-govern-your-ai-infrastructure/01-gateway/01-attach-targets/mcp/mcp-servers/01-configure-auth/authorization-code-flow/consent-portal/README.md).
+
+## Resources this sample creates
+
+| Resource | Created by | Notes |
+| :--- | :--- | :--- |
+| 2 IdP applications | `00_create_*_apps.py` | Gateway resource app (Entra: also the portal login client) + frontend client |
+| Gateway service role | `01_create_gateway.py` | The token operations, the identity service's OAuth secrets, CloudWatch Logs |
+| AgentCore Gateway | `01_create_gateway.py` | MCP, `CUSTOM_JWT`, `supportedVersions` includes `2025-11-25` |
+| Primary IdP credential provider | `02_create_portal.py` | `CustomOauth2`. **Must issue JWTs** |
+| Portal execution role | `02_create_portal.py` | Trust pinned to the portal ARN after creation |
+| Consent portal | `02_create_portal.py` | One gateway as its only source; `name` and `sources` are immutable |
+| GitHub credential provider | `03_create_github_provider.py` | `GithubOauth2`, outbound only |
+| Gateway target | `04_create_github_target.py` | MCP server, schema upfront, `AUTHORIZATION_CODE` |
+| AgentCore Runtime | AgentCore CLI (CDK) | Patched by `05_patch_agentcore_json.py` |
+
+## Two credential providers, one portal
+
+The distinction the API makes here is the one most worth internalising.
+
+| | Primary IdP provider | Outbound (per-target) provider |
+| :--- | :--- | :--- |
+| Answers | who the user signs in **as** | what the agent gets consent to act **on** |
+| Referenced by | `idpConfig.credentialProviderArn` on the portal | `providerArn` in a target's `credentialProviderConfigurations` |
+| Vendor constraint | must issue **JWT** access tokens (`CustomOauth2`, `CognitoOauth2`, `OktaOauth2`, `MicrosoftOauth2`, `Auth0Oauth2`, …) | any vendor, including OAuth2-only ones (`GithubOauth2`, `SlackOauth2`, `AtlassianOauth2`, …) |
+| How many | one per portal | one per downstream resource; one can back several targets |
+| In this sample | Entra ID or Okta | GitHub |
+
+GitHub is rejected as a primary IdP by construction, not by policy: it issues
+no ID token and publishes no OIDC discovery document, so portal sign-in cannot
+work with it.
+
+## Ordering, and why it is circular
+
+Each of these needs the previous one to exist, and the last two close a loop
+back to the first.
+
+1. IdP app — created with a **placeholder** redirect URI, because the portal
+   URL does not exist yet.
+2. Primary IdP credential provider — needs the app's client id and secret.
+3. Gateway — needs the discovery URL; must be JWT-authorized.
+4. Portal execution role — needs the gateway ARN for its permissions policy;
+   created with a wildcard `consent-portal/*` in its trust policy because the
+   portal ARN is not known yet.
+5. Consent portal — needs the provider, the role and the gateway. **Now**
+   `portalUrl` exists. Its hostname is derived from the **gateway** id, not the
+   portal id: `<gateway-id>.consent-portal.<region>.amazonaws.com`. Do not
+   assume its scheme either — it has been observed both with and without the
+   `https://` prefix, so normalize before building URLs from it.
+6. Back to the IdP app: register `<portalUrl>/callback`.
+7. GitHub OAuth App → outbound provider → back to the GitHub app to register
+   the `callbackUrl` the provider vends.
+8. Gateway target — needs the provider ARN and `<portalUrl>/connect/callback`.
+
+`02_create_portal.py` closes loops 4→5→6 for you (it re-puts the trust policy
+pinned to the real ARN, and registers the callback). Loop 7 needs you, because
+only you can edit a GitHub OAuth App.

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/IDP_SETUP_ENTRA.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/IDP_SETUP_ENTRA.md
@@ -1,0 +1,356 @@
+# Entra ID setup
+
+**Two** app registrations, not three — the agent forwards the caller's token to
+the gateway unchanged, so there is no separate agent identity:
+
+1. **`agentcore-consent-github-gateway`** — the *resource* app. Its application
+   GUID is the `aud` of every inbound token, validated by both the runtime and
+   the gateway. It is **also** the consent portal's login client
+   (see [detail 1](#1-every-sign-in-targets-the-same-audience)).
+2. **`agentcore-consent-github-frontend`** — the OIDC client the BFF signs users
+   into.
+
+"Resource app" is a role, not a name: in Entra terms it is the registration you
+**Expose an API** on, so other apps can request a scope *for* it. Nothing is
+literally named `ResourceApp`.
+
+> **Two ways to do this setup:**
+> - **Automated** (recommended): `python deploy/00_create_entra_apps.py`.
+>   ~30 seconds. See [Automated path](#automated-path).
+> - **Manual**: click through the Entra admin center, ~15 minutes. See
+>   [Manual path](#manual-path).
+>
+> Both produce the same result. The manual walkthrough is there for environments
+> without the Azure CLI, and for understanding what each step does.
+
+## Architecture recap
+
+`$GW` below is the **gateway app's GUID** — `GATEWAY_CLIENT_ID` in `.env`, and
+also `IDP_AUDIENCE`:
+
+```
+👤 User ──sign in──▶ …-github-frontend         (the OIDC client)
+                        │ token: aud = $GW, scp = access_as_user
+                        ▼
+                     AgentCore Runtime         (allowedAudience: $GW)
+                        │ same token, forwarded unchanged
+                        ▼
+                     AgentCore Gateway         (allowedAudience: $GW)
+
+👤 User ──sign in──▶ Consent portal ──as …-github-gateway──▶ Entra
+                        │ binds GitHub consent to this user's `sub`
+                        ▼
+                     AgentCore token vault
+```
+
+One audience, two sign-in paths. That is the whole design: because both the BFF
+and the portal request `api://$GW/access_as_user`, both tokens carry the same
+`aud` — and therefore the same `sub` — so consent granted on the portal is found
+when the gateway looks it up.
+
+Both authorizers list two spellings of that audience, `$GW` and `api://$GW`.
+Entra puts the bare GUID in `aud`, but the identifier URI is what several tools
+display, so accepting both removes a class of copy-paste mismatch.
+
+## Prerequisites
+
+- An Entra tenant where you can register apps **and grant admin consent**.
+  Application Administrator is enough to create apps; granting tenant-wide
+  consent needs Privileged Role Administrator or Global Administrator.
+- At least one active test user in the tenant. For a single-tenant registration,
+  directory membership is enough.
+- For the automated path: [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+  2.50+.
+
+---
+
+## Automated path
+
+### Step A1 — Bootstrap `.env`
+
+```bash
+cp config.example.env .env
+```
+
+Leave the Entra placeholders alone; the script fills them in.
+
+### Step A2 — Sign in and confirm the tenant
+
+```bash
+az login
+az account show --query "{tenantId: tenantId, user: user.name}"
+```
+
+If the wrong tenant comes back, re-run `az login --tenant <tenant-id>`.
+
+### Step A3 — Run the automation
+
+```bash
+python deploy/00_create_entra_apps.py          # --rotate-secrets to force new secrets
+```
+
+It performs every action in the manual path below:
+
+1. Creates `agentcore-consent-github-gateway` and
+   `agentcore-consent-github-frontend`.
+2. Sets the frontend's web redirect to `http://localhost:8000/auth/callback`.
+3. On the resource app: `identifierUris = api://<appId>`,
+   `api.requestedAccessTokenVersion = 2`, and an `access_as_user` scope.
+4. Mints a client secret for each app.
+5. Grants the frontend delegated permission to the resource app's
+   `access_as_user`, **and** the resource app the same permission on itself —
+   each with `add`, `grant` **and** `admin-consent`.
+6. Writes everything to `.env`.
+
+Idempotent: apps are reused by display name, and secrets are only minted when
+`.env` is missing them.
+
+### Step A4 — Verify
+
+```bash
+grep -E '^(IDP|TENANT_ID|GATEWAY_CLIENT_ID|PORTAL_CLIENT_ID|FRONTEND_CLIENT_ID|IDP_DISCOVERY_URL|IDP_AUDIENCE|GATEWAY_SCOPE|PORTAL_SCOPES)=' .env
+```
+
+Expect `IDP=entra`, `PORTAL_CLIENT_ID` **equal to** `GATEWAY_CLIENT_ID`, an
+`IDP_DISCOVERY_URL` containing `/v2.0/`, and `IDP_AUDIENCE` as a bare GUID.
+
+Then confirm Entra agrees:
+
+```bash
+az ad app show --id "$GATEWAY_CLIENT_ID" \
+  --query "{v:api.requestedAccessTokenVersion, uris:identifierUris, scopes:api.oauth2PermissionScopes[].value}"
+
+# a tenant-wide grant should exist for each app
+az ad app permission list-grants --id "$GATEWAY_CLIENT_ID" \
+  --filter "consentType eq 'AllPrincipals'"
+```
+
+`v` must be `2`. You are done — continue at step 3 of the
+[README quick start](README.md#quick-start).
+
+> **If `admin-consent` failed**, the script says which app needs it. Ask an
+> admin to run `az ad app permission admin-consent --id <appId>`, or use
+> App registrations → the app → API permissions → *Grant admin consent*.
+
+### Re-running and tearing down
+
+| Goal | Command |
+| :--- | :--- |
+| Re-run safely (picks up existing apps) | `python deploy/00_create_entra_apps.py` |
+| Force-rotate both client secrets | `python deploy/00_create_entra_apps.py --rotate-secrets` |
+| Delete both app registrations | `python deploy/00_delete_entra_apps.py --yes` |
+
+Run the delete **after** `deploy/teardown.py` — the resource app is the
+gateway's audience and the portal's login client, so removing it first breaks
+both in ways that look like configuration bugs.
+
+---
+
+## How the four Entra settings fit together
+
+Four values do the real work in this setup. The automation sets all four for
+you, so this section is background: read it if you are configuring by hand,
+adapting the sample to apps that already exist, or curious *why* a value is what
+it is.
+
+### 1. Every sign-in targets the same audience
+
+Under Entra the `sub` claim is a **pairwise identifier (PPID)**, not a stable
+per-user value. What it is keyed on is easy to get backwards: `sub` is pairwise
+on the **resource** the token is audienced at (`aud`), *not* on the client that
+requested it (`azp`).
+
+This matters because consent is stored under the `sub` the portal authenticated
+and looked up under the `sub` the gateway resolves. If those differed, AgentCore
+would bind consent under one identity and look it up under another, and every
+tool call would re-prompt even though the user had just consented — with nothing
+reporting an error.
+
+They do not differ here, and the reason is the shared audience: the frontend and
+the portal both request `api://<GUID>/access_as_user`, so both tokens carry
+`aud = <GUID>` and therefore the same `sub`, even though they sign in through two
+different client apps. **Verified live** — the frontend's token has
+`azp = <frontend app>` while the portal signs in as the resource app, and the two
+`sub` values are byte-identical.
+
+Practical consequence: keep `GATEWAY_SCOPE` and `PORTAL_SCOPES` pointed at the
+**same** `api://<GUID>/...` audience. Using this app as the portal's login client
+(so `PORTAL_CLIENT_ID == GATEWAY_CLIENT_ID`) is convenient because it already
+exists and holds a secret, but it is not what makes the subjects match — the
+shared audience is. `/debug/token` prints `aud`, `azp` and `sub` side by side.
+
+### 2. Access tokens are v2 (`requestedAccessTokenVersion: 2`)
+
+With this set, Entra issues v2 access tokens. Left at the default, it issues
+v1-style tokens whose `iss` is
+`https://sts.windows.net/<tenant>/`. The gateway, the runtime and the portal all
+validate against the **`/v2.0/`** discovery document, which advertises
+`https://login.microsoftonline.com/<tenant>/v2.0`. A v1 token therefore surfaces as
+`Claim 'iss' value mismatch with configuration` or `insufficient_scope` — worth
+recognising, because both read like scope problems.
+
+```bash
+az ad app show --id "$GATEWAY_CLIENT_ID" --query "api.requestedAccessTokenVersion"   # want 2
+az ad app update --id "$GATEWAY_CLIENT_ID" --set 'api.requestedAccessTokenVersion=2'
+```
+
+**Sign out and back in after changing this.** Your BFF session still holds the
+v1 token it was issued earlier; the new setting only takes effect on the next
+authentication.
+
+### 3. `audience` is the bare GUID
+
+With v2 tokens Entra sets `aud` to the **application id**. The `api://<GUID>` form is the
+*identifier URI*, a separate string that never appears in `aud`. Give
+`idpConfig.audience` the GUID, matching what the token carries.
+
+### 4. The portal requests the *fully qualified* scope
+
+Two readers want the same permission spelled differently. The gateway reads the
+short name out of an issued token's `scp` claim. The portal and the BFF *request*
+a token, and Entra's `/authorize` only accepts
+`api://<GUID>/access_as_user`. So `PORTAL_SCOPES` and `GATEWAY_SCOPE` both carry
+the qualified form, and the gateway still matches on the short name it finds in
+`scp`.
+
+---
+
+## Manual path
+
+Produces the same result as the automation, click by click.
+
+### Step 0 — Bootstrap `.env`
+
+```bash
+cp config.example.env .env
+az login
+TENANT_ID=$(az account show --query tenantId -o tsv)
+```
+
+Keep `.env` open beside the admin center. Whenever a step says "copy X → `VAR`",
+paste it immediately rather than backtracking.
+
+### Step 1 — Register the resource app (`agentcore-consent-github-gateway`)
+
+1. **Entra admin center → App registrations → New registration**.
+2. Name `agentcore-consent-github-gateway`; supported account types **Accounts
+   in this organizational directory only**; leave Redirect URI blank.
+3. **Register**, then copy from Overview:
+   - Application (client) ID → `GATEWAY_CLIENT_ID` **and** `PORTAL_CLIENT_ID`
+     **and** `IDP_AUDIENCE`
+   - Directory (tenant) ID → `TENANT_ID`
+4. **Expose an API → Set** the Application ID URI (accept `api://<appId>`).
+5. **Add a scope**: name `access_as_user`, who can consent **Admins and users**,
+   display name "Access AgentCore as the signed-in user", **Enabled**.
+   The full string `api://<GUID>/access_as_user` → `GATEWAY_SCOPE`, and
+   `openid api://<GUID>/access_as_user` → `PORTAL_SCOPES`.
+6. **Certificates & secrets → New client secret** → copy the Value →
+   `PORTAL_CLIENT_SECRET`. (This app is the portal's login client, so this is
+   the portal's secret.)
+7. Force v2 tokens — no console field exists for this, so use the CLI:
+   ```bash
+   OBJ=$(az ad app show --id "$GATEWAY_CLIENT_ID" --query id -o tsv)
+   az rest --method PATCH --url "https://graph.microsoft.com/v1.0/applications/$OBJ" \
+     --headers "Content-Type=application/json" \
+     --body '{"api":{"requestedAccessTokenVersion":2}}'
+   ```
+8. Grant the app its own scope, so the portal's server-side login needs no
+   per-user consent screen:
+   ```bash
+   SCOPE_ID=$(az ad app show --id "$GATEWAY_CLIENT_ID" \
+     --query "api.oauth2PermissionScopes[?value=='access_as_user'].id | [0]" -o tsv)
+   az ad app permission add --id "$GATEWAY_CLIENT_ID" \
+     --api "$GATEWAY_CLIENT_ID" --api-permissions "$SCOPE_ID=Scope"
+   az ad app permission grant --id "$GATEWAY_CLIENT_ID" \
+     --api "$GATEWAY_CLIENT_ID" --scope access_as_user
+   az ad app permission admin-consent --id "$GATEWAY_CLIENT_ID"
+   ```
+   All three matter. `add` records the permission on the app registration, but
+   until `grant` creates the grant object there is nothing for Entra to
+   evaluate at token time — so you can see `admin-consent` report success and
+   still be refused a token for want of consent.
+
+Do **not** set a redirect URI yet — `<portalUrl>` does not exist until
+quick-start step 4. Do **not** mark the app a public client; it holds a secret
+and exchanges the code server-side.
+
+### Step 2 — Register the frontend app (`agentcore-consent-github-frontend`)
+
+1. **New registration**, name `agentcore-consent-github-frontend`, same account
+   types, Redirect URI **Web** → `http://localhost:8000/auth/callback`.
+   > For an `http://` redirect URI, Entra accepts only the hostname
+   > `localhost` spelled out; `127.0.0.1` and other loopback addresses are
+   > rejected.
+2. Copy Application (client) ID → `FRONTEND_CLIENT_ID`.
+3. **Certificates & secrets → New client secret** → Value →
+   `FRONTEND_CLIENT_SECRET`.
+4. Grant it the resource app's scope, and consent it:
+   ```bash
+   az ad app permission add --id "$FRONTEND_CLIENT_ID" \
+     --api "$GATEWAY_CLIENT_ID" --api-permissions "$SCOPE_ID=Scope"
+   az ad app permission grant --id "$FRONTEND_CLIENT_ID" \
+     --api "$GATEWAY_CLIENT_ID" --scope access_as_user
+   az ad app permission admin-consent --id "$FRONTEND_CLIENT_ID"
+   ```
+
+### Step 3 — Finish `.env`
+
+```bash
+IDP=entra
+TENANT_ID=<tenant id>
+GATEWAY_CLIENT_ID=<gateway app GUID>
+PORTAL_CLIENT_ID=<the same GUID>            # same audience — see detail 1
+PORTAL_CLIENT_SECRET=<gateway app secret>
+FRONTEND_CLIENT_ID=<frontend GUID>
+FRONTEND_CLIENT_SECRET=<frontend secret>
+IDP_DISCOVERY_URL=https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration
+IDP_AUDIENCE=<gateway app GUID>             # bare GUID — see detail 3
+GATEWAY_SCOPE=api://<GUID>/access_as_user   # qualified — see detail 4
+PORTAL_SCOPES=openid api://<GUID>/access_as_user
+```
+
+`deploy/02_create_portal.py` adds `<portalUrl>/callback` to the resource app's
+`web.redirectUris` once the portal exists. Note `az ad app update
+--web-redirect-uris` **replaces** the whole array, so if you ever run it by
+hand, pass every URI you need in one call.
+
+### Step 4 — Verify
+
+Walk one app at a time; switching between them mid-check is how mistakes happen.
+
+**Resource app** (`agentcore-consent-github-gateway`):
+
+- **Expose an API**: Application ID URI is `api://<GUID>`, `access_as_user` Enabled.
+- **API permissions**: its own `access_as_user` shows ✓ Granted.
+- **Manifest**: `api.requestedAccessTokenVersion` is `2`.
+- **Authentication**: after quick-start step 4, `https://<portalUrl>/callback`
+  is listed under Web — with **no trailing slash**.
+
+**Frontend app** (`agentcore-consent-github-frontend`):
+
+- **Authentication**: Web redirect `http://localhost:8000/auth/callback`.
+- **API permissions**: the resource app's `access_as_user` shows ✓ Granted.
+
+Finally, sign in through the BFF and open <http://localhost:8000/debug/token>.
+In the decoded claims: `aud` equals `GATEWAY_CLIENT_ID`, `iss` ends in `/v2.0`,
+`scp` contains `access_as_user`. Sign in to the consent portal as the **same**
+user and confirm the `sub` there matches.
+
+## Troubleshooting
+
+| `AADSTS` code | Meaning | Fix |
+| :--- | :--- | :--- |
+| `AADSTS65001` | Consent not granted | Run all three permission commands on the affected app, or re-run `00_create_entra_apps.py` |
+| `AADSTS500113` | No reply address registered | The redirect URI does not match. Check `web.redirectUris` against `PORTAL_CALLBACK_URL` / `FRONTEND_REDIRECT_URI`, exactly, no trailing slash |
+| `AADSTS7000215` | Invalid client secret | Rotate: `00_create_entra_apps.py --rotate-secrets`, then re-run `02_create_portal.py` so the provider gets the new secret |
+| `AADSTS50013` | Assertion invalid or expired | Sign out and back in |
+| `AADSTS50105` | User not assigned to the application | The test user is a guest or from another directory; use a member of this tenant |
+| `AADSTS9002313` | Malformed request | Usually a scope typo — check the fully qualified form |
+
+| Symptom | Cause | Fix |
+| :--- | :--- | :--- |
+| `Claim 'iss' value mismatch` or `insufficient_scope` | v1/v2 mismatch | Set `requestedAccessTokenVersion: 2` (detail 2), then **sign out and back in** |
+| `/?error=login_failed` right after the portal is created | Redirect URI mismatch, usually a trailing slash | Compare `az ad app show --id "$PORTAL_CLIENT_ID" --query web.redirectUris` against `PORTAL_CALLBACK_URL` |
+| A consent-required error although `admin-consent` succeeded | The explicit `az ad app permission grant` was skipped | Run `add`, `grant` **and** `admin-consent` |
+| Portal shows Connected but tool calls re-prompt | Portal user ≠ app user | Compare `sub` at `/debug/token` against the portal header |
+| Login stops working after about a year | The client secret expired (`--years 1`) | Rotate it and re-run `02_create_portal.py` |

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/IDP_SETUP_OKTA.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/IDP_SETUP_OKTA.md
@@ -1,0 +1,351 @@
+# Okta setup
+
+**Two** OIDC web apps, plus one custom scope and two access policies on a
+**custom authorization server**. There is no agent app — the agent forwards the
+caller's token to the gateway unchanged:
+
+1. **Frontend app** — the OIDC client the BFF signs users into.
+2. **Portal login app** — a *separate* confidential client the consent portal
+   signs users in as ([why it can be separate](#one-difference-from-entra-the-portal-gets-its-own-app)).
+
+> **Two ways to do this setup:**
+> - **Automated** (recommended): set `OKTA_DOMAIN` + `OKTA_ADMIN_TOKEN`, then
+>   `python deploy/00_create_okta_apps.py`. ~30 seconds. See
+>   [Automated path](#automated-path).
+> - **Manual**: click through the Okta admin console, ~15 minutes. See
+>   [Manual path](#manual-path).
+
+## Architecture recap
+
+```
+👤 User ──sign in──▶ Frontend app
+                        │ token: iss = custom AS, aud = api://default, scp = access_as_user
+                        ▼
+                     AgentCore Runtime   (authorizer: aud = api://default)
+                        │ same token, forwarded unchanged
+                        ▼
+                     AgentCore Gateway   (authorizer: aud = api://default)
+
+👤 User ──sign in──▶ Consent portal ──as the portal login app──▶ Okta
+                        │ binds GitHub consent to this user's `sub`
+                        ▼
+                     AgentCore token vault
+```
+
+Both sign-ins go to the **same custom authorization server**, so both tokens
+carry the same `iss` and `aud`. Okta's `sub` is stable per user, so consent binds
+under the identity the gateway later resolves.
+
+## Prerequisites
+
+- An Okta org with **API Access Management** — the paid add-on that provides
+  custom authorization servers. Without it this variant cannot work; use Entra ID
+  instead. See [detail 2](#2-a-custom-authorization-server).
+- An admin API token: Okta admin → **Security → API → Tokens → Create Token**,
+  minted by an Org or Super Admin. Used only by the setup scripts and by
+  quick-start step 4's callback registration — never at runtime.
+- A test user you can sign in as, assigned to both apps.
+
+---
+
+## Automated path
+
+### Step A1 — Find your domain and authorization server
+
+**`OKTA_DOMAIN`** is the app-facing host — your admin console URL **without**
+`-admin`:
+
+| Admin URL | `OKTA_DOMAIN` |
+| :--- | :--- |
+| `https://integrator-1234567-admin.okta.com/admin/dashboard` | `integrator-1234567.okta.com` |
+| `https://dev-987654.okta.com/admin/dashboard` | `dev-987654.okta.com` |
+
+The scripts normalise a pasted scheme, a trailing slash, and the `-admin` host,
+but OIDC discovery is only served from the app-facing host.
+
+**`OKTA_AUTH_SERVER_ID`**: Okta admin → **Security → API → Authorization
+Servers**. Take the last path segment of the **Issuer URI** column —
+`…/oauth2/default` → `default`; `…/oauth2/ausXXXX` → `ausXXXX`. Note the
+**Audience** too (usually `api://default`).
+
+> The built-in server answers to *both* `default` and its literal `aus…` id.
+> Either works; copy the Issuer URI's segment and don't switch later. Mixing the
+> two forms is [detail 1](#1-one-spelling-of-the-authorization-server-everywhere).
+
+> **Table empty?** Some newer Integrator tenants ship without one. Create it:
+> *Add Authorization Server*, name `default`, audience `api://default`. If the
+> option is missing entirely, your org lacks API Access Management.
+
+### Step A2 — Verify the discovery document *before* creating anything
+
+```bash
+curl -s "https://<OKTA_DOMAIN>/oauth2/<OKTA_AUTH_SERVER_ID>/.well-known/openid-configuration" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['issuer']); print(d['scopes_supported'])"
+```
+
+You want an `issuer` containing `/oauth2/<id>`. Interpret failures:
+
+| What you get | Meaning |
+| :--- | :--- |
+| Valid JSON, issuer contains `/oauth2/…` | Correct — proceed |
+| Issuer is the bare domain | You hit the **org** server — see [detail 2](#2-a-custom-authorization-server) |
+| A sign-in page | You used the `-admin` host |
+| 404 | Wrong auth server id, or none exists |
+
+Do not proceed until this returns valid JSON.
+
+### Step A3 — Configure and run
+
+```bash
+cp config.example.env .env
+# set in .env:
+#   OKTA_DOMAIN=integrator-1234567.okta.com
+#   OKTA_ADMIN_TOKEN=00...
+#   OKTA_AUTH_SERVER_ID=default
+python deploy/00_create_okta_apps.py          # --rotate-secrets to force new secrets
+```
+
+It performs every action in the manual path:
+
+1. Verifies the authorization server and captures its audience.
+2. Creates the `access_as_user` custom scope (`consent: IMPLICIT`, published).
+3. Creates both web apps — `client_secret_basic`, `authorization_code` +
+   `refresh_token` — the frontend with the localhost redirect, the portal login
+   app with a **placeholder** redirect that quick-start step 4 replaces.
+4. Assigns both to the built-in **Everyone** group.
+5. Mints a client secret for each.
+6. Creates one access policy + `ACTIVE` rule per app, admitting
+   `authorization_code` with `openid profile email access_as_user`.
+7. Writes everything to `.env`.
+
+Re-runs are safe: apps, scope and policies are looked up by name.
+
+### Step A4 — Confirm the apps are assigned to users
+
+The script assigns the **Everyone** group where the API allows it.
+
+- **Success**: output shows `✓ Assigned … to Everyone`. Nothing more to do.
+- **Warning**: output shows `⚠ 'Everyone' group not found` or an assign failure.
+  Assign manually: Okta admin → **Applications** → the app → **Assignments** →
+  *Assign → Assign to People* (or *to Groups → Everyone*).
+
+**How you'll know if it was skipped:** sign-in fails with Okta's error page,
+*"User is not assigned to the client application."*
+
+> **Federation Broker Mode.** On some newer Integrator tenants every user can
+> reach every app without an explicit assignment, so this call has nothing to do
+> and may be rejected outright. Treat successful sign-in as the real test.
+
+### Step A5 — Verify
+
+```bash
+grep -E '^(IDP|OKTA_DOMAIN|OKTA_AUTH_SERVER_ID|PORTAL_APP_ID|FRONTEND_CLIENT_ID|PORTAL_CLIENT_ID|IDP_DISCOVERY_URL|IDP_AUDIENCE|GATEWAY_SCOPE|PORTAL_SCOPES)=' .env
+```
+
+Expect `IDP=okta`, an `IDP_DISCOVERY_URL` whose path segment matches
+`OKTA_AUTH_SERVER_ID` exactly, `IDP_AUDIENCE=api://default`, and
+`GATEWAY_SCOPE=access_as_user` (short form — Okta uses one spelling end to end).
+
+You are done — continue at step 3 of the
+[README quick start](README.md#quick-start).
+
+### Re-running and tearing down
+
+| Goal | Command |
+| :--- | :--- |
+| Re-run safely | `python deploy/00_create_okta_apps.py` |
+| Force-rotate both client secrets | `python deploy/00_create_okta_apps.py --rotate-secrets` |
+| Delete both apps | `python deploy/00_delete_okta_apps.py --yes` |
+| Also delete this sample's two access policies | `python deploy/00_delete_okta_apps.py --yes --policies` |
+
+Run these **after** `deploy/teardown.py`. The `access_as_user` scope is left in
+place either way, since an authorization server is usually shared.
+
+---
+
+## How the four Okta settings fit together
+
+Four values do the real work in this setup. `00_create_okta_apps.py` sets all
+four for you, so this section is background: read it if you are configuring by
+hand, adapting the sample to an authorization server that already exists, or
+curious *why* a value is what it is.
+
+### 1. One spelling of the authorization server, everywhere
+
+The built-in custom authorization server answers to **two** path segments — the
+alias `default` and its literal id (`aus…`):
+
+```
+https://<domain>/oauth2/default/.well-known/openid-configuration
+https://<domain>/oauth2/aus1a2b3c4d5EXAMPLE/.well-known/openid-configuration
+```
+
+Both return HTTP 200, and both report the *same* `issuer`
+(`https://<domain>/oauth2/default`) — verified live. So for **token validation**
+they are equivalent, which is exactly what makes the failure confusing.
+
+The **consent portal** treats them differently: it compares the gateway
+authorizer's `discoveryUrl` against the IdP credential provider's as *strings*,
+so the two need the same spelling. Verified by testing all four combinations of
+(provider form × gateway form) — matching pairs work; a mismatch fails closed
+with `login_unavailable`, an error that says nothing about the cause.
+
+`00_create_okta_apps.py` therefore keeps **the segment you configured** in
+`OKTA_AUTH_SERVER_ID` and builds every URL from it, using the resolved id only
+for Admin API calls. Both legs read that one `IDP_DISCOVERY_URL`, so they agree
+by construction. Only hand-editing one side breaks it.
+
+### 2. A *custom* authorization server
+
+A **custom** authorization server issues verifiable JWTs, which is what the
+gateway's JWT authorizer and the consent portal both need. Okta's **org** server
+(`https://<domain>/.well-known/…`) issues **opaque** access tokens instead, and
+cannot host a custom audience or scope, so `CreateConsentPortal` does not accept
+it.
+
+A **custom** server (`https://<domain>/oauth2/<AS_ID>/…`) issues verifiable JWTs.
+The built-in one is named `default`; it exists only on orgs with **API Access
+Management**.
+
+### 3. The access policy admits `openid`
+
+The consent portal always requests `openid` **in addition to** whatever is in
+`PORTAL_SCOPES`, so every scope it requests needs to be defined on the
+authorization server *and* admitted by that client's access-policy rule. When
+one is missing, `/authorize` returns a policy-evaluation error that does not name
+it.
+
+Two things to know: a brand-new custom authorization server has **no policy at
+all**, and an **Inactive** policy is silently skipped during evaluation.
+
+### 4. Users are assigned to both apps
+
+Okta issues a token only to users assigned to the application, so assign every
+user who will sign in — to **both** apps. An unassigned user sees
+`User is not assigned to the client application` at sign-in.
+
+### One difference from Entra: the portal gets its own app
+
+In Okta, one user carries one `sub`, and the client that asked for the token
+does not change it. A dedicated portal login app therefore authenticates people
+under the identity the gateway will resolve later, which is what lets the portal
+keep its own confidential client.
+
+Under Entra this is not true: `sub` is pairwise per resource, which is why that
+variant reuses the resource app. See
+[IDP_SETUP_ENTRA.md](IDP_SETUP_ENTRA.md#1-every-sign-in-targets-the-same-audience).
+
+---
+
+## Manual path
+
+```bash
+export OKTA_DOMAIN=integrator-1234567.okta.com     # app-facing host
+export OKTA_TOKEN=<your SSWS token>
+export AS_ID=default
+```
+
+### Step 1 — Add the custom scope
+
+Okta admin → **Security → API → Authorization Servers** → your server →
+**Scopes** → **Add Scope**:
+
+| Field | Value |
+| :--- | :--- |
+| Name | `access_as_user` |
+| Display phrase | Access AgentCore on the user's behalf |
+| Description | Allows calling the AgentCore runtime and gateway as the signed-in user. |
+| Include in public metadata | ✅ |
+| Set as a default scope | ❌ (only when explicitly requested) |
+| User consent | **Implicit** — the GitHub consent is the one that matters here |
+
+### Step 2 — Register the two web apps
+
+For **each** of `AgentCore Consent GitHub Frontend` and
+`agentcore-consent-portal-login`:
+
+1. **Applications → Create App Integration → OIDC – OpenID Connect → Web
+   Application**.
+2. Grant types: **Authorization Code** (+ **Refresh Token**).
+3. Sign-in redirect URI:
+   - frontend → `http://localhost:8000/auth/callback`
+   - portal login → `https://localhost/placeholder` (a throwaway; Okta requires
+     at least one with the auth-code grant, and quick-start step 4 replaces it)
+4. Controlled access: *Allow everyone in your organization to access*.
+5. **Save**, then General → Client Credentials → **Edit**: Client Authentication
+   = **Client secret**. Optionally check **Require PKCE as additional
+   verification** — the BFF sends `code_challenge_method=S256` regardless, so
+   this is defense in depth.
+6. Copy the **Client ID** and **client secret** →
+   `FRONTEND_CLIENT_ID`/`_SECRET` and `PORTAL_CLIENT_ID`/`_SECRET`.
+7. For the portal app, also copy its **app id** (the `0oa…` in the URL) →
+   `PORTAL_APP_ID`. Quick-start step 4 needs it to `PUT` the real redirect.
+
+> For Okta OIDC apps the app `id` and the OAuth `client_id` are normally the
+> **same** value. Both are `0oa…`, which makes them easy to confuse, but seeing
+> them equal is not a mistake.
+
+### Step 3 — One access policy per app
+
+**Access Policies → Add New Access Policy**, twice:
+
+| Policy name | Assign to | Rule |
+| :--- | :--- | :--- |
+| `Consent sample - Frontend` | the frontend app | grant **Authorization Code**; scopes `openid`, `profile`, `email`, `offline_access`, `access_as_user` |
+| `Consent sample - Portal login` | the portal login app | grant **Authorization Code**; scopes `openid`, `profile`, `email`, `access_as_user` |
+
+For each: create the policy, **Add Rule** with the grant type and scope
+checklist above, then **switch the policy status to Active** — the card starts
+**Inactive**, and an inactive policy is silently ignored (detail 3).
+
+### Step 4 — Fill in `.env`
+
+```bash
+IDP=okta
+OKTA_DOMAIN=<app-facing host>
+OKTA_ADMIN_TOKEN=<SSWS token>
+OKTA_AUTH_SERVER_ID=<the Issuer URI's last segment: default or ausXXXX>
+PORTAL_APP_ID=<the portal app's 0oa… id>
+FRONTEND_CLIENT_ID=<…>
+FRONTEND_CLIENT_SECRET=<…>
+PORTAL_CLIENT_ID=<…>
+PORTAL_CLIENT_SECRET=<…>
+IDP_DISCOVERY_URL=https://<domain>/oauth2/<AS_ID>/.well-known/openid-configuration
+IDP_AUDIENCE=api://default        # the AS `audiences` value, never the gateway URL
+GATEWAY_SCOPE=access_as_user      # short name — Okta uses one spelling
+PORTAL_SCOPES=openid access_as_user
+```
+
+### Step 5 — Verify
+
+On the authorization server:
+
+- **Scopes**: `access_as_user` listed.
+- **Access Policies**: both policies present and **Active**, each assigned to its
+  own client, each with an Authorization Code rule.
+
+On each app:
+
+- Grant types Authorization Code (+ Refresh Token); redirect URI as above;
+  client authentication = client secret.
+- **Assignments**: your test user (or Everyone).
+
+Then sign in through the BFF and open <http://localhost:8000/debug/token>:
+`aud` equals `IDP_AUDIENCE`, `iss` is the custom-AS issuer, `scp` contains
+`access_as_user`. Sign in to the consent portal as the **same** user and confirm
+the `sub` matches.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| :--- | :--- | :--- |
+| `E0000011 Invalid token provided` on every admin call | `OKTA_ADMIN_TOKEN` expired (Okta expires tokens after 30 days of inactivity), revoked, or from another org | Mint a new one: Security → API → Tokens → Create Token |
+| Script says the authorization server was not found | `OKTA_AUTH_SERVER_ID` wrong, or the org has no custom server | Re-check step A1; create one, or use Entra if API Access Management is unavailable |
+| `CreateConsentPortal` rejects the IdP provider | You pointed at the **org** server, which issues opaque tokens | Use the custom AS discovery URL (detail 2) |
+| `GET /login` → `/?error=login_unavailable` | Discovery URL forms differ between gateway and provider, **or** the portal never resolved the authorizer | Make the two byte-identical (detail 1), then `python deploy/01_create_gateway.py --okta --reapply-authorizer` |
+| `Policy evaluation failed` at `/authorize` | Policy Inactive, assigned to the wrong client, or its rule omits a requested scope — often `openid` | Activate it, check the client, add the scope (detail 3) |
+| `User is not assigned to the client application` | The user is not assigned to that app (detail 4) | Assign the user to that app |
+| `PKCE code challenge is required` | The app requires PKCE but the client did not send one | The BFF sends S256 via authlib's `client_kwargs`; restore it if you edited `auth_okta.py` |
+| `/?error=login_failed` right after the portal is created | Redirect URI mismatch, usually a trailing slash | Compare the portal app's `redirect_uris` against `PORTAL_CALLBACK_URL` |
+| 401 when the agent is invoked | `aud` ≠ `IDP_AUDIENCE`, or the runtime and the frontend use different authorization servers | Decode at `/debug/token`; confirm `OKTA_AUTH_SERVER_ID` matches on both sides |
+| `https://https://…` in a URL | `OKTA_DOMAIN` pasted with a scheme | Harmless — `okta_domain()` normalises it |

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/README.md
@@ -325,7 +325,7 @@ redirect endpoint and vends its address.
 > when GitHub refuses the `redirect_uri` — a symptom that points at the portal
 > rather than at the OAuth App.
 
-### 6. Attach the GitHub MCP server as a 3LO target
+### 6. Attach the GitHub MCP server as an authorization-code-flow target
 
 ```bash
 python deploy/04_create_github_target.py --entra
@@ -730,16 +730,30 @@ scaffolded project folder per runtime (`consentGithubAgent/`, `consentGithubOkta
   sent over plain HTTP and break the sample. Serving this anywhere other than
   localhost means terminating TLS and adding `https_only=True` to the
   `SessionMiddleware` in [`frontend/app.py`](frontend/app.py).
-- **One statement in each role uses `"Resource": "*"`** — the AgentCore Identity
-  actions (`GetWorkloadAccessToken*`, `GetResourceOauth2Token`,
-  `CompleteResourceTokenAuth`) on the gateway service role and on the portal
-  execution role. Every other statement is scoped to a specific ARN: the portal
-  role's gateway and credential-provider reads, the log-group writes, and both
-  Secrets Manager reads, which are limited to the
-  `bedrock-agentcore-identity!default/oauth2/*` path — and on the portal role
-  additionally to secrets tagged `owningService = bedrock-agentcore-identity`.
-  If your account can express those identity actions more narrowly, do so; check
-  before copying these policies into anything shared.
+- **No statement in either IAM role uses `"Resource": "*"`.** The AgentCore
+  Identity actions (`GetWorkloadAccessToken*`, `GetResourceOauth2Token`,
+  `CompleteResourceTokenAuth`) *do* support resource-level permissions, so they
+  are scoped to this account and region:
+
+  ```
+  arn:aws:bedrock-agentcore:<region>:<account>:token-vault/*
+  arn:aws:bedrock-agentcore:<region>:<account>:workload-identity-directory/*
+  ```
+
+  Both families are listed because the [service reference](https://servicereference.us-east-1.amazonaws.com/v1/bedrock-agentcore/bedrock-agentcore.json)
+  marks none of the supported resource types as required. The vault and directory
+  **ids** stay wildcarded on purpose: AgentCore owns those names and mints a
+  workload identity per runtime and gateway, so pinning today's `default` would
+  break as soon as the service picks something else. The remaining statements are
+  pinned to a single gateway, credential-provider, log-group or secret ARN, and
+  the portal role's Secrets Manager read additionally requires
+  `owningService = bedrock-agentcore-identity`.
+
+  To go further, these actions also accept condition keys —
+  `bedrock-agentcore:InboundJwtClaim/{iss,aud,sub,client_id,scope}` and
+  `bedrock-agentcore:userid` — so you can require, say, a specific token issuer
+  and audience. Not used here, because the correct values differ per tenant and a
+  wrong one fails closed in a way that is hard to diagnose from the portal.
 - **Names are user-facing.** Whatever you call the target and the outbound
   provider is what end users read on the Connections page. `github-mcp-server`
   suits a sample; outside one, choose wording that means something to the person

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/README.md
@@ -1,0 +1,746 @@
+# Managed consent dashboard: an agent reaching GitHub with the user's own authorization
+
+A deployed agent needs to read a user's private GitHub data. GitHub only issues
+user-delegated tokens through the OAuth 2.0 authorization code flow (3LO), which
+needs a browser, a consent screen, and somewhere to receive the redirect — none
+of which an agent running in a container has.
+
+This sample solves that with the **AgentCore consent portal**: a hosted,
+AWS-managed dashboard where each end user connects their own GitHub account,
+*out of band*, before or independently of any conversation with the agent. The
+agent never handles a GitHub credential, and you write no consent UI and no
+callback server.
+
+## Architecture
+
+Two independent flows that meet at the **token vault**. Consent happens once, in
+the browser, on a page AWS hosts. Every later request reads the result.
+
+```mermaid
+flowchart TB
+    U(["End user"])
+
+    subgraph consent["① Consent — out of band, once per user"]
+        direction LR
+        CP["<b>Consent portal</b><br/><i>AWS-managed, hosted</i>"]
+    end
+
+    subgraph request["② Every request afterwards"]
+        direction LR
+        BFF["<b>FastAPI BFF</b><br/><i>your code</i>"]
+        RT["<b>Strands agent</b><br/><i>on AgentCore Runtime</i>"]
+        GW["<b>AgentCore Gateway</b><br/><i>MCP, JWT inbound auth</i>"]
+    end
+
+    TV[("<b>Token vault</b><br/>AgentCore Identity")]
+    GH["<b>GitHub MCP server</b><br/>api.githubcopilot.com"]
+    BR["Bedrock model"]
+
+    U ==>|"1· sign in (Entra / Okta)"| CP
+    CP ==>|"2· Connect → authorize at GitHub"| GH
+    CP ==>|"3· CompleteResourceTokenAuth<br/>binds consent to this user"| TV
+
+    U -->|"a· sign in, then ask"| BFF
+    BFF -->|"b· user JWT as Bearer"| RT
+    RT -->|"picks a tool"| BR
+    RT -->|"c· MCP, same JWT forwarded"| GW
+    GW -->|"d· stored token for this user?"| TV
+    GW -->|"e· call GitHub as the user"| GH
+
+    classDef awsmgd fill:#ecfdf5,stroke:#4ac26b,color:#1f2328
+    classDef yours fill:#eff6ff,stroke:#54aeff,color:#1f2328
+    classDef ext fill:#f6f8fa,stroke:#8c959f,color:#1f2328
+    class CP,GW,TV awsmgd
+    class BFF,RT yours
+    class GH,BR ext
+```
+
+Green is AWS-managed, blue is code in this sample, grey is external.
+
+**1–3** is the consent leg. The portal authenticates the user against your IdP,
+walks them through GitHub's authorization, and calls `CompleteResourceTokenAuth`
+so the resulting token is bound to *that* user. You write no consent UI and no
+callback server.
+
+**a–e** is every request afterwards. One token does both inbound hops: the
+runtime and the gateway are configured with the same issuer and audience, so the
+agent forwards the caller's JWT to the gateway unchanged. At step **d** the
+gateway looks up the user's stored GitHub token; if there isn't one it returns a
+`-32042` elicitation instead of failing, and the agent replies with the portal
+link.
+
+The model's only job is choosing which GitHub tool answers the question. It
+never sees a GitHub credential: the gateway holds that, and only because the user
+granted it on the portal.
+
+For the same thing as sequence diagrams, including both consent legs and the
+`-32042` path, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+### Five identities to keep straight
+
+Most of the difficulty in this sample is telling these apart. Three live in your
+IdP and GitHub; two are AgentCore credential providers that wrap them.
+
+| Identity | Env var | What it is |
+| :--- | :--- | :--- |
+| **Resource / audience app** | `GATEWAY_CLIENT_ID` | The app every inbound token is audienced at — validated by *both* the runtime and the gateway. Under Entra it is **also** the portal's login client; under Okta the portal gets its own. |
+| **Frontend app** | `FRONTEND_CLIENT_ID` | The OIDC client the BFF signs users into. Requests `GATEWAY_SCOPE`, so the token it receives is audienced at the resource app above. |
+| **Portal login client** | `PORTAL_CLIENT_ID` | What the consent portal signs users in as. Entra: equal to `GATEWAY_CLIENT_ID` (its `sub` is pairwise per resource). Okta: a separate app (its `sub` is stable per user). |
+| **Primary IdP credential provider** | `IDP_PROVIDER_ARN` | AgentCore's wrapper around the portal login client — who the user signs in **as**. Must issue JWTs. Referenced by `idpConfig.credentialProviderArn`. |
+| **GitHub outbound provider** | `GITHUB_PROVIDER_ARN` | AgentCore's wrapper around your GitHub OAuth App — what the agent gets consent to act **on**. Referenced by the target's `providerArn`. Vends the callback URL you paste into GitHub. |
+
+The two credential providers are the pair most worth internalising: the primary
+IdP answers *who is this user*, the outbound provider answers *what may we do on
+their behalf*. GitHub can only ever be the second — it publishes no OIDC
+discovery document, so `CreateConsentPortal` rejects it as a primary IdP.
+
+## Prerequisites
+
+**Tooling**
+
+| Requirement | Why |
+| :--- | :--- |
+| Python 3.10+ | The scripts and the BFF |
+| **boto3/botocore ≥ 1.43.88** | First release whose `bedrock-agentcore-control` model carries the consent-portal operations. On anything older every call fails with `'BedrockAgentCoreControlPlaneFrontingLayer' object has no attribute 'create_consent_portal'`, which reads like a missing feature rather than a stale SDK. The scripts check and tell you. |
+| Node.js 20+ and `@aws/agentcore` (`npm install -g @aws/agentcore`) | Deploys the runtime |
+| AWS CDK 2.x (`npm install -g aws-cdk@2`) + a bootstrapped account | The AgentCore CLI deploys through CDK |
+| AWS CLI v2, one credential source | Ambiguous credentials are a common source of confusing failures |
+
+**Accounts and access**
+
+- AWS credentials that can create gateways, gateway targets, OAuth2 credential
+  providers, consent portals, IAM roles, and AgentCore runtimes.
+- Bedrock model access for Claude Sonnet 4.5 in your region.
+- A **GitHub account** that can create an [OAuth App](https://github.com/settings/developers).
+- **One identity provider**, either:
+  - **Microsoft Entra ID** — a tenant where you can register applications and
+    grant admin consent, plus the Azure CLI (`az`, ≥ 2.50) signed in. See
+    [IDP_SETUP_ENTRA.md](IDP_SETUP_ENTRA.md).
+  - **Okta** — an org with **API Access Management** (custom authorization
+    servers; the org server issues opaque tokens, which cannot work here), and
+    an admin API token. See [IDP_SETUP_OKTA.md](IDP_SETUP_OKTA.md).
+- At least one **test user** who can sign in, assigned to the apps.
+
+All commands run from this directory.
+
+> [!NOTE]
+> **Validation status.** Both variants were built and run end to end against a
+> real AWS account and real identity providers: Entra ID and Okta sign-in, portal
+> consent, and a live GitHub MCP call through the gateway using the user's own
+> authorization. The optional gateway interceptor was verified too (22
+> invocations, 2 rewrites — it fires only on the consent elicitation).
+>
+> The one hop not exercised is the **Bedrock model call**, because the test
+> account's daily token quota is zero pending a Support increase. Everything the
+> model depends on — runtime IAM, the inference profile, tool discovery — is
+> verified, so expect that to be the last mile rather than a rework.
+
+## Quick start
+
+### 1. Configure
+
+```bash
+cp config.example.env .env
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# Sanity-check the SDK floor before you create anything:
+python -c "import boto3,botocore;print(boto3.__version__,botocore.__version__)"
+```
+
+Edit `.env` and set `AWS_REGION`, `FRONTEND_SESSION_SECRET`
+(`python -c 'import secrets;print(secrets.token_hex(32))'`), and — for Okta —
+`OKTA_DOMAIN` and `OKTA_ADMIN_TOKEN`.
+
+> [!NOTE]
+> **One `.env` holds one deployment.** A single file is all you need: `IDP=` in
+> it selects the provider, and the deploy scripts write everything else they
+> resolve back into it. If you want **both** providers standing at once, give
+> each its own file — see [Running both identity providers side by
+> side](#running-both-identity-providers-side-by-side).
+>
+> `.env` and `.env.*` are gitignored; `config.example.env` is the tracked
+> template.
+
+### 2. Set up the identity provider
+
+One identity provider serves **three** inbound legs: the runtime's authorizer,
+the gateway's authorizer, and the consent portal's own sign-in.
+`CreateConsentPortal` validates that the gateway's authorizer and the portal's
+credential provider reference the **same OIDC issuer**, so they cannot drift.
+
+Each variant needs **two** applications, not three — the agent forwards the
+caller's token to the gateway unchanged, so there is no separate agent identity.
+
+Pick your provider below. Each script is idempotent, writes everything it
+resolves into `.env`, and has a manual equivalent in its `IDP_SETUP_*.md`.
+
+<details open>
+<summary><b>Microsoft Entra ID</b></summary>
+
+```bash
+az login                                   # a tenant where you can register apps
+python deploy/00_create_entra_apps.py      # add --rotate-secrets to force new secrets
+```
+
+| App it creates | Role |
+| :--- | :--- |
+| `agentcore-consent-github-gateway` | The **resource** app: the audience of every inbound token, for both the runtime and the gateway. Also the portal's login client. |
+| `agentcore-consent-github-frontend` | The OIDC client the BFF signs users in with; web redirect `http://localhost:8000/auth/callback`. |
+
+It also sets, on the resource app: `identifierUris = api://<appId>`, an
+`access_as_user` scope, `api.requestedAccessTokenVersion: 2`, a client secret,
+and that scope granted **and** admin-consented to itself.
+
+Written to `.env`: `IDP=entra`, `TENANT_ID`, `GATEWAY_CLIENT_ID`,
+`PORTAL_CLIENT_ID` (equal to `GATEWAY_CLIENT_ID`), `PORTAL_CLIENT_SECRET`,
+`FRONTEND_CLIENT_ID`, `FRONTEND_CLIENT_SECRET`, `IDP_DISCOVERY_URL`,
+`IDP_AUDIENCE`, `GATEWAY_SCOPE`, `PORTAL_SCOPES`.
+
+Three Entra specifics that fail *later* if wrong, each checked or set for you:
+
+- **`requestedAccessTokenVersion: 2`.** Without it Entra issues v1-style tokens
+  whose `iss` is `sts.windows.net`, which will not match the `/v2.0/` discovery
+  document. It surfaces as `Claim 'iss' value mismatch` or `insufficient_scope`
+  — both of which read like scope bugs.
+- **`IDP_AUDIENCE` is the bare app GUID**, not `api://<GUID>`. A v2 token's
+  `aud` holds the application id on its own; the `api://` form is the identifier
+  URI, and configuring that instead matches nothing.
+- **Scopes must be fully qualified** (`api://<GUID>/access_as_user`). Entra's
+  `/authorize` rejects the short name, even though the gateway reads the short
+  name out of the issued token's `scp`.
+
+Full detail, including the manual `az` commands: [IDP_SETUP_ENTRA.md](IDP_SETUP_ENTRA.md).
+
+</details>
+
+<details>
+<summary><b>Okta</b></summary>
+
+Set these in `.env` first — the script cannot discover them:
+
+```bash
+OKTA_DOMAIN=integrator-1234567.okta.com    # NOT the -admin hostname
+OKTA_ADMIN_TOKEN=<SSWS token>              # Security → API → Tokens → Create Token
+OKTA_AUTH_SERVER_ID=default                # a CUSTOM authorization server
+```
+
+```bash
+python deploy/00_create_okta_apps.py       # add --rotate-secrets to force new secrets
+```
+
+| App it creates | Role |
+| :--- | :--- |
+| `AgentCore Consent GitHub Frontend` | Confidential web app, authorization code, redirect `http://localhost:8000/auth/callback`. The BFF sends PKCE (S256) regardless, so you can turn on *Require PKCE* without a code change. |
+| `agentcore-consent-portal-login` | A **separate** confidential web app for the portal's sign-in, created with a placeholder redirect that step 4 replaces. |
+
+On the authorization server it adds an `access_as_user` scope and one access
+policy per app, each admitting `authorization_code` with
+`openid profile email access_as_user`.
+
+Written to `.env`: `IDP=okta`, `OKTA_AUTH_SERVER_ID`, `PORTAL_APP_ID`,
+`FRONTEND_CLIENT_ID`/`_SECRET`, `PORTAL_CLIENT_ID`/`_SECRET`,
+`IDP_DISCOVERY_URL`, `IDP_AUDIENCE`, `GATEWAY_SCOPE`, `PORTAL_SCOPES`.
+
+Four Okta specifics:
+
+- **Pick one spelling of the authorization server and keep it.** The built-in
+  server answers to both `default` and its literal `aus…` id, with the same
+  issuer — but the gateway and the portal compare discovery URLs as *strings*.
+  The script builds every URL from the `OKTA_AUTH_SERVER_ID` you set, so they
+  agree; hand-editing one side breaks sign-in with `login_unavailable`. See
+  [the callout in Troubleshooting](#troubleshooting-error-ladder).
+- **It must be a *custom* authorization server.** The org server
+  (`https://<domain>/.well-known/…`) issues **opaque** access tokens and cannot
+  host a custom audience or scope, so `CreateConsentPortal` rejects it. Custom
+  servers require the **API Access Management** feature; the built-in one is
+  named `default`, with audience `api://default`.
+- **The access policy must admit `openid`.** The portal always requests it on
+  top of `PORTAL_SCOPES`, and a scope the policy does not admit fails
+  `/authorize` with a policy error that never names the missing scope. A
+  brand-new custom server has *no* policy at all.
+- **Assign your test users to both apps.** Okta issues no token to an
+  unassigned user; sign-in fails with `User is not assigned to the client
+  application`. The script assigns the `Everyone` group where it can.
+
+Unlike Entra, the portal gets its **own** login app. Okta's `sub` is stable per
+user across client apps, so consent still binds under the identity the gateway
+later resolves.
+
+Full detail, including the manual `curl` calls: [IDP_SETUP_OKTA.md](IDP_SETUP_OKTA.md).
+
+</details>
+
+> [!NOTE]
+> Every remaining step takes the same `--entra` or `--okta` flag. It is required
+> and has no default: a guessed profile would create — or on teardown, delete —
+> resources for the wrong identity provider. Adding a provider is a new
+> `deploy/idps/<name>.json` plus a `00_create_<name>_apps.py`; nothing else
+> branches on the IdP.
+
+### 3. Create the gateway
+
+```bash
+python deploy/01_create_gateway.py --entra
+```
+
+MCP protocol, `CUSTOM_JWT` inbound auth over your IdP's discovery URL.
+
+### 4. Create the consent portal
+
+```bash
+python deploy/02_create_portal.py --entra
+```
+
+Creates the primary IdP credential provider, the execution role, and the
+portal; polls until `ACTIVE`; then registers `https://<portalUrl>/callback` on
+your IdP app for you.
+
+**Checkpoint A.** Open the printed portal URL and sign in. You should land back
+on the portal with an **empty Connections page**. Empty is the result you want
+at this stage — you have not attached a target that needs authorization, so the
+portal has nothing to offer. Reaching this screen at all exercises the entire
+identity chain: the IdP app, the discovery URL, the scopes, the audience, the
+gateway authorizer, and the callback registration.
+
+### 5. Create the GitHub OAuth App and its credential provider
+
+Create an [OAuth App](https://github.com/settings/developers) with any
+placeholder callback URL, then:
+
+```bash
+export GITHUB_CLIENT_ID="…"
+export GITHUB_CLIENT_SECRET="…"
+python deploy/03_create_github_provider.py --entra
+```
+
+The script prints a `callbackUrl`. **Copy it into your GitHub OAuth App's
+Authorization callback URL before continuing.** The value is not yours to pick:
+the code-for-token exchange happens inside AgentCore, so AgentCore hosts the
+redirect endpoint and vends its address.
+
+> This paste is easy to postpone and expensive to forget. Step 6 will succeed
+> without it and the target will report `READY`, because nothing validates the
+> GitHub side until someone actually authorizes. You find out at **Connect**,
+> when GitHub refuses the `redirect_uri` — a symptom that points at the portal
+> rather than at the OAuth App.
+
+### 6. Attach the GitHub MCP server as a 3LO target
+
+```bash
+python deploy/04_create_github_target.py --entra
+```
+
+### 7. Consent, as a user
+
+Open the portal again. A **GitHub** row appears on the Connections page; choose
+**Connect**, authorize at GitHub, and you are returned to
+`/connect/callback`, where the portal calls `CompleteResourceTokenAuth` to bind
+that consent to *you*.
+
+**Checkpoint B.** The row shows as connected. That proves all three URLs below
+are right — which is most of the difficulty in this sample.
+
+> Expect a delay before a new target shows up — that list comes from a cache
+> with a lifetime of roughly **5 minutes**. Seeing nothing immediately after
+> step 6 is normal, so wait the full five before you go looking for a fault.
+
+### 8. Deploy the agent
+
+```bash
+agentcore create --name "$AGENT_RUNTIME_NAME" --project-name "$AGENT_RUNTIME_NAME" \
+  --framework Strands --model-provider Bedrock --memory none \
+  --build CodeZip --language Python --defaults
+
+# The agent replaces the scaffold's entrypoint.
+cp agent/agent.py "$AGENT_RUNTIME_NAME"/app/"$AGENT_RUNTIME_NAME"/main.py
+
+python deploy/05_patch_agentcore_json.py --entra
+
+cd "$AGENT_RUNTIME_NAME"
+agentcore validate && agentcore deploy -y -v
+agentcore status          # copy the invoke URL
+cd ..
+```
+
+> [!NOTE]
+> Only `main.py` is copied. The scaffold manages dependencies in
+> `app/<name>/pyproject.toml` (with a `uv.lock`), not a `requirements.txt`, and
+> it already declares everything the agent imports — `bedrock-agentcore`,
+> `strands-agents` and `mcp`. [`agent/requirements.txt`](agent/requirements.txt)
+> is kept as documentation of that dependency set; you do not copy it in.
+> Verified against AgentCore CLI 0.25.0.
+
+Put the invoke URL in `.env` as `AGENT_RUNTIME_INVOKE_URL` **with
+`?qualifier=DEFAULT` appended** — without the qualifier every invoke returns
+`404 UnknownOperationException`. The URL that `agentcore status` prints has the
+runtime ARN percent-encoded in its path; copy it verbatim and append the
+qualifier.
+
+Optionally: `python deploy/06_enable_observability.py --entra` sets log
+retention and prints the debugging queries.
+
+### 9. Run the frontend
+
+```bash
+python frontend/app.py    # http://localhost:8000
+```
+
+Sign in as the same user who consented, and ask something like *"Search GitHub
+for amazon-bedrock-agentcore-samples and summarize the top result."*
+
+**Checkpoint C.** You get real GitHub results. That proves consent is bound to
+the same identity the gateway resolves from your token.
+
+### Optional: steer *every* client to the portal (gateway interceptor)
+
+By default the consent substitution happens in **agent code**: `agent/agent.py`
+catches the `-32042` elicitation and replies with the portal URL. That covers
+this sample's agent and nothing else. Any other MCP client on the same gateway —
+the [MCP Inspector](../../07-centralize-and-govern-your-ai-infrastructure/01-gateway/05-community/gateway-mcp-inspector/),
+a coding agent, a colleague's script — still receives the raw AgentCore Identity
+authorize URL, and following that directly bypasses the portal's session
+binding.
+
+To move the substitution into the gateway instead, so it applies to every
+client:
+
+```bash
+python deploy/07_deploy_interceptor.py --entra
+```
+
+That deploys a Lambda [RESPONSE interceptor](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-interceptors.html)
+([`deploy/lambda/interceptor.py`](deploy/lambda/interceptor.py)) which rewrites
+`body.error.data.elicitations[*].url` on a `-32042` response. A gateway supports
+at most one RESPONSE interceptor.
+
+| Flag | Effect |
+| :--- | :--- |
+| *(default)* | `--mode rewrite` — inject the portal URL |
+| `--mode log-only` | pass through, but log the whole event. Use this if the rewrite stops matching and you need to see the payload shape. |
+| `--remove` | detach and delete the Lambda and its role |
+
+#### Configuration you can change
+
+All optional, all in `.env`, all defaulted to something that works. Set none of
+them and the interceptor behaves exactly as described above.
+
+| Variable | Default | Why you would change it |
+| :--- | :--- | :--- |
+| `INTERCEPTOR_TARGET_URL` | `PORTAL_URL` | **The most useful one.** Send users to your own landing page instead of straight to the portal — somewhere you can explain what is about to happen, or add a support link. The portal still gathers the consent; this only changes the first hop the user sees. |
+| `INTERCEPTOR_PASS_REQUEST_HEADERS` | `false` | `true` lets the interceptor read request headers. Needed only if you extend the handler to branch on the caller. Leaving it false keeps the caller's JWT out of the interceptor event, and out of CloudWatch in `log-only` mode. |
+| `INTERCEPTOR_IDENTITY_URL_HOST` | `bedrock-agentcore` | The guard deciding which URLs may be rewritten. Widen it only if you know why; it is what stops the handler touching an unrelated URL in an elicitation. |
+| `INTERCEPTOR_LOG_RETENTION_DAYS` | unset (never expire) | Set it. Lambda creates the log group with no expiry, so interceptor logs otherwise accumulate for the life of the account. |
+| `INTERCEPTOR_TIMEOUT_SECONDS` | `10` | The gateway waits on this Lambda on **every** response, so it bounds your tail latency. Keep it small — measured execution is 2–17 ms. |
+| `INTERCEPTOR_MEMORY_MB` | `128` | Measured usage is ~37 MB, so 128 is already generous. |
+| `INTERCEPTOR_RUNTIME` | `python3.12` | Pin to whatever your org standardises on. |
+| `INTERCEPTOR_LAMBDA_NAME` | `<idp>-consent-jit-interceptor` | Match your own naming convention. |
+| `INTERCEPTOR_ROLE_NAME` | `<Idp>ConsentInterceptorRole` | Same. |
+
+Changing any of them is just another run of the script — it updates the existing
+Lambda and re-applies the gateway wiring in place:
+
+```bash
+# e.g. keep 14 days of logs and interpose your own landing page
+echo 'INTERCEPTOR_LOG_RETENTION_DAYS=14' >> .env
+echo 'INTERCEPTOR_TARGET_URL=https://intranet.example.com/connect-github' >> .env
+python deploy/07_deploy_interceptor.py --entra
+```
+
+Two things that are **not** configurable, deliberately. The interception point is
+`RESPONSE` only, because a REQUEST interceptor cannot see the elicitation. And
+the rewrite targets `body.error.data.elicitations[*].url` on error code `-32042`;
+if that payload ever changes shape, the handler logs a warning that it matched
+nothing rather than silently passing the raw URL through, and `--mode log-only`
+is how you inspect the new shape.
+
+Three details worth knowing:
+
+- It runs with `passRequestHeaders: false`. The rewrite needs only the response
+  body, so the caller's JWT never enters the interceptor event — or CloudWatch.
+- A host guard means it only replaces URLs containing `bedrock-agentcore`; it
+  will not touch an unrelated URL that happens to appear in an elicitation.
+- `UpdateGateway` is a **full replace**. The script reads the gateway back and
+  re-sends `protocolConfiguration`, because dropping it would silently reset
+  `supportedVersions` and disable URL-mode elicitation — the very thing the
+  interceptor exists to handle.
+
+Agent-side and gateway-side handling compose safely — verified, not assumed. The
+interceptor rewrites only the URL; the `-32042` code and its message survive, so
+the agent still recognises the elicitation and still renders its own portal
+message. Both layers agree on the destination, and neither has to know about the
+other. What changes is that clients *other* than this agent now get the portal
+URL too.
+
+### 10. See the unconsented path
+
+**Sign in as a second IdP user who has not consented**, and make the same call.
+Consent is stored per user, so a colleague's first request hits the unconsented
+path while yours keeps working — which is also the honest way to demonstrate it.
+
+Instead of an error you get the portal URL and an explanation: the gateway
+returned `-32042` and the agent translated it. Confirm in the logs:
+
+```bash
+cd "$AGENT_RUNTIME_NAME" && agentcore logs --since 10m --query "CONSENT_REQUIRED"
+```
+
+Have that user Connect on the portal, ask again, and it works.
+
+> [!NOTE]
+> The portal's Connections page shows **Connect** for an unconnected provider,
+> but once connected its Action column is empty — there is **no Disconnect
+> button** to undo it from the UI. Nor is there a revoke API: the data plane has
+> no delete-token operation (see the full op list via
+> `list(boto3.client("bedrock-agentcore").meta.service_model.operation_names)`).
+> So do not plan a demo around toggling one user's consent off and on. Use a
+> second user, or reset the stored grant by deleting the gateway target and its
+> credential provider and recreating them (in that order — a provider still
+> referenced by a target cannot be deleted).
+
+## Sample prompts
+
+Ask these at <http://localhost:8000> once you are signed in and connected. The
+target ships with 44 GitHub tools ([`gateway/github-tools.json`](gateway/github-tools.json)),
+and the model picks which one answers the question.
+
+| Prompt | Exercises |
+| :--- | :--- |
+| `Search GitHub for amazon-bedrock-agentcore-samples and summarize the top result.` | `search_repositories` — the default prompt, and the lightest read |
+| `Who am I on GitHub?` | `get_me` — the clearest proof the call runs as *you*, not as a service identity |
+| `List my open pull requests.` | `search_pull_requests` against your own account |
+| `What are the 5 most recent commits on the main branch of awslabs/agentcore-samples?` | `list_commits` |
+| `Read the README of awslabs/agentcore-samples and tell me what folder 05 covers.` | `get_file_contents` |
+
+`Who am I on GitHub?` is the one to demo. Two people asking it get two different
+answers from the same agent, the same gateway and the same target — which is the
+whole point of per-user consent.
+
+Before consenting (or as a user who has not), any of these returns the portal
+prompt instead of data — see [step 10](#10-see-the-unconsented-path).
+
+## Running both identity providers side by side
+
+The AWS resources for two providers coexist without conflict — every name is
+IdP-prefixed (`entra-consent-github-gw` vs `okta-consent-github-gw`, and so on).
+What does *not* coexist is `.env`: it is a single flat namespace, so a second
+run would overwrite the first's `GATEWAY_ID`, `PORTAL_ID` and the rest.
+
+Give each deployment its own state file with `CONSENT_ENV_FILE`, honoured by
+every deploy script and by the frontend:
+
+```bash
+# Entra (the default file)
+python deploy/01_create_gateway.py --entra
+python frontend/app.py
+
+# Okta, side by side
+export CONSENT_ENV_FILE=.env.okta
+python deploy/00_create_okta_apps.py
+python deploy/01_create_gateway.py --okta
+CONSENT_ENV_FILE=.env.okta python frontend/app.py
+```
+
+Three things to get right when doing this:
+
+- **Give each an `AGENT_RUNTIME_NAME` of its own** (e.g. `consentGithubAgent`
+  and `consentGithubOkta`). The name becomes the CDK stack, so reusing it would
+  redeploy over the first runtime. Each also gets its own scaffolded project
+  folder, and `agentcore/aws-targets.json` inside it pins the target account.
+- **Use a separate GitHub OAuth App per provider.** Each variant's credential
+  provider vends its own callback URL, and a GitHub OAuth App accepts only one —
+  so sharing an app means whichever you registered last is the only one that can
+  complete Connect.
+- **Only one frontend can hold port 8000.** Stop the other, or change
+  `FRONTEND_PORT` *and* register the matching redirect URI with that provider.
+
+Sessions do not leak between them: the frontend stamps each session with a
+deployment id and drops one minted by the other deployment, rather than leaving
+you apparently signed in with a token the other runtime would reject.
+
+## Three URLs, none interchangeable
+
+Getting these confused is the single most common way this setup fails, and
+every failure presents as something else.
+
+| URL | Registered with | Set in | Purpose |
+| :--- | :--- | :--- | :--- |
+| `https://<portalUrl>/callback` | the **primary IdP app** (Entra: the gateway resource app; Okta: the portal login app) | step 4, automatically | where the **IdP** returns the user after portal sign-in |
+| `https://<portalUrl>/connect/callback` | nobody — it is the target's `defaultReturnUrl` | step 6 | where the **outbound provider** returns the user, binding consent to their session |
+| `https://bedrock-agentcore.<region>.amazonaws.com/identities/oauth2/callback/<uuid>` | the **GitHub OAuth App** | step 5, by you | where the authorization **code** is delivered |
+
+No trailing slashes. A trailing slash on the first one makes the IdP treat the
+callback as unregistered, and the failure surfaces as a generic login error.
+
+## Troubleshooting (error ladder)
+
+| Symptom | Cause | Fix |
+| :--- | :--- | :--- |
+| `object has no attribute 'create_consent_portal'` | boto3/botocore older than 1.43.88 | `pip install -U 'boto3>=1.43.88'`; the scripts also check and tell you |
+| Connections page is empty right after step 6 | That list is served from a cache with a lifetime of about 5 minutes | Give it the full 5 minutes before you start debugging |
+| `GET /login` → `/?error=login_unavailable` | The portal could not resolve the gateway's authorizer, **or** the two `discoveryUrl` values differ | `python deploy/01_create_gateway.py --<idp> --reapply-authorizer`; if that does not fix it, make the two discovery URLs byte-identical (see below) |
+| `CreateConsentPortal` rejects the gateway | Gateway inbound auth is not JWT, or its issuer differs from the portal's IdP provider | Both must read the same `IDP_DISCOVERY_URL`; re-run step 01 then step 02 |
+| `CreateConsentPortal` rejects the IdP provider | That vendor issues opaque tokens — GitHub, Slack, Salesforce, Atlassian, LinkedIn can never be the primary IdP | Use a JWT-issuing IdP; those vendors are outbound-only |
+| Portal create retries "execution role not assumable yet" | Normal IAM eventual consistency | Nothing — the script retries for you |
+| `/?error=login_failed` right after step 4 | Redirect URI mismatch, most often a trailing slash | Compare the IdP app's redirect URIs against `PORTAL_CALLBACK_URL` exactly |
+| `invalid_scope`, or Okta `Policy evaluation failed`, at `/authorize` | A requested scope is not defined or not permitted — **including `openid`** | Add it to the IdP app (Entra) or the AS access-policy rule (Okta). Entra also needs the fully qualified `api://<GUID>/access_as_user` |
+| Entra `insufficient_scope`, or `Claim 'iss' value mismatch` | Discovery URL is not the `/v2.0/` one, or the app lacks `requestedAccessTokenVersion: 2` | Re-run `deploy/00_create_entra_apps.py`, which sets both |
+| Entra consent-required error although `admin-consent` succeeded | `az ad app permission grant` was skipped, so the permission is recorded on the app but no grant object backs it | Run all three commands in order: `add`, `grant`, `admin-consent` |
+| Okta `E0000011 Invalid token provided` on every admin call | `OKTA_ADMIN_TOKEN` expired (30 days of inactivity) or came from another org | Mint a new one: Security → API → Tokens → Create Token |
+| Okta `https://https://…` in a URL | `OKTA_DOMAIN` pasted with a scheme | Harmless now — `okta_domain()` normalises scheme, trailing slash and the `-admin` host |
+| **Connect** succeeds but tool calls still ask for consent | The portal user and the app user are different accounts | Compare `sub` at `/debug/token` against the id in the portal header |
+| Consent appears to do nothing | The target's `defaultReturnUrl` is not exactly `<portalUrl>/connect/callback` | Re-run step 06; it warns when an existing target disagrees |
+| GitHub rejects `redirect_uri` at **Connect** | The vended `callbackUrl` from step 05 was never pasted into the GitHub OAuth App | Paste it at github.com/settings/developers — one app per variant |
+| No consent screen on reconnect | GitHub does not re-prompt an already-authorized OAuth App | Revoke it under your GitHub authorized apps to see the prompt again |
+| A consent flow resumed after a break fails | Authorization URLs and session URIs live 10 minutes | Start over rather than debugging it |
+| Signed in as the wrong user, or a 403 after switching IdPs | A session cookie from the other deployment | The frontend drops foreign sessions now; an older cookie needs one visit to `/auth/logout` |
+| `404 UnknownOperationException` from the agent | `AGENT_RUNTIME_INVOKE_URL` missing `?qualifier=DEFAULT` | Append it |
+| 401 from the gateway during MCP init | Runtime and gateway `allowedAudience` disagree — the passthrough contract is broken | Re-run `deploy/05_patch_agentcore_json.py` and redeploy |
+| Bedrock `ThrottlingException: Too many tokens per day` | The account's daily token quota is zero (common on new accounts) | Raise it via Support for **every** region the cross-region inference profile spans |
+| Bedrock `Model use case details have not been submitted` | Anthropic's one-time first-time-use form | Bedrock console → Model catalog → an Anthropic model, or `PutUseCaseForModelAccess` |
+| `agentcore deploy` → `Could not assume role … in <other account>` | `<name>/agentcore/aws-targets.json` pins the account from the first deploy | Repoint it and reset `agentcore/.cli/deployed-state.json` |
+| `400` on every portal request | The `Host` header is not a valid FQDN | Use `portalUrl` exactly as returned |
+| `aws bedrock-agentcore-control get-consent-portal` → `Found invalid choice` | Your AWS CLI bundles its own botocore, older than the consent-portal model | Use the venv's Python, or upgrade the CLI |
+| `GetConsentPortal` → constraint violation on the identifier | It takes the portal **id** (`<name>-<10 chars>`) or ARN, not the name | Get the id from `ListConsentPortals` |
+
+Portal authorization **fails closed** and its errors are deliberately
+non-diagnostic — a deny and an unreachable dependency look identical from
+outside. Read your configuration, not the error string.
+
+> [!IMPORTANT]
+> **The two `discoveryUrl` values must match exactly.** The gateway's
+> `customJWTAuthorizer.discoveryUrl` and the portal IdP credential provider's
+> `oauthDiscovery.discoveryUrl` are compared as strings, not by resolved issuer.
+>
+> With Okta this bites easily, because a custom authorization server answers on
+> **both** `…/oauth2/default/.well-known/openid-configuration` and
+> `…/oauth2/<AS_ID>/.well-known/openid-configuration` — same HTTP 200, same
+> `issuer` — yet mixing the two forms across the gateway and the provider makes
+> the portal fail closed with `login_unavailable`. Verified by putting the pair
+> through all four combinations.
+>
+> The scripts derive both from a single `IDP_DISCOVERY_URL`, so they agree by
+> construction. If you hand-edit one side, change the other too and re-run
+> step 01.
+
+## Teardown
+
+Reverse order. The runtime first, because it is a CDK stack:
+
+```bash
+cd "$AGENT_RUNTIME_NAME"
+agentcore remove agent --name "$AGENT_RUNTIME_NAME" -y && agentcore deploy -y -v
+cd ..
+
+python deploy/teardown.py --entra --clean-env
+python deploy/00_delete_entra_apps.py --yes     # optional
+```
+
+`teardown.py` deletes the targets, the GitHub provider, the portal (**waiting
+for that delete to finish** — removing its IdP provider or execution role from
+under a still-`DELETING` portal is how you get a stuck delete), then the IdP
+provider, the roles and the gateway. It verifies and reports survivors; some
+AgentCore deletes are async, so re-run it if it complains. `--verify-only`
+checks without deleting.
+
+Your GitHub OAuth App is yours to delete at
+<https://github.com/settings/developers>.
+
+## Repository layout
+
+```
+07-consent-portal-auth-code-flow-targets/
+├─ README.md                     # this file — quick start, troubleshooting, teardown
+├─ ARCHITECTURE.md               # sequence diagrams: both consent legs, the -32042 path
+├─ IDP_SETUP_ENTRA.md            # Entra setup, automated + manual, and why each value
+├─ IDP_SETUP_OKTA.md             # Okta setup, automated + manual (custom AS, policies)
+├─ config.example.env            # tracked template; copy to .env
+├─ requirements.txt              # deploy scripts + the BFF
+│
+├─ deploy/                       # numbered, idempotent, each takes --entra | --okta
+│  ├─ _common.py                 #   .env state, IdP profile loading, boto3 floor check
+│  ├─ idps/entra.json            #   IdP *shape* (vendor, discovery-URL rule); values live in .env
+│  ├─ idps/okta.json
+│  ├─ 00_create_entra_apps.py    #   2 Entra apps, scopes, v2 tokens, admin consent
+│  ├─ 00_create_okta_apps.py     #   2 Okta apps, custom scope, access policies
+│  ├─ 00_delete_*_apps.py        #   IdP teardown (run last)
+│  ├─ 01_create_gateway.py       #   service role + CUSTOM_JWT gateway (+ --reapply-authorizer)
+│  ├─ 02_create_portal.py        #   IdP provider + exec role + CreateConsentPortal + callback
+│  ├─ 03_create_github_provider.py #  GithubOauth2 provider; prints the callback to paste
+│  ├─ 04_create_github_target.py #   MCP target, schema upfront, AUTHORIZATION_CODE
+│  ├─ 05_patch_agentcore_json.py #   runtime inbound JWT + env vars
+│  ├─ 06_enable_observability.py #   log retention + debugging queries
+│  ├─ 07_deploy_interceptor.py   #   OPTIONAL: gateway-wide elicitation rewrite
+│  ├─ lambda/interceptor.py      #   the RESPONSE interceptor handler
+│  └─ teardown.py                #   reverse-order delete + verify (--clean-env)
+│
+├─ agent/
+│  ├─ agent.py                   # Strands agent; forwards the caller's JWT, handles -32042
+│  └─ requirements.txt           # documents the dependency set (the CLI scaffold owns deps)
+│
+├─ frontend/                     # FastAPI BFF — one app, one adapter per IdP
+│  ├─ app.py                     #   routes, session, agent invocation (IdP-agnostic)
+│  ├─ auth_entra.py              #   MSAL confidential client
+│  ├─ auth_okta.py               #   authlib, auth code + PKCE
+│  └─ templates/                 #   base, home (with the demo diagram), result, token
+│
+└─ gateway/
+   └─ github-tools.json          # GitHub MCP tool schema, supplied upfront to the target
+```
+
+Generated at deploy time and gitignored: `.env` (and `.env.*`), `.venv/`, and one
+scaffolded project folder per runtime (`consentGithubAgent/`, `consentGithubOkta/`).
+
+## Documentation
+
+- [Consent portal overview](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-consent-portal.html)
+  · [prerequisites](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-consent-portal-prerequisites.html)
+  · [execution role](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-consent-portal-execution-role.html)
+  · [configuring a target](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-configure-consent-portal-target.html)
+- [OAuth 2.0 authorization URL session binding](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/oauth2-authorization-url-session-binding.html)
+  and [`CompleteResourceTokenAuth`](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_CompleteResourceTokenAuth.html)
+- [Gateway outbound auth](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-outbound-auth.html)
+  and [adding gateway targets](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets.html)
+- [Outbound credential providers](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-outbound-credential-provider.html)
+
+## Security notes
+
+- **Client secrets** are read from the environment or prompted for with
+  `getpass`, never taken on the command line, and never printed. They land in
+  `.env` — or `.env.<name>` if you use `CONSENT_ENV_FILE` — which is gitignored
+  (both patterns) but **plaintext**. Treat these as a sandbox, not a template
+  for production secret handling. Running two providers side by side means two
+  full sets of secrets on disk, so mind what you copy between files.
+- **The Okta admin token is setup-only.** `OKTA_ADMIN_TOKEN` is used by
+  `00_create_okta_apps.py` and by step 02's callback registration, and never at
+  runtime. You can blank it once setup is done. Okta expires API tokens after
+  30 days of inactivity, so a stale one fails every admin call with
+  `E0000011 Invalid token provided`.
+- **GitHub scopes** (`repo user workflow`) are broad for a tutorial. Trim them
+  in [`deploy/03_create_github_provider.py`](deploy/03_create_github_provider.py)
+  and [`deploy/04_create_github_target.py`](deploy/04_create_github_target.py).
+- **The IdP client secret expires** (one year, as issued here). A long-lived
+  deployment needs a rotation plan.
+- **`/debug/token`** displays the user's access token to help you verify the
+  audience and subject claims. It requires a signed-in session, but it is still a
+  debug route — remove it if you reuse the frontend.
+- **The BFF session cookie is tuned for `http://localhost`.** It is signed,
+  `HttpOnly` and `SameSite=Lax`, and it carries the user's access token — but it
+  is deliberately *not* `Secure`, because that flag would stop the cookie being
+  sent over plain HTTP and break the sample. Serving this anywhere other than
+  localhost means terminating TLS and adding `https_only=True` to the
+  `SessionMiddleware` in [`frontend/app.py`](frontend/app.py).
+- **One statement in each role uses `"Resource": "*"`** — the AgentCore Identity
+  actions (`GetWorkloadAccessToken*`, `GetResourceOauth2Token`,
+  `CompleteResourceTokenAuth`) on the gateway service role and on the portal
+  execution role. Every other statement is scoped to a specific ARN: the portal
+  role's gateway and credential-provider reads, the log-group writes, and both
+  Secrets Manager reads, which are limited to the
+  `bedrock-agentcore-identity!default/oauth2/*` path — and on the portal role
+  additionally to secrets tagged `owningService = bedrock-agentcore-identity`.
+  If your account can express those identity actions more narrowly, do so; check
+  before copying these policies into anything shared.
+- **Names are user-facing.** Whatever you call the target and the outbound
+  provider is what end users read on the Connections page. `github-mcp-server`
+  suits a sample; outside one, choose wording that means something to the person
+  deciding whether to grant access.

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/README.md
@@ -1,0 +1,71 @@
+# The agent
+
+[`agent.py`](agent.py) is a Strands agent that runs on AgentCore Runtime. It is
+the one file you copy into the CLI-scaffolded project at deploy time:
+
+```bash
+cp agent/agent.py "$AGENT_RUNTIME_NAME"/app/"$AGENT_RUNTIME_NAME"/main.py
+```
+
+Do **not** copy [`requirements.txt`](requirements.txt) alongside it. The scaffold
+tracks the runtime's dependencies in `app/<name>/pyproject.toml` with a
+`uv.lock`, and already declares everything `agent.py` imports. That file is here
+to document the dependency set for anyone deploying the agent another way.
+
+## What it does, and deliberately does not
+
+It reads the caller's JWT from the `Authorization` header and forwards it to the
+gateway **unchanged** as the MCP Bearer credential. It performs no token
+exchange, holds no GitHub credential, and never calls GitHub directly — the
+gateway does that, using the authorization the user granted on the consent
+portal.
+
+That is why `requirements.txt` here is short: no boto3, no AgentCore Identity
+calls. The only AWS-shaped thing the agent needs is the Bedrock access the
+Runtime execution role already has.
+
+## The consent path
+
+`tools/list` always succeeds, because the gateway target was created with its
+tool schema supplied upfront. Only `tools/call` needs the user's GitHub token,
+and if there is none the gateway replies with a URL-mode elicitation — JSON-RPC
+error `-32042` — instead of failing.
+
+The agent turns that into a plain instruction naming the **consent portal**, not
+the raw AgentCore Identity authorize URL in the elicitation payload. Following
+that raw URL would skip the portal's session binding; the portal calls
+`CompleteResourceTokenAuth` on the user's behalf.
+
+Because the elicitation's propagation path through the MCP client is not a
+public contract, detection covers both shapes it can arrive in:
+
+- a `toolResult` with `status: "error"` on the Strands message history
+  (`consent_needed_in_history`), and
+- a raised exception, unwrapped through the anyio task groups the MCP client
+  runs inside (`unwrap`).
+
+Matching requires an **error** status, so a successful tool result that happens
+to mention the code does not trip it. The system prompt also tells the model to
+relay such an error verbatim rather than retrying or working around it.
+
+Every detection logs a line starting `CONSENT_REQUIRED`, which is what makes
+this observable:
+
+```bash
+agentcore logs --since 10m --query "CONSENT_REQUIRED"
+```
+
+## Environment
+
+Set by [`../deploy/05_patch_agentcore_json.py`](../deploy/05_patch_agentcore_json.py):
+
+| Variable | Purpose |
+| :--- | :--- |
+| `GATEWAY_MCP_URL` | The gateway's `/mcp` endpoint |
+| `PORTAL_URL` | Shown to users who have not consented yet |
+| `AWS_REGION` | Region for the Bedrock model |
+| `MODEL_ID` | Optional override; defaults to Claude Sonnet 4.5 |
+
+The same script adds `Authorization` to the runtime's `requestHeaderAllowlist`.
+Without that the header is stripped before the handler runs and the agent has
+nothing to forward.

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/agent.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/agent.py
@@ -1,0 +1,247 @@
+"""Strands agent on AgentCore Runtime, reaching GitHub through a Gateway (3LO).
+
+Copy this over the scaffolded project's entrypoint, then deploy:
+
+    agentcore create --name "$AGENT_RUNTIME_NAME" --framework Strands \\
+      --model-provider Bedrock --memory none --build CodeZip --defaults
+    cp agent/agent.py "$AGENT_RUNTIME_NAME"/app/"$AGENT_RUNTIME_NAME"/main.py
+    python deploy/05_patch_agentcore_json.py --entra   # or --okta
+    cd "$AGENT_RUNTIME_NAME" && agentcore validate && agentcore deploy -y -v
+
+What the handler does:
+
+  1. Reads the caller's JWT from the Authorization header (allowlisted by
+     deploy/05_patch_agentcore_json.py — without that the header is stripped).
+
+  2. Forwards it to the gateway VERBATIM as the MCP Bearer credential. This is
+     passthrough, not an OBO token exchange: the runtime and the gateway trust
+     the same issuer and audience, so one token satisfies both authorizers.
+     That also keeps the identity the gateway resolves for this caller
+     identical to the identity they signed in as on the consent portal, which
+     is what makes their stored consent findable. (For the OBO variant, where
+     each hop gets its own audience, see ../obo-training/3-examples/.)
+
+  3. Lets the LLM pick a GitHub tool. `tools/list` always succeeds because the
+     target was created with its schema upfront — nobody has to authorize
+     anything to browse the catalogue.
+
+  4. On `tools/call`, the gateway needs the user's GitHub token. If they have
+     consented on the portal, it uses the stored token and the call just
+     works. If they have NOT, the gateway returns a URL-mode elicitation as a
+     JSON-RPC error, code -32042, carrying an AgentCore Identity authorize URL
+     in error.data.elicitations[*].url. This handler detects that and replies
+     with the CONSENT PORTAL URL instead — the portal authenticates the user,
+     gathers consent, and calls CompleteResourceTokenAuth for them. The raw
+     identity URL is deliberately not shown: following it directly skips the
+     portal's session binding.
+
+Env vars (set by deploy/05_patch_agentcore_json.py):
+    GATEWAY_MCP_URL, PORTAL_URL, AWS_REGION
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from mcp.client.streamable_http import streamablehttp_client
+from strands import Agent
+from strands.tools.mcp.mcp_client import MCPClient
+
+GATEWAY_MCP_URL = os.environ.get("GATEWAY_MCP_URL", "")
+PORTAL_URL = os.environ.get("PORTAL_URL", "")
+MODEL_ID = os.environ.get("MODEL_ID") or "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+# The JSON-RPC error code the gateway uses for "this request requires more
+# information" — i.e. the user must complete an authorization flow first.
+AUTH_ELICITATION_CODE = "-32042"
+
+# The AgentCore Identity authorize URL that the elicitation carries. Two uses:
+# it is the most specific signal that a failure really is a consent failure,
+# and it is the string that must never reach the user (following it directly
+# bypasses the portal's session binding).
+IDENTITY_AUTHORIZE_MARKER = "identities/oauth2/authorize"
+
+# Substrings that identify an unconsented tool call. Observed live: Strands
+# raises McpError whose str() is only "This request requires more information."
+# — no code, no URL — while the tool *result* handed to the model carries the
+# code, the message and the URL. So both spellings are needed.
+CONSENT_MARKERS = (
+    AUTH_ELICITATION_CODE,
+    "requires more information",
+    "Please login to this URL",
+    IDENTITY_AUTHORIZE_MARKER,
+)
+
+app = BedrockAgentCoreApp()
+log = app.logger
+
+
+def consent_message() -> str:
+    portal = PORTAL_URL or "(PORTAL_URL is not set on this runtime)"
+    return (
+        "You have not connected your GitHub account yet, so I cannot read GitHub "
+        f"on your behalf.\n\n"
+        f"Open the consent portal at {portal}, sign in with the same account you "
+        "used here, choose **Connect** on the GitHub row, then ask me again.\n\n"
+        "Two things to expect: a newly added connection can take up to 5 minutes "
+        "to appear on that page, and GitHub will not re-prompt if you have "
+        "authorized this app before."
+    )
+
+
+def mentions_consent_elicitation(blob: object) -> bool:
+    """True if `blob` looks like the gateway's unconsented-call elicitation.
+
+    Takes any object and searches its JSON (or string) form, because the
+    elicitation reaches us in more than one shape: as a tool result recorded on
+    the Agent's message history, or as a raised MCP error.
+    """
+    try:
+        text = blob if isinstance(blob, str) else json.dumps(blob, default=str)
+    except (TypeError, ValueError):
+        text = str(blob)
+    return any(marker in text for marker in CONSENT_MARKERS)
+
+
+def consent_needed_in_history(agent: Agent) -> bool:
+    """Scan the Agent's messages for a tool result that failed for consent.
+
+    Strands records every tool call and its result on `agent.messages`, and
+    catches the raised McpError so the model can react to it — which means the
+    failure shows up here rather than as an exception out of the stream.
+
+    Two accepted shapes, because status is not guaranteed to be spelled
+    "error": either an error-status result mentioning any consent marker, or
+    any result carrying the identity authorize URL, which appears nowhere else.
+    """
+    for message in getattr(agent, "messages", []) or []:
+        for block in message.get("content", []) or []:
+            result = block.get("toolResult") if isinstance(block, dict) else None
+            if not result:
+                continue
+            blob = json.dumps(result, default=str)
+            if IDENTITY_AUTHORIZE_MARKER in blob:
+                return True
+            if result.get("status") == "error" and mentions_consent_elicitation(result):
+                return True
+    return False
+
+
+@contextmanager
+def gateway_mcp_client(user_token: str) -> Iterator[MCPClient]:
+    """Open a Strands MCPClient against the gateway, as the calling user."""
+    if not GATEWAY_MCP_URL:
+        raise RuntimeError("GATEWAY_MCP_URL is not set. Re-run deploy/05_patch_agentcore_json.py and redeploy.")
+    headers = {"Authorization": f"Bearer {user_token}"}
+    client = MCPClient(lambda: streamablehttp_client(GATEWAY_MCP_URL, headers=headers))
+    with client:
+        yield client
+
+
+SYSTEM_PROMPT = """
+You are a GitHub assistant. You reach GitHub through tools provided by an
+Amazon Bedrock AgentCore Gateway, which calls the GitHub MCP server with the
+user's own delegated authorization.
+
+Guidelines:
+  - Choose the narrowest tool that answers the question, and pass only the
+    arguments you were given or can infer confidently.
+  - Summarize results in a couple of sentences unless asked for detail. Do not
+    invent repositories, users, or numbers that a tool did not return.
+  - If a tool fails because the user has not authorized GitHub access, reply
+    with exactly this and nothing else: "GitHub is not connected." Never copy a
+    URL out of an error message — the application appends the correct link
+    itself, and the one in the error must not be shown. Do not retry the tool.
+  - Do not discuss tokens, OAuth, or AgentCore internals unless asked.
+"""
+
+
+def unwrap(err: BaseException, depth: int = 0) -> BaseException:
+    """Peel anyio TaskGroup wrappers to the real cause.
+
+    Strands' MCPClient runs inside task groups that wrap the underlying error,
+    so the outer exception is usually uninformative.
+    """
+    if depth > 5:
+        return err
+    inner = getattr(err, "exceptions", None) or ((err.__cause__,) if err.__cause__ else ())
+    return unwrap(inner[0], depth + 1) if inner else err
+
+
+@app.entrypoint
+async def invoke(payload, context):
+    """Runtime entrypoint.
+
+    An async generator, so failures are yielded as text rather than returned
+    (`return <value>` is illegal in an async generator).
+    """
+    headers = context.request_headers or {}
+    auth = headers.get("Authorization") or headers.get("authorization") or ""
+    if not auth.startswith("Bearer "):
+        yield "ERROR: missing or malformed Authorization header."
+        return
+    user_token = auth.split(" ", 1)[1]
+
+    prompt = payload.get("prompt") or "Search GitHub for amazon-bedrock-agentcore-samples."
+
+    try:
+        with gateway_mcp_client(user_token) as mcp_client:
+            tools = mcp_client.list_tools_sync()
+            log.info("Gateway MCP tools discovered: count=%d", len(tools))
+
+            agent = Agent(model=MODEL_ID, system_prompt=SYSTEM_PROMPT, tools=tools)
+
+            # Buffered, not streamed through, on purpose. The model sees the
+            # elicitation's raw identity URL in the failed tool result, and a
+            # model that echoes it cannot be un-echoed once yielded. Holding
+            # the text until the tool results are known makes the consent reply
+            # deterministic instead of prompt-dependent. Nothing is lost here:
+            # the caller concatenates the stream before rendering anyway. Drop
+            # the buffering if you need true incremental output, and accept
+            # that the raw URL may then reach the user.
+            chunks: list[str] = []
+            async for event in agent.stream_async(prompt):
+                data = event.get("data")
+                if isinstance(data, str):
+                    chunks.append(data)
+            answer = "".join(chunks)
+
+            if consent_needed_in_history(agent):
+                log.info(
+                    "CONSENT_REQUIRED: gateway returned an auth elicitation (%s); "
+                    "replacing the model's reply with the portal instruction",
+                    AUTH_ELICITATION_CODE,
+                )
+                yield consent_message()
+                return
+
+            # Belt and braces: never let the identity URL through even if the
+            # tool-result scan missed the failure.
+            if IDENTITY_AUTHORIZE_MARKER in answer:
+                log.info("CONSENT_REQUIRED: identity URL found in the model's reply; substituting")
+                yield consent_message()
+                return
+
+            yield answer
+    except Exception as e:  # noqa: BLE001
+        root = unwrap(e)
+        if mentions_consent_elicitation(str(e)) or mentions_consent_elicitation(str(root)):
+            log.info("CONSENT_REQUIRED: gateway raised an auth elicitation (%s)", AUTH_ELICITATION_CODE)
+            yield consent_message()
+            return
+        log.error(
+            "Gateway / MCP / agent error: outer=%s: %s | root=%s: %s",
+            type(e).__name__,
+            e,
+            type(root).__name__,
+            root,
+        )
+        yield f"ERROR: {type(e).__name__}: {e}\nroot cause: {type(root).__name__}: {root}"
+
+
+if __name__ == "__main__":
+    app.run()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/agent.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/agent.py
@@ -1,4 +1,4 @@
-"""Strands agent on AgentCore Runtime, reaching GitHub through a Gateway (3LO).
+"""Strands agent on AgentCore Runtime, reaching GitHub through a Gateway.
 
 Copy this over the scaffolded project's entrypoint, then deploy:
 

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/requirements.txt
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/agent/requirements.txt
@@ -1,0 +1,16 @@
+# Documentation of what agent.py needs, NOT a file you copy into the project.
+#
+# The AgentCore CLI scaffold (verified on 0.25.0) manages the runtime's
+# dependencies in app/<name>/pyproject.toml with a uv.lock, and it already
+# declares every package listed here. Only agent.py is copied into the
+# scaffold. If you deploy the agent some other way, this is the dependency set
+# to reproduce.
+#
+# Kept minimal on purpose: the agent forwards the caller's token to the gateway
+# and drives an LLM, so it makes no AgentCore Identity calls of its own.
+
+bedrock-agentcore>=0.1.0
+
+# Strands + the MCP client used to talk to AgentCore Gateway.
+strands-agents>=0.4.0
+mcp>=1.2.0

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/config.example.env
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/config.example.env
@@ -1,0 +1,158 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Consent portal + GitHub MCP sample — copy to .env and fill in.
+#
+#   cp config.example.env .env
+#
+# Most values are written for you by the deploy scripts. The ones you must set
+# by hand are marked SET ME. Everything under "populated by …" can stay empty.
+#
+# ONE FILE HOLDS ONE DEPLOYMENT. IDP= below selects the provider, and a single
+# .env is all you need. To stand up BOTH providers at once, give each its own
+# file — the deploy scripts and the frontend all honour CONSENT_ENV_FILE:
+#
+#   cp config.example.env .env.okta
+#   CONSENT_ENV_FILE=.env.okta python deploy/00_create_okta_apps.py
+#   CONSENT_ENV_FILE=.env.okta python frontend/app.py
+#
+# Give each deployment a distinct AGENT_RUNTIME_NAME (it becomes the CDK stack)
+# and its own GitHub OAuth App. See the README section "Running both identity
+# providers side by side".
+#
+# This file is the tracked template. .env and .env.* are gitignored and hold
+# plaintext secrets — including, for Okta, an admin API token.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Which identity provider ──────────────────────────────────────────────────
+# Set by deploy/00_create_entra_apps.py or deploy/00_create_okta_apps.py.
+# The frontend reads it to pick its sign-in adapter.
+IDP=
+
+# ── AWS ──────────────────────────────────────────────────────────────────────
+# SET ME. Must be a region where AgentCore Gateway and consent portals are
+# available.
+AWS_REGION=us-east-1
+
+# ── Entra ID only ────────────────────────────────────────────────────────────
+# All populated by deploy/00_create_entra_apps.py. Leave blank for Okta.
+TENANT_ID=
+# The gateway resource app. It is ALSO the consent portal's login client —
+# under Entra the `sub` claim is pairwise per app, so the portal must sign
+# users in through the same app the gateway audiences, or consent binds under
+# one identity and is looked up under another.
+GATEWAY_CLIENT_ID=
+
+# ── Okta only ────────────────────────────────────────────────────────────────
+# SET ME (both) if using Okta; leave blank for Entra.
+#   OKTA_DOMAIN: your tenant, e.g. integrator-1234567.okta.com (NOT the -admin host)
+#   OKTA_ADMIN_TOKEN: Okta admin -> Security -> API -> Tokens -> Create Token.
+#     Needs Org/Super Admin. Used only by the 00_* scripts and by
+#     02_create_portal.py to register the portal callback. Never used at runtime.
+OKTA_DOMAIN=
+OKTA_ADMIN_TOKEN=
+# The CUSTOM authorization server. The org server issues opaque access tokens,
+# which neither the gateway nor the portal can validate.
+OKTA_AUTH_SERVER_ID=default
+# Populated by deploy/00_create_okta_apps.py (the 0oa… app id, not a client id).
+PORTAL_APP_ID=
+
+# ── Primary IdP, resolved (populated by deploy/00_create_*_apps.py) ──────────
+# One issuer serves all three inbound legs: the runtime, the gateway, and the
+# consent portal's own sign-in. CreateConsentPortal validates that the gateway
+# authorizer and the portal's IdP provider reference the same issuer.
+IDP_DISCOVERY_URL=
+# Entra: the bare app GUID (v2 tokens set aud to the application id, so
+# api://<GUID> would fail validation). Okta: the authorization server's
+# `audiences` value, e.g. api://default.
+IDP_AUDIENCE=
+# What the frontend requests at sign-in. Entra needs the fully qualified
+# api://<GUID>/access_as_user; Okta uses the short access_as_user.
+GATEWAY_SCOPE=
+# What the consent portal requests at its own sign-in. openid must be present —
+# the portal always requests it, and every scope it requests must be permitted
+# on the IdP app. 02_create_portal.py prepends it if you drop it.
+PORTAL_SCOPES=
+
+# ── Frontend (the BFF) ───────────────────────────────────────────────────────
+# Client IDs are populated by the 00_* scripts; secrets are minted by them too.
+FRONTEND_CLIENT_ID=
+FRONTEND_CLIENT_SECRET=replace-me
+FRONTEND_HOST=localhost
+FRONTEND_PORT=8000
+# Must be registered on the frontend app in the IdP. The 00_* scripts do that.
+FRONTEND_REDIRECT_URI=http://localhost:8000/auth/callback
+# SET ME to a long random string: python -c 'import secrets;print(secrets.token_hex(32))'
+FRONTEND_SESSION_SECRET=
+
+# ── Consent portal login client ──────────────────────────────────────────────
+# Populated by the 00_* scripts. Under Entra PORTAL_CLIENT_ID == GATEWAY_CLIENT_ID
+# (see above); under Okta it is a separate confidential app, which is safe
+# because Okta's `sub` is stable per user across client apps.
+PORTAL_CLIENT_ID=
+PORTAL_CLIENT_SECRET=replace-me
+
+# ── GitHub OAuth App (the outbound provider) ─────────────────────────────────
+# SET ME. Create an OAuth App at https://github.com/settings/developers with any
+# placeholder callback URL; deploy/03_create_github_provider.py prints the real
+# one for you to paste back in.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# ── Resource names (override only if you need to) ────────────────────────────
+# Defaults are derived from the IdP profile: <idp>-consent-github-gw and
+# <idp>-github-consent-portal. PORTAL_NAME must be 1–50 characters and cannot
+# be changed after creation.
+GATEWAY_NAME=
+PORTAL_NAME=
+# Optional: bring your own gateway service role. If blank,
+# deploy/01_create_gateway.py creates one and writes the ARN back here.
+GATEWAY_SERVICE_ROLE_ARN=
+
+# ── AgentCore Runtime (the agent) ────────────────────────────────────────────
+# SET ME. AgentCore CLI rules: <= 23 characters, starts with a letter,
+# alphanumeric only — no hyphens or underscores. Use camelCase.
+AGENT_RUNTIME_NAME=consentGithubAgent
+# Optional: override the model the agent uses.
+MODEL_ID=
+
+# ── Optional gateway interceptor (deploy/07_deploy_interceptor.py) ───────────
+# Only relevant if you run step 07. Every one of these is optional and the
+# defaults work as-is; see README "Configuration you can change".
+#
+# Where users are sent instead of the raw identity URL. Defaults to PORTAL_URL.
+# Set this to your own landing page if you want to explain what is about to
+# happen before handing off — the portal still gathers the consent.
+INTERCEPTOR_TARGET_URL=
+# Override the derived resource names (default: <idp>-consent-jit-interceptor
+# and <Idp>ConsentInterceptorRole).
+INTERCEPTOR_LAMBDA_NAME=
+INTERCEPTOR_ROLE_NAME=
+# Lambda sizing. The gateway waits on this Lambda on every response, so keep the
+# timeout small. Measured usage is ~37 MB and 2–17 ms.
+INTERCEPTOR_RUNTIME=
+INTERCEPTOR_TIMEOUT_SECONDS=
+INTERCEPTOR_MEMORY_MB=
+# Retention for /aws/lambda/<function>. Unset means logs never expire.
+INTERCEPTOR_LOG_RETENTION_DAYS=
+# The safety guard: only URLs containing this substring are rewritten.
+INTERCEPTOR_IDENTITY_URL_HOST=
+# true lets the interceptor see request headers. Default false keeps the
+# caller's JWT out of the interceptor event and out of CloudWatch.
+INTERCEPTOR_PASS_REQUEST_HEADERS=
+
+# ── Populated by the deploy scripts — leave blank ────────────────────────────
+GATEWAY_ID=
+GATEWAY_URL=
+GATEWAY_MCP_URL=
+PORTAL_ID=
+PORTAL_ARN=
+PORTAL_URL=
+PORTAL_CALLBACK_URL=
+PORTAL_CONNECT_RETURN_URL=
+IDP_PROVIDER_ARN=
+PORTAL_EXECUTION_ROLE_ARN=
+GITHUB_PROVIDER_ARN=
+GITHUB_PROVIDER_CALLBACK_URL=
+GITHUB_TARGET_ID=
+# From `agentcore status` after deploying. MUST end with ?qualifier=DEFAULT —
+# without it the invoke returns 404 UnknownOperationException.
+AGENT_RUNTIME_INVOKE_URL=

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_create_entra_apps.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_create_entra_apps.py
@@ -1,0 +1,317 @@
+"""Automate the Microsoft Entra ID setup for the consent-portal sample (Azure CLI).
+
+Two app registrations, not three — this sample uses passthrough (the agent
+forwards the user's token to the gateway as-is), so there is no agent app:
+
+  1. Gateway resource app (agentcore-consent-github-gateway)
+       - identifierUris: api://<appId>
+       - api.requestedAccessTokenVersion: 2  (v2 tokens; the gateway's and
+         runtime's /v2.0/ discovery URL fails iss validation without it)
+       - Expose-an-API scope: access_as_user
+       - ALSO the consent portal's login client: a client secret, plus its own
+         access_as_user permission granted and admin-consented to itself.
+
+     Why the portal signs in through this same app: under Entra the `sub`
+     claim is a pairwise identifier keyed on the app a token is issued FOR.
+     Consent granted on the portal is stored under the portal login's `sub`,
+     and looked up under the `sub` the gateway resolves from the caller's
+     token. Both tokens here are issued for this one resource app, so the two
+     `sub` values are identical by construction and consent binds correctly.
+
+  2. Frontend app (agentcore-consent-github-frontend)
+       - web redirect: http://localhost:8000/auth/callback + a client secret
+       - delegated permission to the resource app's access_as_user,
+         granted + admin-consented (so sign-in shows no extra consent screen)
+
+Writes to .env: TENANT_ID, GATEWAY_CLIENT_ID, PORTAL_CLIENT_ID (== gateway),
+PORTAL_CLIENT_SECRET, FRONTEND_CLIENT_ID, FRONTEND_CLIENT_SECRET,
+IDP_DISCOVERY_URL, IDP_AUDIENCE, GATEWAY_SCOPE, PORTAL_SCOPES, IDP=entra.
+
+The portal's real redirect URI cannot be registered yet — the portal URL does
+not exist until deploy/02_create_portal.py creates the portal. That script
+registers it for you.
+
+Prerequisites: Azure CLI >= 2.50, signed in (`az login`) as a user who can
+create app registrations and grant admin consent.
+
+Run from the sample root:
+    python deploy/00_create_entra_apps.py
+Re-running is safe: apps are reused by display name and secrets are only
+minted when .env is missing them (pass --rotate-secrets to force).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import ENV_PATH, save_env
+
+APP_NAMES = {
+    "gateway": "agentcore-consent-github-gateway",
+    "frontend": "agentcore-consent-github-frontend",
+}
+REDIRECT_URI = "http://localhost:8000/auth/callback"
+SIGN_IN_AUDIENCE = "AzureADMyOrg"
+SCOPE_VALUE = "access_as_user"
+
+
+def die(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def az(*args: str, check: bool = True):
+    cmd = ["az", *args]
+    if "--output" not in args:
+        cmd += ["--output", "json"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        if check:
+            die(f"`{' '.join(cmd)}` failed with exit {proc.returncode}:\n{proc.stderr.strip() or proc.stdout.strip()}")
+        return None
+    if proc.stdout.strip():
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return proc.stdout.strip()
+    return None
+
+
+def graph_get(path: str) -> dict:
+    return az("rest", "--method", "GET", "--url", f"https://graph.microsoft.com/v1.0{path}")
+
+
+def graph_patch(path: str, body: dict) -> None:
+    az(
+        "rest",
+        "--method",
+        "PATCH",
+        "--url",
+        f"https://graph.microsoft.com/v1.0{path}",
+        "--headers",
+        "Content-Type=application/json",
+        "--body",
+        json.dumps(body),
+    )
+
+
+def create_or_get_app(name: str, *, redirect_uri: str | None = None) -> dict:
+    apps = az("ad", "app", "list", "--display-name", name)
+    if apps:
+        app = apps[0]
+        print(f"  • App exists: {name} (appId={app['appId']})")
+        if redirect_uri:
+            uris = (app.get("web", {}) or {}).get("redirectUris", []) or []
+            if redirect_uri not in uris:
+                az("ad", "app", "update", "--id", app["appId"], "--web-redirect-uris", redirect_uri)
+                print(f"    ✓ Set redirect URI: {redirect_uri}")
+        return app
+    args = ["ad", "app", "create", "--display-name", name, "--sign-in-audience", SIGN_IN_AUDIENCE]
+    if redirect_uri:
+        args += ["--web-redirect-uris", redirect_uri]
+    app = az(*args)
+    print(f"  ✓ Created app: {name} (appId={app['appId']})")
+    # The resource app also needs a service principal so permissions can be
+    # granted against it. `az ad sp create` errors if one exists; tolerate that.
+    az("ad", "sp", "create", "--id", app["appId"], check=False)
+    return app
+
+
+def ensure_v2_access_tokens(object_id: str) -> None:
+    """Force v2 access tokens. Without this Entra issues v1-style tokens whose
+    iss (sts.windows.net) fails the gateway's and runtime's /v2.0/ discovery
+    check with "Claim 'iss' value mismatch"."""
+    app = graph_get(f"/applications/{object_id}")
+    if (app.get("api") or {}).get("requestedAccessTokenVersion") == 2:
+        print("    • api.requestedAccessTokenVersion already 2")
+        return
+    graph_patch(f"/applications/{object_id}", {"api": {"requestedAccessTokenVersion": 2}})
+    print("    ✓ Set api.requestedAccessTokenVersion = 2")
+
+
+def ensure_access_as_user_scope(object_id: str) -> str:
+    app = graph_get(f"/applications/{object_id}")
+    scopes = list((app.get("api") or {}).get("oauth2PermissionScopes") or [])
+    for s in scopes:
+        if s.get("value") == SCOPE_VALUE:
+            print(f"    • Scope already exists: {SCOPE_VALUE}")
+            return s["id"]
+    scope_id = str(uuid.uuid4())
+    scopes.append(
+        {
+            "adminConsentDescription": "Allows the calling application to invoke this API as the signed-in user.",
+            "adminConsentDisplayName": "Access as the signed-in user",
+            "id": scope_id,
+            "isEnabled": True,
+            "type": "User",
+            "userConsentDescription": None,
+            "userConsentDisplayName": None,
+            "value": SCOPE_VALUE,
+        }
+    )
+    graph_patch(f"/applications/{object_id}", {"api": {"oauth2PermissionScopes": scopes}})
+    print(f"    ✓ Added scope: {SCOPE_VALUE}")
+    return scope_id
+
+
+def add_permission_and_grant(consumer_app_id: str, api_app_id: str, scope_id: str) -> None:
+    """Declare the delegated permission, grant it, and admin-consent it.
+
+    All three are needed: without the explicit `permission grant`, the consent
+    is declared but never activated, and tokens fail with a consent-required
+    error even though admin-consent reported success.
+    """
+    az(
+        "ad",
+        "app",
+        "permission",
+        "add",
+        "--id",
+        consumer_app_id,
+        "--api",
+        api_app_id,
+        "--api-permissions",
+        f"{scope_id}=Scope",
+        check=False,
+    )
+    az(
+        "ad",
+        "app",
+        "permission",
+        "grant",
+        "--id",
+        consumer_app_id,
+        "--api",
+        api_app_id,
+        "--scope",
+        SCOPE_VALUE,
+        check=False,
+    )
+    proc = subprocess.run(
+        ["az", "ad", "app", "permission", "admin-consent", "--id", consumer_app_id],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        print(f"    ✓ Granted + admin-consented {SCOPE_VALUE} for {consumer_app_id}")
+    else:
+        err = (proc.stderr or proc.stdout).strip().splitlines()
+        print(
+            f"    ⚠ admin-consent failed: {err[-1] if err else 'unknown'}\n"
+            f"      Ask a Global Admin to run:\n"
+            f"        az ad app permission admin-consent --id {consumer_app_id}",
+            file=sys.stderr,
+        )
+
+
+def env_value_is_placeholder(key: str) -> bool:
+    if not ENV_PATH.exists():
+        return True
+    for line in ENV_PATH.read_text().splitlines():
+        if line.startswith(f"{key}="):
+            return line[len(key) + 1 :].strip() in ("", "replace-me", "REPLACE_ME")
+    return True
+
+
+def reset_client_secret(app_id: str, label: str) -> str:
+    result = az(
+        "ad",
+        "app",
+        "credential",
+        "reset",
+        "--id",
+        app_id,
+        "--display-name",
+        label,
+        "--years",
+        "1",
+        "--append",
+    )
+    return result["password"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rotate-secrets",
+        action="store_true",
+        help="Mint fresh client secrets even if .env already has values.",
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("az"):
+        die("Azure CLI (`az`) not found on PATH. See https://learn.microsoft.com/cli/azure/install-azure-cli")
+    account = az("account", "show", check=False)
+    if not account or "tenantId" not in account:
+        die("Not signed in to Azure CLI. Run `az login` first.")
+    tenant_id = account["tenantId"]
+    print(f"Signed in to tenant {tenant_id}")
+
+    print("\n[1/4] App registrations…")
+    gateway_app = create_or_get_app(APP_NAMES["gateway"])
+    frontend_app = create_or_get_app(APP_NAMES["frontend"], redirect_uri=REDIRECT_URI)
+
+    print("\n[2/4] Gateway resource app: identifier URI, v2 tokens, scope…")
+    az("ad", "app", "update", "--id", gateway_app["appId"], "--identifier-uris", f"api://{gateway_app['appId']}")
+    ensure_v2_access_tokens(gateway_app["id"])
+    scope_id = ensure_access_as_user_scope(gateway_app["id"])
+
+    print("\n[3/4] Permissions (sleeping 8s for AAD propagation)…")
+    time.sleep(8)
+    # Frontend -> resource app: what the BFF requests at sign-in.
+    print("  • FrontendApp -> GatewayApp.access_as_user")
+    add_permission_and_grant(frontend_app["appId"], gateway_app["appId"], scope_id)
+    # Resource app -> itself: the portal's server-side login requests this
+    # scope as the resource app, so it needs its own permission consented.
+    print("  • GatewayApp -> GatewayApp.access_as_user (portal login client)")
+    add_permission_and_grant(gateway_app["appId"], gateway_app["appId"], scope_id)
+
+    print("\n[4/4] Client secrets + .env…")
+    new_secrets: dict[str, str] = {}
+    if args.rotate_secrets or env_value_is_placeholder("FRONTEND_CLIENT_SECRET"):
+        new_secrets["FRONTEND_CLIENT_SECRET"] = reset_client_secret(frontend_app["appId"], "consent-sample-frontend")
+    if args.rotate_secrets or env_value_is_placeholder("PORTAL_CLIENT_SECRET"):
+        # The portal login client IS the gateway resource app.
+        new_secrets["PORTAL_CLIENT_SECRET"] = reset_client_secret(gateway_app["appId"], "consent-sample-portal-login")
+    print(f"  ✓ Client secrets: {len(new_secrets)} freshly minted, {2 - len(new_secrets)} kept")
+
+    gid = gateway_app["appId"]
+    save_env(
+        IDP="entra",
+        TENANT_ID=tenant_id,
+        GATEWAY_CLIENT_ID=gid,
+        PORTAL_CLIENT_ID=gid,
+        FRONTEND_CLIENT_ID=frontend_app["appId"],
+        IDP_DISCOVERY_URL=f"https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration",
+        # The bare GUID, not api://<GUID>: with v2 tokens Entra sets aud to
+        # the application id, and pinning the identifier URI fails validation.
+        IDP_AUDIENCE=gid,
+        # What the frontend requests at sign-in. Entra's /authorize only
+        # accepts the fully qualified form.
+        GATEWAY_SCOPE=f"api://{gid}/access_as_user",
+        # What the portal requests at its own sign-in (openid is prepended
+        # automatically by 02_create_portal.py if you drop it).
+        PORTAL_SCOPES=f"openid api://{gid}/access_as_user",
+        **new_secrets,
+    )
+    print("  ✓ Wrote IDs, discovery URL, audience, and scopes to .env")
+
+    print()
+    print("✓ Entra ID setup complete (2 apps: gateway resource + frontend).")
+    print("  The gateway resource app doubles as the consent portal's login")
+    print("  client — see the docstring for why Entra requires that.")
+    print()
+    print("Next: python deploy/01_create_gateway.py --entra")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_create_okta_apps.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_create_okta_apps.py
@@ -1,0 +1,378 @@
+"""Automate the Okta setup for the consent-portal sample (Okta Admin API).
+
+Two OIDC web apps plus scope/policy work on a CUSTOM authorization server —
+this sample uses passthrough (the agent forwards the user's token to the
+gateway as-is), so there is no agent app:
+
+  1. Frontend app (AgentCore Consent GitHub Frontend)
+       Confidential web app, authorization_code + refresh_token, redirect
+       http://localhost:8000/auth/callback, assigned to Everyone. "Require
+       PKCE" is left off; the BFF sends S256 regardless, so turning it on
+       later needs no code change.
+  2. Portal login app (agentcore-consent-portal-login)
+       A SEPARATE confidential web app for the consent portal's own sign-in.
+       Okta's `sub` is a stable per-user identifier — the same user gets the
+       same `sub` regardless of client app — so a dedicated portal client is
+       safe (unlike Entra, where the portal must reuse the resource app).
+       Created with a placeholder redirect; deploy/02_create_portal.py swaps
+       in the real `<portalUrl>/callback` once the portal exists.
+
+  On the authorization server (OKTA_AUTH_SERVER_ID, default "default"):
+       - custom scope `access_as_user`
+       - one access policy + rule per app admitting authorization_code with
+         openid/profile/email/access_as_user. Every scope the portal requests
+         — openid included — must be admitted by the rule, or /authorize
+         fails with a policy-evaluation error.
+
+  The portal and gateway require a CUSTOM authorization server (the org
+  server issues opaque access tokens, which neither can validate). The
+  built-in "default" custom AS exists on orgs with the API Access Management
+  feature; its audience is api://default.
+
+Writes to .env: OKTA_DOMAIN, OKTA_AUTH_SERVER_ID, PORTAL_APP_ID,
+FRONTEND_CLIENT_ID/SECRET, PORTAL_CLIENT_ID/SECRET, IDP_DISCOVERY_URL,
+IDP_AUDIENCE, GATEWAY_SCOPE, PORTAL_SCOPES, IDP=okta.
+
+Prerequisites in .env (or exported): OKTA_DOMAIN (e.g.
+integrator-1234567.okta.com) and OKTA_ADMIN_TOKEN (Okta admin -> Security ->
+API -> Tokens; needs Org/Super Admin). The token is only used by this script
+and by 02_create_portal.py's callback registration — never at runtime.
+
+Run from the sample root:
+    python deploy/00_create_okta_apps.py
+Re-running is safe: apps/scopes/policies are reused by name; secrets are only
+minted when .env is missing them (pass --rotate-secrets to force).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import ENV_PATH, load_env, okta_domain, save_env
+
+APP_LABELS = {
+    "frontend": "AgentCore Consent GitHub Frontend",
+    "portal": "agentcore-consent-portal-login",
+}
+REDIRECT_URI = "http://localhost:8000/auth/callback"
+PORTAL_PLACEHOLDER_REDIRECT = "https://localhost/placeholder"
+SCOPE_NAME = "access_as_user"
+
+
+def die(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+class OktaClient:
+    """Thin Okta Admin API client (Authorization: SSWS <token>)."""
+
+    def __init__(self, domain: str, token: str) -> None:
+        if "-admin." in domain:
+            domain = domain.replace("-admin.", ".")
+            print(f"  ! OKTA_DOMAIN looked like the admin host; using {domain}")
+        self.domain = domain
+        self.base = f"https://{domain}/api/v1"
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"SSWS {token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def request(self, method: str, path: str, *, json_body=None, params=None):
+        url = f"{self.base}{path}"
+        resp = self.session.request(method, url, json=json_body, params=params, timeout=30)
+        if resp.status_code == 204:
+            return None
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+            except ValueError:
+                body = resp.text
+            # Redact everything except Okta's error-diagnostic fields.
+            if isinstance(body, dict):
+                body = {k: v for k, v in body.items() if k.startswith("error")}
+            die(f"Okta API call failed: {method} {url}\n  HTTP {resp.status_code}\n  {body}")
+        try:
+            return resp.json()
+        except ValueError:
+            return resp.text
+
+    def get(self, path: str, **kw):
+        return self.request("GET", path, **kw)
+
+    def post(self, path: str, **kw):
+        return self.request("POST", path, **kw)
+
+    def put(self, path: str, **kw):
+        return self.request("PUT", path, **kw)
+
+
+def env_value_is_placeholder(key: str) -> bool:
+    if not ENV_PATH.exists():
+        return True
+    for line in ENV_PATH.read_text().splitlines():
+        if line.startswith(f"{key}="):
+            return line[len(key) + 1 :].strip() in ("", "replace-me", "REPLACE_ME")
+    return True
+
+
+def find_app_by_label(client: OktaClient, label: str):
+    apps = client.get("/apps", params={"q": label, "filter": 'status eq "ACTIVE"', "limit": 20})
+    return next((a for a in apps if a.get("label") == label), None)
+
+
+def create_web_app(client: OktaClient, label: str, redirect_uris: list[str]) -> dict:
+    body = {
+        "name": "oidc_client",
+        "label": label,
+        "signOnMode": "OPENID_CONNECT",
+        "credentials": {"oauthClient": {"token_endpoint_auth_method": "client_secret_basic"}},
+        "settings": {
+            "oauthClient": {
+                "application_type": "web",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "redirect_uris": redirect_uris,
+            }
+        },
+    }
+    return client.post("/apps", json_body=body)
+
+
+def assign_app_to_everyone(client: OktaClient, app: dict) -> None:
+    """Okta issues no token to a user who is not assigned to the app."""
+    groups = client.get("/groups", params={"q": "Everyone", "limit": 10})
+    everyone = next(
+        (g for g in groups if (g.get("profile") or {}).get("name") == "Everyone" and g.get("type") == "BUILT_IN"),
+        None,
+    )
+    if not everyone:
+        print(
+            f"    ⚠ 'Everyone' group not found; assign users to {app['label']} manually\n"
+            f"      (Okta admin -> Applications -> {app['label']} -> Assignments).",
+            file=sys.stderr,
+        )
+        return
+    client.put(f"/apps/{app['id']}/groups/{everyone['id']}", json_body={})
+    print(f"    ✓ Assigned {app['label']} to Everyone")
+
+
+def get_or_create_app(client: OktaClient, label: str, redirect_uris: list[str]):
+    existing = find_app_by_label(client, label)
+    if existing:
+        print(f"  • App exists: {label}")
+        assign_app_to_everyone(client, existing)
+        return existing, False
+    app = create_web_app(client, label, redirect_uris)
+    print(f"  ✓ Created app: {label}")
+    assign_app_to_everyone(client, app)
+    return app, True
+
+
+def rotate_client_secret(client: OktaClient, app_id: str) -> str:
+    resp = client.post(f"/apps/{app_id}/credentials/secrets")
+    secret = resp.get("client_secret")
+    if not secret:
+        die(f"Okta returned no client_secret for app {app_id}.")
+    return secret
+
+
+def ensure_scope(client: OktaClient, as_id: str) -> None:
+    for s in client.get(f"/authorizationServers/{as_id}/scopes"):
+        if s["name"] == SCOPE_NAME:
+            print(f"  • Scope already exists: {SCOPE_NAME}")
+            return
+    client.post(
+        f"/authorizationServers/{as_id}/scopes",
+        json_body={
+            "name": SCOPE_NAME,
+            "displayName": "Access AgentCore on the user's behalf",
+            "description": "Allows calling the AgentCore runtime and gateway as the signed-in user.",
+            "consent": "IMPLICIT",
+            "metadataPublish": "ALL_CLIENTS",
+            "default": False,
+            "system": False,
+        },
+    )
+    print(f"  ✓ Created scope: {SCOPE_NAME}")
+
+
+def ensure_policy_and_rule(client: OktaClient, as_id: str, *, name: str, client_id: str, scopes: list[str]) -> None:
+    policies = client.get(f"/authorizationServers/{as_id}/policies")
+    existing = next((p for p in policies if p.get("name") == name), None)
+    body = {
+        "type": "OAUTH_AUTHORIZATION_POLICY",
+        "status": "ACTIVE",
+        "name": name,
+        "description": f"Consent-portal sample policy for {name}",
+        "conditions": {"clients": {"include": [client_id]}},
+    }
+    if existing:
+        body["id"] = existing["id"]
+        client.put(f"/authorizationServers/{as_id}/policies/{existing['id']}", json_body=body)
+        policy_id = existing["id"]
+        print(f"  • Policy updated: {name}")
+    else:
+        policy_id = client.post(f"/authorizationServers/{as_id}/policies", json_body=body)["id"]
+        print(f"  ✓ Policy created: {name}")
+
+    rule_name = "Auth code"
+    rule_body = {
+        "type": "RESOURCE_ACCESS",
+        "name": rule_name,
+        "status": "ACTIVE",
+        "priority": 1,
+        "conditions": {
+            "people": {"users": {"include": [], "exclude": []}, "groups": {"include": ["EVERYONE"], "exclude": []}},
+            "grantTypes": {"include": ["authorization_code"]},
+            "scopes": {"include": scopes},
+        },
+        "actions": {
+            "token": {
+                "accessTokenLifetimeMinutes": 60,
+                "refreshTokenLifetimeMinutes": 0,
+                "refreshTokenWindowMinutes": 10080,
+                "inlineHook": None,
+            }
+        },
+    }
+    rules = client.get(f"/authorizationServers/{as_id}/policies/{policy_id}/rules")
+    existing_rule = next((r for r in rules if r.get("name") == rule_name), None)
+    if existing_rule:
+        rule_body["id"] = existing_rule["id"]
+        client.put(
+            f"/authorizationServers/{as_id}/policies/{policy_id}/rules/{existing_rule['id']}",
+            json_body=rule_body,
+        )
+        print(f"    • Rule updated (scopes={scopes})")
+    else:
+        client.post(f"/authorizationServers/{as_id}/policies/{policy_id}/rules", json_body=rule_body)
+        print(f"    ✓ Rule created (scopes={scopes})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rotate-secrets", action="store_true", help="Mint fresh client secrets.")
+    args = parser.parse_args()
+
+    load_env()
+    domain = okta_domain() if os.environ.get("OKTA_DOMAIN", "").strip() else ""
+    okta_token = os.environ.get("OKTA_ADMIN_TOKEN", "").strip()
+    as_id = os.environ.get("OKTA_AUTH_SERVER_ID", "default").strip() or "default"
+    if not domain or domain.startswith("integrator-1234567"):
+        die("OKTA_DOMAIN must be set to your Okta tenant (e.g. integrator-1234567.okta.com).")
+    if not okta_token:
+        die(
+            "OKTA_ADMIN_TOKEN is not set. Create one at Okta admin -> Security ->\n"
+            "API -> Tokens -> Create Token (needs Org/Super Admin), then add it to .env."
+        )
+
+    client = OktaClient(domain, okta_token)
+
+    print("[1/4] Authorization server…")
+    servers = client.get("/authorizationServers")
+    server = next((s for s in servers if s["id"] == as_id or s["name"] == as_id), None)
+    if not server:
+        die(
+            f"Authorization server '{as_id}' not found. This sample needs a CUSTOM\n"
+            f"authorization server (API Access Management). Available: "
+            f"{[(s['name'], s['id']) for s in servers]}"
+        )
+    # Okta accepts BOTH the literal id (aus…) and the alias "default" as the
+    # path segment, on the Admin API and on the discovery endpoint alike, and
+    # both discovery URLs report the same issuer. They are still not
+    # interchangeable downstream: the consent portal compares the gateway
+    # authorizer's discoveryUrl against the IdP credential provider's as
+    # STRINGS, so a deployment that mixes the two forms fails closed with
+    # `login_unavailable`. Keep the segment the operator configured and use it
+    # for every URL, so all three legs agree by construction.
+    as_url_segment = as_id
+    as_api_id = server["id"]
+    audiences = server.get("audiences") or []
+    audience = audiences[0] if audiences else "api://default"
+    print(f"  ✓ {server['name']} (id={as_api_id}, audience={audience})")
+    if as_url_segment != as_api_id:
+        print(f"    URLs will use the configured segment '{as_url_segment}' (same issuer).")
+    ensure_scope(client, as_api_id)
+
+    print("\n[2/4] App registrations…")
+    frontend_app, frontend_new = get_or_create_app(client, APP_LABELS["frontend"], [REDIRECT_URI])
+    portal_app, portal_new = get_or_create_app(client, APP_LABELS["portal"], [PORTAL_PLACEHOLDER_REDIRECT])
+
+    frontend_client_id = frontend_app["credentials"]["oauthClient"]["client_id"]
+    portal_client_id = portal_app["credentials"]["oauthClient"]["client_id"]
+
+    def get_secret(app: dict, is_new: bool, env_key: str) -> str | None:
+        if is_new:
+            secret = (app.get("credentials") or {}).get("oauthClient", {}).get("client_secret")
+            if secret:
+                return secret
+        if args.rotate_secrets or env_value_is_placeholder(env_key):
+            return rotate_client_secret(client, app["id"])
+        return None
+
+    frontend_secret = get_secret(frontend_app, frontend_new, "FRONTEND_CLIENT_SECRET")
+    portal_secret = get_secret(portal_app, portal_new, "PORTAL_CLIENT_SECRET")
+    minted = sum(1 for s in (frontend_secret, portal_secret) if s)
+    print(f"  ✓ Client secrets: {minted} freshly minted, {2 - minted} kept")
+
+    print("\n[3/4] Access policies (sleeping 3s for propagation)…")
+    time.sleep(3)
+    ensure_policy_and_rule(
+        client,
+        as_api_id,
+        name="Consent sample - Frontend",
+        client_id=frontend_client_id,
+        scopes=["openid", "profile", "email", "offline_access", SCOPE_NAME],
+    )
+    # The portal always requests openid plus PORTAL_SCOPES; every one of them
+    # must be admitted here or /authorize fails with a policy error.
+    ensure_policy_and_rule(
+        client,
+        as_api_id,
+        name="Consent sample - Portal login",
+        client_id=portal_client_id,
+        scopes=["openid", "profile", "email", SCOPE_NAME],
+    )
+
+    print("\n[4/4] Writing .env…")
+    env_writes = {
+        "IDP": "okta",
+        "OKTA_DOMAIN": client.domain,
+        "OKTA_AUTH_SERVER_ID": as_url_segment,
+        "PORTAL_APP_ID": portal_app["id"],
+        "FRONTEND_CLIENT_ID": frontend_client_id,
+        "PORTAL_CLIENT_ID": portal_client_id,
+        "IDP_DISCOVERY_URL": (f"https://{client.domain}/oauth2/{as_url_segment}/.well-known/openid-configuration"),
+        "IDP_AUDIENCE": audience,
+        # Okta uses the short scope name end to end — no qualified form.
+        "GATEWAY_SCOPE": SCOPE_NAME,
+        "PORTAL_SCOPES": f"openid {SCOPE_NAME}",
+    }
+    if frontend_secret:
+        env_writes["FRONTEND_CLIENT_SECRET"] = frontend_secret
+    if portal_secret:
+        env_writes["PORTAL_CLIENT_SECRET"] = portal_secret
+    save_env(**env_writes)
+    print("  ✓ Wrote IDs, discovery URL, audience, and scopes to .env")
+
+    print()
+    print("✓ Okta setup complete (frontend app + separate portal login app).")
+    print("  Make sure your test user is assigned to BOTH apps.")
+    print()
+    print("Next: python deploy/01_create_gateway.py --okta")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_delete_entra_apps.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_delete_entra_apps.py
@@ -1,0 +1,78 @@
+"""Delete the two Entra app registrations this sample created.
+
+Run this LAST — after `deploy/teardown.py`. The gateway resource app is the
+gateway's audience and the portal's login client, so deleting it while either
+still exists breaks them in ways that look like configuration bugs.
+
+Deletes by display name:
+  - agentcore-consent-github-gateway  (gateway audience + portal login client)
+  - agentcore-consent-github-frontend (the BFF's OIDC client)
+
+Run from the sample root:
+    python deploy/00_delete_entra_apps.py --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+
+APP_NAMES = [
+    "agentcore-consent-github-gateway",
+    "agentcore-consent-github-frontend",
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yes", action="store_true", help="Delete without prompting.")
+    args = parser.parse_args()
+
+    if not shutil.which("az"):
+        print("ERROR: Azure CLI (`az`) not found on PATH.", file=sys.stderr)
+        sys.exit(1)
+
+    found: list[tuple[str, str]] = []
+    for name in APP_NAMES:
+        proc = subprocess.run(
+            ["az", "ad", "app", "list", "--display-name", name, "--output", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            print(f"  ⚠ Could not list apps named {name}", file=sys.stderr)
+            continue
+        for app in json.loads(proc.stdout or "[]"):
+            found.append((name, app["appId"]))
+
+    if not found:
+        print("Nothing to delete — no matching app registrations found.")
+        return
+
+    print("Will delete these Entra app registrations:")
+    for name, app_id in found:
+        print(f"  - {name} ({app_id})")
+    if not args.yes and input("\nProceed? [y/N] ").strip().lower() not in ("y", "yes"):
+        print("Aborted.")
+        return
+
+    for name, app_id in found:
+        proc = subprocess.run(
+            ["az", "ad", "app", "delete", "--id", app_id],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            print(f"  ✓ Deleted {name}")
+        else:
+            err = (proc.stderr or proc.stdout).strip().splitlines()
+            print(f"  ⚠ Failed to delete {name}: {err[-1] if err else 'unknown'}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_delete_okta_apps.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/00_delete_okta_apps.py
@@ -1,0 +1,129 @@
+"""Delete the two Okta apps this sample created (and optionally its AS policies).
+
+Run this LAST — after `deploy/teardown.py`.
+
+Okta requires an app to be deactivated before it can be deleted, so each app
+gets a POST .../lifecycle/deactivate followed by a DELETE.
+
+Deletes by label:
+  - AgentCore Consent GitHub Frontend
+  - agentcore-consent-portal-login
+
+Leaves alone by default: the `access_as_user` scope and the two access
+policies on the authorization server, because the authorization server is
+usually shared. Pass --policies to remove the two policies this sample added
+(named "Consent sample - …"); the scope is left either way.
+
+Needs OKTA_DOMAIN and OKTA_ADMIN_TOKEN in .env.
+
+Run from the sample root:
+    python deploy/00_delete_okta_apps.py --yes
+    python deploy/00_delete_okta_apps.py --yes --policies
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import load_env, okta_domain
+
+APP_LABELS = [
+    "AgentCore Consent GitHub Frontend",
+    "agentcore-consent-portal-login",
+]
+POLICY_NAMES = [
+    "Consent sample - Frontend",
+    "Consent sample - Portal login",
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yes", action="store_true", help="Delete without prompting.")
+    parser.add_argument(
+        "--policies",
+        action="store_true",
+        help="Also delete the two access policies this sample added to the authorization server.",
+    )
+    args = parser.parse_args()
+
+    load_env()
+    domain = okta_domain() if os.environ.get("OKTA_DOMAIN", "").strip() else ""
+    token = os.environ.get("OKTA_ADMIN_TOKEN", "").strip()
+    as_id = os.environ.get("OKTA_AUTH_SERVER_ID", "default").strip() or "default"
+    if not domain or not token:
+        print("ERROR: OKTA_DOMAIN and OKTA_ADMIN_TOKEN must be set in .env.", file=sys.stderr)
+        sys.exit(1)
+
+    base = f"https://{domain}/api/v1"
+    headers = {
+        "Authorization": f"SSWS {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    found: list[tuple[str, str]] = []
+    for label in APP_LABELS:
+        resp = requests.get(
+            f"{base}/apps",
+            headers=headers,
+            params={"q": label, "limit": 20},
+            timeout=30,
+        )
+        if resp.status_code >= 400:
+            print(f"  ⚠ Could not list apps matching {label} (HTTP {resp.status_code})", file=sys.stderr)
+            continue
+        for app in resp.json():
+            if app.get("label") == label:
+                found.append((label, app["id"]))
+
+    policies_to_delete: list[tuple[str, str]] = []
+    if args.policies:
+        resp = requests.get(f"{base}/authorizationServers/{as_id}/policies", headers=headers, timeout=30)
+        if resp.status_code < 400:
+            for p in resp.json():
+                if p.get("name") in POLICY_NAMES:
+                    policies_to_delete.append((p["name"], p["id"]))
+
+    if not found and not policies_to_delete:
+        print("Nothing to delete — no matching Okta apps or policies found.")
+        return
+
+    print("Will delete:")
+    for label, app_id in found:
+        print(f"  - app: {label} ({app_id})")
+    for name, pid in policies_to_delete:
+        print(f"  - policy: {name} ({pid}) on authorization server {as_id}")
+    if not args.yes and input("\nProceed? [y/N] ").strip().lower() not in ("y", "yes"):
+        print("Aborted.")
+        return
+
+    for label, app_id in found:
+        # Okta refuses to delete an ACTIVE app.
+        requests.post(f"{base}/apps/{app_id}/lifecycle/deactivate", headers=headers, timeout=30)
+        resp = requests.delete(f"{base}/apps/{app_id}", headers=headers, timeout=30)
+        if resp.status_code < 400:
+            print(f"  ✓ Deleted app: {label}")
+        else:
+            print(f"  ⚠ Failed to delete app {label} (HTTP {resp.status_code})", file=sys.stderr)
+
+    for name, pid in policies_to_delete:
+        resp = requests.delete(f"{base}/authorizationServers/{as_id}/policies/{pid}", headers=headers, timeout=30)
+        if resp.status_code < 400:
+            print(f"  ✓ Deleted policy: {name}")
+        else:
+            print(f"  ⚠ Failed to delete policy {name} (HTTP {resp.status_code})", file=sys.stderr)
+
+    print()
+    print(f"Left in place: the `access_as_user` scope on authorization server {as_id}.")
+    print("Remove it yourself if nothing else uses it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/01_create_gateway.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/01_create_gateway.py
@@ -1,0 +1,316 @@
+"""Create the AgentCore Gateway that the consent portal will front.
+
+Creates, idempotently:
+  1. The gateway service role (AmazonBedrockAgentCoreGatewayRole-<GATEWAY_NAME>),
+     unless GATEWAY_SERVICE_ROLE_ARN is set. It needs the AgentCore Identity
+     token operations, because the gateway itself performs the outbound 3LO
+     exchange against GitHub on the user's behalf, plus read access to the
+     identity service's own OAuth secrets and CloudWatch Logs.
+  2. The gateway: protocolType MCP, inbound authorizerType CUSTOM_JWT over
+     your IdP's OIDC discovery URL.
+
+Two details that are load-bearing and easy to get wrong:
+
+  * supportedVersions must include "2025-11-25". That MCP protocol version is
+    what enables URL-mode elicitation, which is how the gateway asks an
+    unconsented user to authorize a 3LO target. On older versions only, an
+    AUTHORIZATION_CODE target has no way to prompt.
+
+  * The gateway's authorizer and the consent portal's IdP credential provider
+    must reference the SAME OIDC issuer. CreateConsentPortal validates this at
+    create time, so a mismatch is rejected in step 02 rather than at login.
+    Both read IDP_DISCOVERY_URL from .env, so they agree by construction.
+
+On a re-run the authorizer config is reconciled if it drifted (a rotated
+GATEWAY_CLIENT_ID or a discovery URL edited by hand) — both of those surface
+at runtime as an opaque 401 during MCP initialization.
+
+Writes to .env: GATEWAY_ID, GATEWAY_URL, GATEWAY_MCP_URL,
+GATEWAY_SERVICE_ROLE_ARN.
+
+If the consent portal later answers `login_unavailable` on GET /login, re-run
+this with --reapply-authorizer. Re-sending an unchanged authorizer makes the
+portal re-resolve it; a portal created before the gateway's authorizer was
+resolvable otherwise stays broken with a deliberately non-diagnostic error.
+
+Run from the sample root:
+    python deploy/01_create_gateway.py --entra
+    python deploy/01_create_gateway.py --okta
+    python deploy/01_create_gateway.py --okta --reapply-authorizer
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    check_boto_version,
+    control_client,
+    discovery_url,
+    find_gateway_by_name,
+    gateway_name,
+    gateway_role_name,
+    load_env,
+    must_env,
+    save_env,
+    select_idp_with_args,
+)
+
+# Newest first. 2025-11-25 enables URL-mode elicitation (the authorization
+# code flow); the older two are listed so a client that cannot speak it still
+# connects instead of failing version negotiation.
+MCP_SUPPORTED_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"]
+
+ROLE_POLICY_NAME = "AgentCoreGatewayOutboundAuth"
+
+
+def allowed_audiences(idp: dict, audience: str) -> list[str]:
+    """The audiences the gateway accepts on inbound tokens.
+
+    Entra with requestedAccessTokenVersion 2 sets aud to the bare application
+    id, but the identifier-URI form is accepted too by some client libraries,
+    so both are listed. Okta stamps aud from the authorization server's
+    `audiences` value verbatim, and api://<that> would be wrong.
+    """
+    if idp["name"] == "entra":
+        return [audience, f"api://{audience}"]
+    return [audience]
+
+
+def ensure_service_role(iam, role_name: str, account_id: str, region: str) -> str:
+    trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+                # Confused-deputy guards.
+                "Condition": {
+                    "StringEquals": {"aws:SourceAccount": account_id},
+                    "ArnLike": {"aws:SourceArn": f"arn:aws:bedrock-agentcore:{region}:{account_id}:*"},
+                },
+            }
+        ],
+    }
+    permission_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                # The gateway calls these to obtain the user's GitHub token
+                # from the token vault (or to mint the authorization URL when
+                # the user has not consented yet).
+                "Sid": "AgentCoreIdentityOutbound",
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+                    "bedrock-agentcore:GetWorkloadAccessToken",
+                    "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+                    "bedrock-agentcore:GetResourceOauth2Token",
+                    "bedrock-agentcore:CompleteResourceTokenAuth",
+                ],
+                "Resource": "*",
+            },
+            {
+                "Sid": "ReadAgentCoreOauthSecrets",
+                "Effect": "Allow",
+                "Action": ["secretsmanager:GetSecretValue"],
+                "Resource": [
+                    (f"arn:aws:secretsmanager:{region}:{account_id}:secret:bedrock-agentcore-identity!default/oauth2/*")
+                ],
+            },
+            {
+                "Sid": "CloudWatchLogs",
+                "Effect": "Allow",
+                "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:DescribeLogStreams",
+                ],
+                "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/gateway*",
+            },
+        ],
+    }
+
+    created = False
+    try:
+        role_arn = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(trust_policy),
+            Description="AgentCore Gateway service role - consent portal + GitHub MCP sample",
+        )["Role"]["Arn"]
+        print(f"  ✓ Created IAM role: {role_name}")
+        created = True
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in {"EntityAlreadyExists", "EntityAlreadyExistsException"}:
+            raise
+        role_arn = iam.get_role(RoleName=role_name)["Role"]["Arn"]
+        print(f"  • IAM role already exists: {role_name}")
+
+    # Unconditional: put_role_policy is an upsert, so a re-run repairs drift.
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName=ROLE_POLICY_NAME,
+        PolicyDocument=json.dumps(permission_policy),
+    )
+    print(f"  ✓ Attached inline policy: {ROLE_POLICY_NAME}")
+
+    if created:
+        print("  ⏳ Waiting 10s for IAM role propagation…")
+        time.sleep(10)
+    return role_arn
+
+
+def wait_for_ready(control, gateway_id: str) -> None:
+    """CreateGatewayTarget is rejected while the gateway is still CREATING."""
+    for attempt in range(40):
+        gw = control.get_gateway(gatewayIdentifier=gateway_id)
+        status = gw.get("status", "UNKNOWN")
+        if status == "READY":
+            if attempt:
+                print(f"  ✓ Gateway status: READY (after {attempt * 3}s)")
+            return
+        if status in {"FAILED", "DELETING", "DELETED"}:
+            reason = gw.get("statusReasons") or gw.get("failureReason") or "n/a"
+            print(f"ERROR: gateway entered terminal state {status}. Reason: {reason}", file=sys.stderr)
+            sys.exit(1)
+        if attempt == 0:
+            print(f"  ⏳ Waiting for gateway to reach READY (current: {status})…")
+        time.sleep(3)
+    print("ERROR: gateway did not reach READY within 2 minutes.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    idp, args = select_idp_with_args(
+        __doc__,
+        [
+            (
+                ["--reapply-authorizer"],
+                {
+                    "action": "store_true",
+                    "help": "Re-send the authorizer even if unchanged. Use this when the "
+                    "consent portal answers login_unavailable — it makes the portal "
+                    "re-resolve the gateway's authorizer.",
+                },
+            )
+        ],
+    )
+    reapply = args.reapply_authorizer
+    check_boto_version()
+    load_env()
+
+    name = gateway_name(idp)
+    disco = discovery_url(idp)
+    audience = must_env("IDP_AUDIENCE")
+    audiences = allowed_audiences(idp, audience)
+
+    control, region = control_client()
+    iam = boto3.client("iam", region_name=region)
+    account_id = boto3.client("sts", region_name=region).get_caller_identity()["Account"]
+
+    print(f"--- Step 1: gateway service role ({idp['displayName']}) ---")
+    import os
+
+    role_arn = os.environ.get("GATEWAY_SERVICE_ROLE_ARN", "").strip()
+    if role_arn:
+        print(f"  • Using GATEWAY_SERVICE_ROLE_ARN from .env: {role_arn}")
+    else:
+        role_arn = ensure_service_role(iam, gateway_role_name(idp), account_id, region)
+
+    authorizer_config = {"customJWTAuthorizer": {"discoveryUrl": disco, "allowedAudience": audiences}}
+    protocol_config = {
+        "mcp": {
+            "supportedVersions": MCP_SUPPORTED_VERSIONS,
+            "searchType": "SEMANTIC",
+            "sessionConfiguration": {"sessionTimeoutInSeconds": 3600},
+            "streamingConfiguration": {"enableResponseStreaming": True},
+        }
+    }
+
+    print(f"\n--- Step 2: gateway ({name}) ---")
+    print(f"  discoveryUrl:    {disco}")
+    print(f"  allowedAudience: {audiences}")
+    existing = find_gateway_by_name(control, name)
+    if existing:
+        gateway_id = existing["gatewayId"]
+        gateway_url = existing.get("gatewayUrl") or ""
+        print(f"  • Gateway already exists. ID: {gateway_id}")
+
+        # Reconcile authorizer drift. Both known causes (a rotated client id,
+        # or a hand-edited discovery URL) surface at runtime as a 401 during
+        # MCP initialization, which is very hard to attribute.
+        #
+        # Read the authorizer from GetGateway, not from the ListGateways
+        # summary: the summary carries only authorizerType, never
+        # authorizerConfiguration, so comparing against it reports drift on
+        # every run and rewrites a gateway that was already correct.
+        full = control.get_gateway(gatewayIdentifier=gateway_id)
+        current = (full.get("authorizerConfiguration") or {}).get("customJWTAuthorizer", {}) or {}
+        drifted = current.get("discoveryUrl") != disco or set(current.get("allowedAudience") or []) != set(audiences)
+        if drifted or reapply:
+            if drifted:
+                print("  • Authorizer drift detected — updating.")
+                print(f"      discoveryUrl was: {current.get('discoveryUrl') or '(unset)'}")
+                print(f"      allowedAudience was: {sorted(current.get('allowedAudience') or [])}")
+            else:
+                print("  • --reapply-authorizer: re-sending an unchanged authorizer.")
+                print("      This is the fix for a portal answering login_unavailable —")
+                print("      it makes the portal re-resolve the gateway's authorizer.")
+            control.update_gateway(
+                gatewayIdentifier=gateway_id,
+                name=name,
+                roleArn=role_arn,
+                protocolType="MCP",
+                protocolConfiguration=protocol_config,
+                authorizerType="CUSTOM_JWT",
+                authorizerConfiguration=authorizer_config,
+            )
+            print("  ✓ Gateway authorizer updated.")
+    else:
+        response = control.create_gateway(
+            name=name,
+            roleArn=role_arn,
+            description="Consent portal + GitHub MCP server sample",
+            protocolType="MCP",
+            protocolConfiguration=protocol_config,
+            authorizerType="CUSTOM_JWT",
+            authorizerConfiguration=authorizer_config,
+            # DEBUG surfaces the underlying cause in tool-call errors, which
+            # is what makes the -32042 elicitation legible in the agent logs.
+            exceptionLevel="DEBUG",
+        )
+        gateway_id = response["gatewayId"]
+        gateway_url = response.get("gatewayUrl", "")
+        print(f"  ✓ Created. ID: {gateway_id}")
+
+    wait_for_ready(control, gateway_id)
+
+    if not gateway_url:
+        gateway_url = control.get_gateway(gatewayIdentifier=gateway_id).get("gatewayUrl", "")
+    mcp_url = gateway_url if gateway_url.endswith("/mcp") else gateway_url.rstrip("/") + "/mcp"
+
+    save_env(
+        GATEWAY_NAME=name,
+        GATEWAY_ID=gateway_id,
+        GATEWAY_URL=gateway_url,
+        GATEWAY_MCP_URL=mcp_url,
+        GATEWAY_SERVICE_ROLE_ARN=role_arn,
+    )
+    print(f"\n  MCP endpoint: {mcp_url}")
+    print("  Saved to .env: GATEWAY_NAME, GATEWAY_ID, GATEWAY_URL, GATEWAY_MCP_URL,")
+    print("    GATEWAY_SERVICE_ROLE_ARN")
+    print()
+    print(f"Next: python deploy/02_create_portal.py --{idp['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/01_create_gateway.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/01_create_gateway.py
@@ -3,8 +3,9 @@
 Creates, idempotently:
   1. The gateway service role (AmazonBedrockAgentCoreGatewayRole-<GATEWAY_NAME>),
      unless GATEWAY_SERVICE_ROLE_ARN is set. It needs the AgentCore Identity
-     token operations, because the gateway itself performs the outbound 3LO
-     exchange against GitHub on the user's behalf, plus read access to the
+     token operations, because the gateway itself performs the outbound
+     authorization code flow against GitHub on the user's behalf, plus read
+     access to the
      identity service's own OAuth secrets and CloudWatch Logs.
   2. The gateway: protocolType MCP, inbound authorizerType CUSTOM_JWT over
      your IdP's OIDC discovery URL.
@@ -13,7 +14,8 @@ Two details that are load-bearing and easy to get wrong:
 
   * supportedVersions must include "2025-11-25". That MCP protocol version is
     what enables URL-mode elicitation, which is how the gateway asks an
-    unconsented user to authorize a 3LO target. On older versions only, an
+    unconsented user to authorize an authorization-code-flow target. On older
+    versions only, an
     AUTHORIZATION_CODE target has no way to prompt.
 
   * The gateway's authorizer and the consent portal's IdP credential provider
@@ -116,7 +118,29 @@ def ensure_service_role(iam, role_name: str, account_id: str, region: str) -> st
                     "bedrock-agentcore:GetResourceOauth2Token",
                     "bedrock-agentcore:CompleteResourceTokenAuth",
                 ],
-                "Resource": "*",
+                # These actions DO support resource-level permissions, so they
+                # are scoped rather than left on "*". Per the AWS service
+                # reference, GetWorkloadAccessToken* accept workload-identity
+                # and workload-identity-directory; GetResourceOauth2Token and
+                # CompleteResourceTokenAuth additionally accept token-vault and
+                # oauth2credentialprovider. No one type is marked required, so
+                # both families are covered below rather than guessing which the
+                # service authorizes against.
+                #
+                # The vault and directory ids stay wildcarded: AgentCore names
+                # them ("default" today) and mints a workload identity per
+                # runtime/gateway, so pinning exact ids would break the moment
+                # the service picks a different one. Region and account are
+                # still pinned, which is the part that matters.
+                "Resource": [
+                    # token-vault/* also covers .../oauth2credentialprovider/*,
+                    # and workload-identity-directory/* also covers
+                    # .../workload-identity/*, because an IAM wildcard spans "/".
+                    # Listing the children as well is redundant — IAM Access
+                    # Analyzer flags it.
+                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/*",
+                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/*",
+                ],
             },
             {
                 "Sid": "ReadAgentCoreOauthSecrets",

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/02_create_portal.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/02_create_portal.py
@@ -168,7 +168,19 @@ def ensure_execution_role(iam, role_name: str, gateway_id: str, region: str, acc
                     "bedrock-agentcore:GetResourceOauth2Token",
                     "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
                 ],
-                "Resource": "*",
+                # Scoped, not "*" — these actions support resource-level
+                # permissions. See the matching comment in
+                # 01_create_gateway.py for which resource types each accepts
+                # and why the vault/directory ids stay wildcarded.
+                "Resource": [
+                    # token-vault/* also covers .../oauth2credentialprovider/*,
+                    # and workload-identity-directory/* also covers
+                    # .../workload-identity/*, because an IAM wildcard spans "/".
+                    # Listing the children as well is redundant — IAM Access
+                    # Analyzer flags it.
+                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/*",
+                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/*",
+                ],
             },
             {
                 "Effect": "Allow",

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/02_create_portal.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/02_create_portal.py
@@ -1,0 +1,472 @@
+"""Create the AgentCore managed consent portal over the gateway from step 01.
+
+Three resources, each idempotent:
+
+  1. The PRIMARY IdP OAuth2 credential provider — who your end users sign in
+     as. This is not the outbound provider they later connect to. It must
+     issue JWT access tokens, which rules out the OAuth2-only vendors
+     (GithubOauth2, SlackOauth2, SalesforceOauth2, AtlasianOauth2,
+     LinkedinOauth2); those are valid *outbound* providers, which is exactly
+     what GitHub is used for in step 03.
+
+     Vendor is CustomOauth2 even for Entra: the MicrosoftOauth2 config takes a
+     tenantId and leaves nowhere to state a discovery URL, and with Entra the
+     discovery URL (specifically its /v2.0/ segment) is the thing that has to
+     be right.
+
+  2. The execution role the portal assumes in your account to read the
+     gateway, its targets and the credential providers, and to call the token
+     operations. There is a chicken-and-egg problem in its trust policy's
+     aws:SourceArn — you cannot know the portal ARN before the portal exists —
+     so the role is created with a wildcard consent-portal/* ARN and re-put
+     pinned to the exact ARN as soon as CreateConsentPortal returns it.
+
+  3. The consent portal itself, polled until status is ACTIVE *and* portalUrl
+     is non-empty. Everything after this is built from that URL.
+
+Then it registers `https://<portalUrl>/callback` as a redirect URI on the
+primary IdP app — Entra via `az`, Okta via the Admin API — because that URL
+does not exist until now. If the CLI or admin token is unavailable it prints
+the command for you to run.
+
+Writes to .env: PORTAL_ID, PORTAL_ARN, PORTAL_URL (bare host),
+PORTAL_CALLBACK_URL, PORTAL_CONNECT_RETURN_URL, IDP_PROVIDER_ARN,
+PORTAL_EXECUTION_ROLE_ARN.
+
+Run from the sample root:
+    python deploy/02_create_portal.py --entra
+    python deploy/02_create_portal.py --okta
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    check_boto_version,
+    control_client,
+    discovery_url,
+    find_portal_by_name,
+    idp_provider_name,
+    load_env,
+    must_env,
+    okta_domain,
+    portal_name,
+    portal_role_name,
+    portal_scopes,
+    save_env,
+    select_idp,
+)
+
+# Public and stable — see the consent portal execution role documentation.
+CONSENT_PORTAL_SERVICE_PRINCIPAL = "bedrock-agentcore.amazonaws.com"
+TERMINAL_STATUSES = ("FAILED", "UPDATE_FAILED", "DELETING")
+MAX_PORTAL_NAME_LENGTH = 50
+ROLE_POLICY_NAME = "ConsentPortalAccess"
+
+
+def portal_client_secret() -> str:
+    """Read the portal login app's secret without putting it in argv."""
+    secret = os.environ.get("PORTAL_CLIENT_SECRET")
+    if not secret or secret in ("replace-me", "REPLACE_ME"):
+        secret = getpass.getpass("Portal login client secret: ")
+    if not secret:
+        print("ERROR: PORTAL_CLIENT_SECRET not set and nothing entered.", file=sys.stderr)
+        sys.exit(1)
+    return secret
+
+
+def ensure_idp_provider(control, idp: dict, name: str, client_id: str, secret: str, disco: str) -> str:
+    print(f"--- Step 1: primary IdP credential provider ({idp['displayName']}) ---")
+    config = {
+        "clientId": client_id,
+        "clientSecret": secret,
+        "oauthDiscovery": {"discoveryUrl": disco},
+    }
+    try:
+        arn = control.create_oauth2_credential_provider(
+            name=name,
+            credentialProviderVendor=idp["vendor"],
+            oauth2ProviderConfigInput={idp["providerConfigKey"]: config},
+        )["credentialProviderArn"]
+        print(f"  ✓ Created: {name}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in ("ConflictException", "ValidationException"):
+            raise
+        arn = control.get_oauth2_credential_provider(name=name)["credentialProviderArn"]
+        print(f"  • Reusing existing: {name}")
+    print(f"  arn: {arn}")
+    return arn
+
+
+def trust_policy(account_id: str, region: str, portal_arn: str | None = None) -> dict:
+    source_arn = portal_arn or f"arn:aws:bedrock-agentcore:{region}:{account_id}:consent-portal/*"
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "ConsentPortalAssumeRolePolicy",
+                "Effect": "Allow",
+                "Principal": {"Service": CONSENT_PORTAL_SERVICE_PRINCIPAL},
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "StringEquals": {"aws:SourceAccount": account_id},
+                    "ArnLike": {"aws:SourceArn": source_arn},
+                },
+            }
+        ],
+    }
+
+
+def ensure_execution_role(iam, role_name: str, gateway_id: str, region: str, account_id: str) -> str:
+    """Create or repair the portal's execution role.
+
+    The permissions policy mirrors the one in the AgentCore developer guide:
+    read the gateway and its targets, read credential providers in the default
+    token vault, the three token operations, and the identity service's own
+    OAuth secrets (tag-conditioned).
+    """
+    print("\n--- Step 2: execution role ---")
+    access_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock-agentcore:GetGateway",
+                    "bedrock-agentcore:GetGatewayTarget",
+                    "bedrock-agentcore:ListGatewayTargets",
+                ],
+                "Resource": f"arn:aws:bedrock-agentcore:{region}:{account_id}:gateway/{gateway_id}",
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock-agentcore:GetOauth2CredentialProvider",
+                    "bedrock-agentcore:ListOauth2CredentialProviders",
+                ],
+                "Resource": [
+                    (f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/default/oauth2credentialprovider/*"),
+                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/default",
+                ],
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock-agentcore:CompleteResourceTokenAuth",
+                    "bedrock-agentcore:GetResourceOauth2Token",
+                    "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+                ],
+                "Resource": "*",
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["secretsmanager:GetSecretValue"],
+                "Resource": [
+                    (f"arn:aws:secretsmanager:{region}:{account_id}:secret:bedrock-agentcore-identity!default/oauth2/*")
+                ],
+                "Condition": {
+                    "StringEquals": {"aws:ResourceTag/aws:secretsmanager:owningService": "bedrock-agentcore-identity"}
+                },
+            },
+        ],
+    }
+
+    try:
+        role_arn = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(trust_policy(account_id, region)),
+            Description="Consent portal execution role - GitHub MCP sample",
+        )["Role"]["Arn"]
+        print(f"  ✓ Created: {role_name}")
+    except iam.exceptions.EntityAlreadyExistsException:
+        role_arn = iam.get_role(RoleName=role_name)["Role"]["Arn"]
+        print(f"  • Reusing existing: {role_name}")
+
+    # Unconditional, not only on create: a re-run should repair drift.
+    iam.put_role_policy(RoleName=role_name, PolicyName=ROLE_POLICY_NAME, PolicyDocument=json.dumps(access_policy))
+    print(f"  arn: {role_arn}")
+    print(f"  trusts: {CONSENT_PORTAL_SERVICE_PRINCIPAL}")
+    return role_arn
+
+
+def wait_for_active(control, portal_id: str) -> str:
+    """Poll until ACTIVE with a portalUrl, or fail loudly.
+
+    Waits on portalUrl and not just on ACTIVE: the URL is what every later
+    step needs, and an ACTIVE portal without one would sail through here and
+    break in step 04 instead.
+    """
+    print("\n  waiting for ACTIVE…")
+    last_status = None
+    for _ in range(30):
+        portal = control.get_consent_portal(consentPortalIdentifier=portal_id)
+        status = portal["status"]
+        if status != last_status:
+            print(f"    status: {status}")
+            last_status = status
+        url = portal.get("portalUrl")
+        if status == "ACTIVE" and url:
+            return url
+        if status in TERMINAL_STATUSES:
+            print(f"ERROR: portal reached terminal status {status}", file=sys.stderr)
+            reason = portal.get("statusReason")
+            if reason:
+                print(f"  reason: {reason}", file=sys.stderr)
+            sys.exit(1)
+        time.sleep(10)
+    print("ERROR: portal did not become ACTIVE with a portalUrl in time.", file=sys.stderr)
+    print(
+        f"  check: aws bedrock-agentcore-control get-consent-portal --consent-portal-identifier {portal_id}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def create_portal_with_retry(control, **kwargs):
+    """CreateConsentPortal, retrying while IAM is still eventually consistent.
+
+    A role created seconds ago is not always assumable yet, and the API
+    surfaces that as a validation error about the execution role rather than
+    as a retryable throttle.
+    """
+    for attempt in range(6):
+        try:
+            return control.create_consent_portal(**kwargs)
+        except ClientError as e:
+            err = e.response["Error"]
+            message = err.get("Message", "")
+            retryable = err["Code"] == "ValidationException" and (
+                "role" in message.lower() or "assume" in message.lower()
+            )
+            if not retryable or attempt == 5:
+                raise
+            print(f"    execution role not assumable yet, retrying: {message}")
+            time.sleep(10)
+    raise AssertionError("unreachable")
+
+
+# --- Registering the portal callback on the IdP ---------------------------------
+
+
+def register_callback_entra(client_id: str, callback_url: str) -> bool:
+    """Add the portal callback to the Entra app's web.redirectUris.
+
+    --web-redirect-uris REPLACES the array, so the current list is read first
+    and the new URI appended. Under Entra this app is also the gateway
+    resource app and may already carry other web redirects.
+    """
+    if not shutil.which("az"):
+        return False
+    show = subprocess.run(
+        ["az", "ad", "app", "show", "--id", client_id, "--query", "web.redirectUris", "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if show.returncode != 0:
+        return False
+    try:
+        current = json.loads(show.stdout or "[]") or []
+    except json.JSONDecodeError:
+        current = []
+    if callback_url in current:
+        print(f"  • Callback already registered on Entra app {client_id}")
+        return True
+    merged = current + [callback_url]
+    update = subprocess.run(
+        ["az", "ad", "app", "update", "--id", client_id, "--web-redirect-uris", *merged],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if update.returncode != 0:
+        print(f"  ⚠ az ad app update failed: {(update.stderr or '').strip().splitlines()[-1:]}", file=sys.stderr)
+        return False
+    print(f"  ✓ Registered callback on Entra app (now {len(merged)} web redirect URI(s))")
+    return True
+
+
+def register_callback_okta(callback_url: str) -> bool:
+    """Replace the placeholder redirect on the Okta portal app with the real one.
+
+    Okta full-object PUTs replace the whole app, so the app is fetched, its
+    redirect_uris swapped, and the whole object put back.
+    """
+    domain = okta_domain() if os.environ.get("OKTA_DOMAIN", "").strip() else ""
+    token = os.environ.get("OKTA_ADMIN_TOKEN", "").strip()
+    app_id = os.environ.get("PORTAL_APP_ID", "").strip()
+    if not (domain and token and app_id):
+        return False
+    import requests
+
+    headers = {
+        "Authorization": f"SSWS {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    base = f"https://{domain}/api/v1/apps/{app_id}"
+    resp = requests.get(base, headers=headers, timeout=30)
+    if resp.status_code >= 400:
+        print(f"  ⚠ Okta GET /apps/{app_id} returned {resp.status_code}", file=sys.stderr)
+        return False
+    app = resp.json()
+    uris = app["settings"]["oauthClient"].get("redirect_uris") or []
+    # Drop the Step-1 placeholder; keep any real URIs already registered.
+    uris = [u for u in uris if not u.startswith("https://localhost/placeholder")]
+    if callback_url not in uris:
+        uris.append(callback_url)
+    app["settings"]["oauthClient"]["redirect_uris"] = uris
+    put = requests.put(base, headers=headers, json=app, timeout=30)
+    if put.status_code >= 400:
+        print(f"  ⚠ Okta PUT /apps/{app_id} returned {put.status_code}", file=sys.stderr)
+        return False
+    print(f"  ✓ Registered callback on Okta portal app (redirect_uris={uris})")
+    return True
+
+
+def print_callback_hint(idp: dict, callback_url: str) -> None:
+    print()
+    print("=" * 68)
+    print("  DO THIS NOW, before creating the GitHub target:")
+    print()
+    print("  Register the portal's callback on its login app. Enter it exactly,")
+    print("  with NO trailing slash — a trailing slash makes the IdP reject the")
+    print("  callback as unregistered, and the failure surfaces as a generic")
+    print("  login error.")
+    print()
+    for line in idp.get("portalCallbackHint", []):
+        print(line.replace("<PORTAL_CALLBACK_URL>", callback_url))
+    print("=" * 68)
+
+
+def main() -> None:
+    idp = select_idp(__doc__)
+    check_boto_version()
+    load_env()
+
+    gateway_id = must_env("GATEWAY_ID")
+    audience = must_env("IDP_AUDIENCE")
+    client_id = must_env("PORTAL_CLIENT_ID")
+    disco = discovery_url(idp)
+    scopes = portal_scopes()
+    secret = portal_client_secret()
+
+    name = portal_name(idp)
+    if not 1 <= len(name) <= MAX_PORTAL_NAME_LENGTH:
+        print(f"ERROR: portal name must be 1-{MAX_PORTAL_NAME_LENGTH} characters.", file=sys.stderr)
+        print(f"  got: {name} ({len(name)})", file=sys.stderr)
+        sys.exit(1)
+
+    control, region = control_client()
+    iam = boto3.client("iam", region_name=region)
+    account_id = boto3.client("sts", region_name=region).get_caller_identity()["Account"]
+
+    idp_arn = ensure_idp_provider(control, idp, idp_provider_name(idp), client_id, secret, disco)
+    role_arn = ensure_execution_role(iam, portal_role_name(idp), gateway_id, region, account_id)
+
+    print("\n--- Step 3: consent portal ---")
+    print(f"  name:     {name}")
+    print(f"  scopes:   {', '.join(scopes)}")
+    print(f"  audience: {audience}")
+    print(f"  source:   gateway {gateway_id}")
+    existing = find_portal_by_name(control, name)
+    if existing:
+        portal_id = existing["consentPortalId"]
+        print(f"  • Reusing existing portal: {portal_id}")
+        portal = control.get_consent_portal(consentPortalIdentifier=portal_id)
+        portal_arn = portal["consentPortalArn"]
+        portal_url = portal.get("portalUrl")
+        if not portal_url or portal["status"] != "ACTIVE":
+            portal_url = wait_for_active(control, portal_id)
+    else:
+        response = create_portal_with_retry(
+            control,
+            name=name,
+            executionRoleArn=role_arn,
+            idpConfig={
+                "credentialProviderArn": idp_arn,
+                # openid is guaranteed present by portal_scopes(): the portal
+                # always requests it, and every scope it requests must be
+                # permitted on the IdP app or authorization fails with
+                # invalid_scope.
+                "scopes": scopes,
+                "audience": audience,
+            },
+            # Exactly one source, and it is not updatable — the gateway a
+            # portal fronts is fixed for the portal's life.
+            sources=[{"identifier": gateway_id, "type": "agentcore-gateway"}],
+            description=f"GitHub MCP consent portal backed by {idp['displayName']}",
+        )
+        portal_id = response["consentPortalId"]
+        portal_arn = response["consentPortalArn"]
+        print(f"  ✓ Created. ID: {portal_id}")
+        portal_url = response.get("portalUrl")
+        if not portal_url or response["status"] != "ACTIVE":
+            portal_url = wait_for_active(control, portal_id)
+
+    iam.update_assume_role_policy(
+        RoleName=portal_role_name(idp),
+        PolicyDocument=json.dumps(trust_policy(account_id, region, portal_arn)),
+    )
+    print(f"  ✓ Trust policy pinned to: {portal_arn}")
+
+    # portalUrl's scheme is not guaranteed: observed WITH "https://" in
+    # us-west-2, and documented elsewhere as a bare host. Normalize to a bare
+    # host, then derive the two URLs with the scheme attached, so nothing
+    # downstream has to get this right twice or double up the prefix.
+    #
+    # The hostname is derived from the GATEWAY id, not the portal id
+    # (entra-consent-github-gw-xxxx.consent-portal.<region>.amazonaws.com),
+    # which is worth knowing when you go looking for it in a browser.
+    bare_url = portal_url.removeprefix("https://").rstrip("/")
+    callback_url = f"https://{bare_url}/callback"
+    connect_return_url = f"https://{bare_url}/connect/callback"
+
+    save_env(
+        PORTAL_ID=portal_id,
+        PORTAL_ARN=portal_arn,
+        PORTAL_URL=bare_url,
+        PORTAL_CALLBACK_URL=callback_url,
+        PORTAL_CONNECT_RETURN_URL=connect_return_url,
+        IDP_PROVIDER_ARN=idp_arn,
+        PORTAL_EXECUTION_ROLE_ARN=role_arn,
+    )
+    print(f"\n  portal url: https://{bare_url}")
+    print("  Saved to .env: PORTAL_ID, PORTAL_ARN, PORTAL_URL, PORTAL_CALLBACK_URL,")
+    print("    PORTAL_CONNECT_RETURN_URL, IDP_PROVIDER_ARN, PORTAL_EXECUTION_ROLE_ARN")
+
+    print("\n--- Step 4: register the portal callback on the IdP ---")
+    registered = (
+        register_callback_entra(client_id, callback_url)
+        if idp["name"] == "entra"
+        else register_callback_okta(callback_url)
+    )
+    if not registered:
+        print("  • Could not register it automatically.")
+        print_callback_hint(idp, callback_url)
+
+    print()
+    print("Verify the login leg now:")
+    print(f"    open https://{bare_url}")
+    print("  Sign in with an IdP user. Expect an EMPTY Connections page — that")
+    print("  empty page is the success condition: the gateway has no")
+    print("  AUTHORIZATION_CODE targets yet, so there is nothing to consent to.")
+    print()
+    print("Next: create the GitHub OAuth App, export GITHUB_CLIENT_ID/SECRET, then")
+    print("    python deploy/03_create_github_provider.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/03_create_github_provider.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/03_create_github_provider.py
@@ -45,6 +45,7 @@ from _common import (
     github_provider_name,
     load_env,
     must_env,
+    must_secret_env,
     save_env,
     select_idp,
 )
@@ -63,7 +64,7 @@ def main() -> None:
     load_env()
 
     client_id = must_env("GITHUB_CLIENT_ID")
-    client_secret = must_env("GITHUB_CLIENT_SECRET")
+    client_secret = must_secret_env("GITHUB_CLIENT_SECRET")
     name = github_provider_name(idp)
 
     control, _ = control_client()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/03_create_github_provider.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/03_create_github_provider.py
@@ -1,0 +1,119 @@
+"""Create the GitHub outbound OAuth2 credential provider.
+
+This is the *outbound* provider — the downstream resource your agent acts on,
+and the thing the user grants consent to on the portal's Connections page. It
+is a different provider from the portal's primary IdP (step 02): the primary
+IdP is who the user signs in AS, this is what the agent gets consent to act ON.
+
+GitHub is a valid outbound vendor (`GithubOauth2`) but could never be the
+primary IdP: it issues no ID token and publishes no OIDC discovery document,
+so portal login cannot work with it by construction.
+
+Before running: create a GitHub OAuth App at https://github.com/settings/developers
+and put anything in its "Authorization callback URL" — you will replace it in a
+moment with a URL AgentCore vends. Then export its credentials:
+
+    export GITHUB_CLIENT_ID="<your-github-client-id>"
+    export GITHUB_CLIENT_SECRET="<your-github-client-secret>"
+
+CreateOauth2CredentialProvider returns a `callbackUrl` unique to this provider,
+shaped
+
+    https://bedrock-agentcore.<region>.amazonaws.com/identities/oauth2/callback/<uuid>
+
+You do NOT choose this URL. AgentCore owns the redirect endpoint because it is
+AgentCore that exchanges the authorization code for a token. Paste it into the
+GitHub OAuth App's Authorization callback URL.
+
+Writes to .env: GITHUB_PROVIDER_ARN, GITHUB_PROVIDER_CALLBACK_URL.
+
+Run from the sample root:
+    python deploy/03_create_github_provider.py --entra
+    python deploy/03_create_github_provider.py --okta
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    check_boto_version,
+    control_client,
+    find_provider,
+    github_provider_name,
+    load_env,
+    must_env,
+    save_env,
+    select_idp,
+)
+
+# The scopes the gateway requests from GitHub on the user's behalf. `repo` and
+# `workflow` are broad for a tutorial — trim to what your tools actually need
+# before reusing this anywhere real. The names shown to end users on the
+# portal's Connections page come from the provider and target names, not from
+# these scopes.
+GITHUB_SCOPES = ["repo", "user", "workflow"]
+
+
+def main() -> None:
+    idp = select_idp(__doc__)
+    check_boto_version()
+    load_env()
+
+    client_id = must_env("GITHUB_CLIENT_ID")
+    client_secret = must_env("GITHUB_CLIENT_SECRET")
+    name = github_provider_name(idp)
+
+    control, _ = control_client()
+
+    if find_provider(control, name):
+        # get_oauth2_credential_provider returns the same callbackUrl the
+        # create call would have. Stored credentials are left unchanged.
+        print(f"--- GitHub credential provider exists — reusing: {name} ---")
+        response = control.get_oauth2_credential_provider(name=name)
+    else:
+        print(f"--- Creating GitHub OAuth2 credential provider: {name} ---")
+        response = control.create_oauth2_credential_provider(
+            name=name,
+            credentialProviderVendor="GithubOauth2",
+            oauth2ProviderConfigInput={
+                "githubOauth2ProviderConfig": {
+                    "clientId": client_id,
+                    "clientSecret": client_secret,
+                }
+            },
+        )
+        print("  ✓ Created")
+
+    provider_arn = response["credentialProviderArn"]
+    identity_callback = response["callbackUrl"]
+
+    print(f"  arn:      {provider_arn}")
+    print(f"  scopes:   {' '.join(GITHUB_SCOPES)} (set on the target in step 04)")
+
+    save_env(GITHUB_PROVIDER_ARN=provider_arn, GITHUB_PROVIDER_CALLBACK_URL=identity_callback)
+    print("  Saved to .env: GITHUB_PROVIDER_ARN, GITHUB_PROVIDER_CALLBACK_URL")
+
+    print()
+    print("=" * 68)
+    print("  *** ACTION REQUIRED — do this before step 04 ***")
+    print()
+    print("  Set your GitHub OAuth App's Authorization callback URL to:")
+    print()
+    print(f"    {identity_callback}")
+    print()
+    print("  at https://github.com/settings/developers")
+    print()
+    print("  Skipping this does NOT fail step 04. The target creates cleanly")
+    print("  and stays READY. The failure appears only when a real user clicks")
+    print("  Connect on the portal and GitHub rejects the redirect_uri — by")
+    print("  which point it looks like a portal bug.")
+    print("=" * 68)
+    print()
+    print(f"Next: python deploy/04_create_github_target.py --{idp['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/04_create_github_target.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/04_create_github_target.py
@@ -1,0 +1,178 @@
+"""Attach the GitHub MCP server to the gateway as a 3LO target (schema upfront).
+
+Creates one gateway target pointing at https://api.githubcopilot.com/mcp with:
+
+  * `mcpToolSchema.inlinePayload` — the tool schema supplied UPFRONT, from
+    gateway/github-tools.json. The alternative (implicit sync) makes the
+    gateway fetch the tool list at create time, which would require an admin
+    to complete a three-legged OAuth flow right then — the exact thing the
+    consent portal exists to avoid. Supplying the schema means the target is
+    immediately READY and `tools/list` works for everyone without anyone
+    authorizing anything; only `tools/call` triggers the consent flow.
+
+  * `grantType: AUTHORIZATION_CODE` — three-legged, per-user consent. This is
+    what puts a row on the portal's Connections page. A CLIENT_CREDENTIALS
+    (two-legged, machine-to-machine) target needs no per-user consent and
+    never appears there.
+
+  * `defaultReturnUrl` = exactly `<portalUrl>/connect/callback`, read from
+    PORTAL_CONNECT_RETURN_URL. This is the consent leg, and it is distinct
+    from the portal's login callback (`<portalUrl>/callback`). If it is
+    missing or wrong, the user authorizes at GitHub successfully and then gets
+    returned somewhere other than the portal, so the consent never binds to
+    their session — a failure that presents as "consent did nothing".
+
+Three different URLs are involved in this sample, none interchangeable:
+
+  | URL                                            | Registered with          |
+  |------------------------------------------------|--------------------------|
+  | https://<portalUrl>/callback                   | the primary IdP app      |
+  | https://<portalUrl>/connect/callback           | nobody — set here        |
+  | https://bedrock-agentcore.<region>.amazonaws.com/identities/oauth2/callback/<uuid> | the GitHub OAuth App |
+
+This script requires PORTAL_CONNECT_RETURN_URL: the sample is portal-only, so
+there is deliberately no localhost-callback-server fallback.
+
+Writes to .env: GITHUB_TARGET_ID.
+
+Run from the sample root:
+    python deploy/04_create_github_target.py --entra
+    python deploy/04_create_github_target.py --okta
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    SAMPLE_ROOT,
+    check_boto_version,
+    control_client,
+    find_target_by_name,
+    github_target_name,
+    load_env,
+    must_env,
+    save_env,
+    select_idp,
+)
+
+# Kept in step with 03_create_github_provider.py's GITHUB_SCOPES. Broad for a
+# tutorial — trim to what your tools actually need before reusing this.
+GITHUB_SCOPES = ["repo", "user", "workflow"]
+
+GITHUB_MCP_ENDPOINT = "https://api.githubcopilot.com/mcp"
+TOOL_SCHEMA_PATH = SAMPLE_ROOT / "gateway" / "github-tools.json"
+
+
+def main() -> None:
+    idp = select_idp(__doc__)
+    check_boto_version()
+    load_env()
+
+    gateway_id = must_env("GATEWAY_ID")
+    provider_arn = must_env("GITHUB_PROVIDER_ARN")
+    return_url = must_env("PORTAL_CONNECT_RETURN_URL")
+    target_name = github_target_name(idp)
+
+    if not TOOL_SCHEMA_PATH.exists():
+        print(f"ERROR: tool schema not found: {TOOL_SCHEMA_PATH}", file=sys.stderr)
+        sys.exit(1)
+    tool_schema = TOOL_SCHEMA_PATH.read_text()
+
+    control, _ = control_client()
+
+    existing = find_target_by_name(control, gateway_id, target_name)
+    if existing:
+        target_id = existing["targetId"]
+        print(f"--- GitHub target exists — reusing: {target_name} ({target_id}) ---")
+        # Report the live defaultReturnUrl: a target created before the portal
+        # existed carries a different one, and its consent will never bind to
+        # the portal session until it is updated.
+        configs = existing.get("credentialProviderConfigurations") or []
+        for cfg in configs:
+            oauth = (cfg.get("credentialProvider") or {}).get("oauthCredentialProvider") or {}
+            live = oauth.get("defaultReturnUrl")
+            if live and live != return_url:
+                print(
+                    f"  ⚠ defaultReturnUrl is {live}\n"
+                    f"    but this portal expects {return_url}\n"
+                    f"    Consent will not bind to the portal session until it matches.\n"
+                    f"    Delete the target and re-run this script, or update it with\n"
+                    f"    UpdateGatewayTarget.",
+                    file=sys.stderr,
+                )
+        save_env(GITHUB_TARGET_ID=target_id)
+        print("  Saved to .env: GITHUB_TARGET_ID")
+        return
+
+    print(f"--- Creating GitHub MCP target: {target_name} (schema upfront) ---")
+    print(f"  endpoint:         {GITHUB_MCP_ENDPOINT}")
+    print("  grantType:        AUTHORIZATION_CODE (3LO — appears on the portal)")
+    print(f"  scopes:           {' '.join(GITHUB_SCOPES)}")
+    print(f"  defaultReturnUrl: {return_url}")
+    print("  No browser authorization happens during creation.")
+
+    response = control.create_gateway_target(
+        gatewayIdentifier=gateway_id,
+        name=target_name,
+        description="GitHub MCP server, 3LO outbound auth, consent granted on the AgentCore consent portal",
+        targetConfiguration={
+            "mcp": {
+                "mcpServer": {
+                    "endpoint": GITHUB_MCP_ENDPOINT,
+                    "mcpToolSchema": {"inlinePayload": tool_schema},
+                }
+            }
+        },
+        credentialProviderConfigurations=[
+            {
+                "credentialProviderType": "OAUTH",
+                "credentialProvider": {
+                    "oauthCredentialProvider": {
+                        "providerArn": provider_arn,
+                        "scopes": GITHUB_SCOPES,
+                        "grantType": "AUTHORIZATION_CODE",
+                        "defaultReturnUrl": return_url,
+                    }
+                },
+            }
+        ],
+    )
+    target_id = response["targetId"]
+    print(f"  ✓ Created. ID: {target_id}  status: {response['status']}")
+
+    save_env(GITHUB_TARGET_ID=target_id)
+    print("  Saved to .env: GITHUB_TARGET_ID")
+
+    print()
+    print("=" * 68)
+    print("  Consent as a user now:")
+    print(f"    open https://{must_env('PORTAL_URL')}")
+    print()
+    print("  1. Sign in with your IdP user.")
+    print("  2. A GitHub row appears on the Connections page. A NEW target does")
+    print("     not appear immediately — the connections list is cached for up")
+    print("     to 5 MINUTES. An empty page right now is expected; wait it out")
+    print("     before debugging.")
+    print("  3. Choose Connect. GitHub asks you to authorize, then returns you")
+    print("     to /connect/callback, where the portal calls")
+    print("     CompleteResourceTokenAuth to bind that consent to YOU.")
+    print()
+    print("  Notes: authorization URLs and session URIs are valid for 10")
+    print("  minutes — an interrupted flow fails in a way that looks like a")
+    print("  config error, so start over rather than debugging it. GitHub also")
+    print("  does not re-prompt once you have authorized an OAuth App, so Connect")
+    print("  may complete with no visible consent screen at all.")
+    print()
+    print("  Consent is per user and there is NO Disconnect action on the portal,")
+    print("  so to show the unconsented path again, sign in as another IdP user.")
+    print("=" * 68)
+    print()
+    print("Next: deploy the agent — see README.md step 7 (agentcore create/deploy),")
+    print(f"  then python deploy/05_patch_agentcore_json.py --{idp['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/04_create_github_target.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/04_create_github_target.py
@@ -1,4 +1,4 @@
-"""Attach the GitHub MCP server to the gateway as a 3LO target (schema upfront).
+"""Attach the GitHub MCP server as an authorization-code-flow target (schema upfront).
 
 Creates one gateway target pointing at https://api.githubcopilot.com/mcp with:
 
@@ -109,7 +109,7 @@ def main() -> None:
 
     print(f"--- Creating GitHub MCP target: {target_name} (schema upfront) ---")
     print(f"  endpoint:         {GITHUB_MCP_ENDPOINT}")
-    print("  grantType:        AUTHORIZATION_CODE (3LO — appears on the portal)")
+    print("  grantType:        AUTHORIZATION_CODE (appears on the portal)")
     print(f"  scopes:           {' '.join(GITHUB_SCOPES)}")
     print(f"  defaultReturnUrl: {return_url}")
     print("  No browser authorization happens during creation.")
@@ -117,7 +117,9 @@ def main() -> None:
     response = control.create_gateway_target(
         gatewayIdentifier=gateway_id,
         name=target_name,
-        description="GitHub MCP server, 3LO outbound auth, consent granted on the AgentCore consent portal",
+        description=(
+            "GitHub MCP server, outbound authorization code flow, consent granted on the AgentCore consent portal"
+        ),
         targetConfiguration={
             "mcp": {
                 "mcpServer": {

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/05_patch_agentcore_json.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/05_patch_agentcore_json.py
@@ -1,0 +1,133 @@
+"""Patch agentcore.json with inbound JWT auth and the agent's env vars.
+
+Run AFTER `agentcore create … --defaults` has scaffolded the project, from
+either the sample root or the scaffolded project folder.
+
+What it sets on the runtime:
+
+  1. requestHeaderAllowlist += Authorization — without this the caller's JWT
+     never reaches the handler, and the agent has nothing to forward.
+
+  2. authorizerType CUSTOM_JWT, with the SAME discoveryUrl and allowedAudience
+     as the gateway (step 01). That shared audience is the passthrough
+     contract: the agent forwards the caller's token to the gateway verbatim,
+     so one token must satisfy both authorizers. Drift here shows up as a 401
+     from the gateway during MCP initialization, which reads like a gateway
+     problem rather than a runtime config one.
+
+  3. envVars the agent reads at runtime: GATEWAY_MCP_URL, PORTAL_URL (so the
+     agent can tell an unconsented user where to go), AWS_REGION.
+
+Idempotent — safe to re-run after any deploy script changes a value.
+
+Run from the sample root:
+    python deploy/05_patch_agentcore_json.py --entra
+    python deploy/05_patch_agentcore_json.py --okta
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    SAMPLE_ROOT,
+    discovery_url,
+    load_env,
+    must_env,
+    select_idp,
+)
+
+
+def allowed_audiences(idp: dict, audience: str) -> list[str]:
+    """Must match 01_create_gateway.py's list exactly — see the docstring."""
+    if idp["name"] == "entra":
+        return [audience, f"api://{audience}"]
+    return [audience]
+
+
+def main() -> None:
+    idp = select_idp(__doc__)
+    load_env()
+
+    # `or`, not a get() default: .env ships the key present but empty, and a
+    # get() default does not fire for an empty string.
+    region = os.environ.get("AWS_REGION") or "us-west-2"
+    runtime_name = must_env("AGENT_RUNTIME_NAME")
+    disco = discovery_url(idp)
+    audiences = allowed_audiences(idp, must_env("IDP_AUDIENCE"))
+    gateway_mcp_url = must_env("GATEWAY_MCP_URL")
+    portal_url = must_env("PORTAL_URL")
+
+    project_dir = SAMPLE_ROOT / runtime_name
+    agentcore_json = project_dir / "agentcore" / "agentcore.json"
+    if not agentcore_json.exists():
+        print(
+            f"ERROR: {agentcore_json} does not exist.\n"
+            f"Scaffold the project first, from the sample root:\n"
+            f'  agentcore create --name "$AGENT_RUNTIME_NAME" --framework Strands \\\n'
+            f"    --model-provider Bedrock --memory none --build CodeZip --defaults",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config = json.loads(agentcore_json.read_text())
+    runtimes = config.setdefault("runtimes", [])
+    runtime = next((r for r in runtimes if r.get("name") == runtime_name), None)
+    if runtime is None:
+        print(
+            f"ERROR: runtime '{runtime_name}' not found in agentcore.json. "
+            f"Available: {[r.get('name') for r in runtimes]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    allowlist = set(runtime.get("requestHeaderAllowlist", []))
+    allowlist.add("Authorization")
+    runtime["requestHeaderAllowlist"] = sorted(allowlist)
+
+    runtime["authorizerType"] = "CUSTOM_JWT"
+    runtime["authorizerConfiguration"] = {"customJwtAuthorizer": {"discoveryUrl": disco, "allowedAudience": audiences}}
+
+    # envVars is an array of {name, value}; an `environmentVariables` object
+    # map is silently dropped by the schema.
+    env_map = {
+        "GATEWAY_MCP_URL": gateway_mcp_url,
+        # Bare host in .env; the agent shows it to users, so give it a scheme.
+        "PORTAL_URL": f"https://{portal_url.removeprefix('https://').rstrip('/')}",
+        "AWS_REGION": region,
+    }
+    # Only forwarded when set, so the agent's own default model stands otherwise.
+    model_id = os.environ.get("MODEL_ID", "").strip()
+    if model_id:
+        env_map["MODEL_ID"] = model_id
+
+    existing = {e["name"]: e["value"] for e in runtime.get("envVars", []) if "name" in e and "value" in e}
+    existing.update(env_map)
+    runtime["envVars"] = [{"name": k, "value": v} for k, v in existing.items()]
+    runtime.pop("environmentVariables", None)
+
+    agentcore_json.write_text(json.dumps(config, indent=2) + "\n")
+
+    print(f"✓ Patched {agentcore_json.relative_to(SAMPLE_ROOT)}")
+    print(f"  requestHeaderAllowlist: {runtime['requestHeaderAllowlist']}")
+    print("  authorizerType:         CUSTOM_JWT")
+    print(f"  discoveryUrl:           {disco}")
+    print(f"  allowedAudience:        {audiences}")
+    print("  envVars:")
+    for k, v in env_map.items():
+        print(f"    {k}={v}")
+    print()
+    print("Next, from inside the project folder:")
+    print(f"  cd {runtime_name}")
+    print("  agentcore validate && agentcore deploy -y -v")
+    print("  agentcore status    # copy the invoke URL")
+    print("  # append ?qualifier=DEFAULT and save it to .env as AGENT_RUNTIME_INVOKE_URL")
+    print("  # (without the qualifier the invoke returns 404 UnknownOperationException)")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/06_enable_observability.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/06_enable_observability.py
@@ -1,0 +1,104 @@
+"""Optional: set log retention and print the debugging recipes for this sample.
+
+AgentCore log groups are created with no expiry, which is a slow cost leak for
+a sample you will tear down. This sets a retention period on the runtime and
+gateway log groups (creating them if they do not exist yet, so retention is in
+place before the first invocation), then prints the queries worth knowing.
+
+Run from the sample root:
+    python deploy/06_enable_observability.py --entra
+    python deploy/06_enable_observability.py --okta --retention-days 7
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import gateway_name, load_env, select_idp_with_args
+
+
+def ensure_retention(logs, group: str, days: int) -> None:
+    try:
+        logs.create_log_group(logGroupName=group)
+        print(f"  ✓ Created log group: {group}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceAlreadyExistsException":
+            print(f"  ⚠ Could not create {group}: {e.response['Error']['Code']}", file=sys.stderr)
+            return
+        print(f"  • Log group exists: {group}")
+    try:
+        logs.put_retention_policy(logGroupName=group, retentionInDays=days)
+        print(f"    ✓ Retention set to {days} day(s)")
+    except ClientError as e:
+        print(f"    ⚠ Could not set retention: {e.response['Error']['Code']}", file=sys.stderr)
+
+
+def main() -> None:
+    idp, args = select_idp_with_args(
+        __doc__,
+        [
+            (
+                ["--retention-days"],
+                {
+                    "type": int,
+                    "default": 14,
+                    "help": "CloudWatch Logs retention in days (default: 14).",
+                },
+            )
+        ],
+    )
+    load_env()
+
+    region = os.environ.get("AWS_REGION") or boto3.Session().region_name
+    logs = boto3.client("logs", region_name=region)
+    runtime_name = os.environ.get("AGENT_RUNTIME_NAME", "")
+    gw_name = gateway_name(idp)
+
+    print(f"--- Log retention ({args.retention_days} days) ---")
+    groups = [f"/aws/bedrock-agentcore/gateway/{gw_name}"]
+    if runtime_name:
+        groups.append(f"/aws/bedrock-agentcore/runtimes/{runtime_name}")
+    for group in groups:
+        ensure_retention(logs, group, args.retention_days)
+
+    print()
+    print("--- Debugging recipes ---")
+    print()
+    print("Agent logs, including the consent-elicitation detection:")
+    print("  # from inside the scaffolded project folder")
+    print("  agentcore logs --since 15m")
+    print('  agentcore logs --since 15m --query "CONSENT_REQUIRED"')
+    print()
+    print("Traces across the runtime -> gateway -> GitHub hops:")
+    print("  agentcore traces --since 15m")
+    print()
+    print("Gateway-side view of a tool call (the -32042 elicitation appears here):")
+    print(f"  aws logs tail /aws/bedrock-agentcore/gateway/{gw_name} --since 15m --region {region}")
+    print()
+    print("Consent state for a target, from the control plane:")
+    print(
+        "  aws bedrock-agentcore-control get-gateway-target --region "
+        f"{region} \\\n"
+        "    --gateway-identifier $GATEWAY_ID --target-id $GITHUB_TARGET_ID \\\n"
+        "    --query credentialProviderConfigurations"
+    )
+    print()
+    print("Portal status and URL:")
+    print(
+        f"  aws bedrock-agentcore-control get-consent-portal --region {region} \\\n"
+        "    --consent-portal-identifier $PORTAL_ID --query '{status:status,url:portalUrl}'"
+    )
+    print()
+    print("One-time console toggles for richer runtime telemetry (CloudWatch ->")
+    print("Application Signals -> Transaction Search, and enabling Application")
+    print("Signals for AgentCore) are per-account, not per-sample.")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/07_deploy_interceptor.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/07_deploy_interceptor.py
@@ -1,0 +1,449 @@
+"""OPTIONAL: wire a RESPONSE interceptor onto the gateway (gateway-wide JIT auth).
+
+Without this, the consent substitution happens in the agent: `agent/agent.py`
+detects the `-32042` elicitation and replies with the portal URL. That protects
+this sample's agent and nothing else — any other MCP client on the same gateway
+(the MCP Inspector, a coding agent, a colleague's script) still receives the raw
+AgentCore Identity authorize URL, and following it bypasses the portal's session
+binding.
+
+This script moves the substitution into the gateway, so **every** client is
+steered to the portal regardless of its code. A gateway supports at most one
+RESPONSE interceptor.
+
+Creates, idempotently:
+  1. A Lambda execution role with CloudWatch Logs access.
+  2. The interceptor Lambda from deploy/lambda/interceptor.py.
+  3. A scoped `lambda:InvokeFunction` grant on the gateway's service role — a
+     separate inline policy, so the gateway's own policy is untouched.
+  4. The gateway's interceptorConfigurations, via UpdateGateway.
+
+Modes:
+    --mode rewrite    (default) inject PORTAL_URL on a -32042 elicitation.
+    --mode log-only   pass through, but log the whole interceptor event. Use this
+                      if the rewrite stops matching and you need to see the real
+                      payload shape in CloudWatch.
+
+Removal:
+    --remove          detach the interceptor and delete the Lambda and its role.
+                      Leaves the gateway, portal and targets alone.
+
+Run from the sample root:
+    python deploy/07_deploy_interceptor.py --entra
+    python deploy/07_deploy_interceptor.py --entra --mode log-only
+    python deploy/07_deploy_interceptor.py --entra --remove
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    DEPLOY_DIR,
+    check_boto_version,
+    control_client,
+    gateway_name,
+    gateway_role_name,
+    interceptor_lambda_name,
+    interceptor_role_name,
+    load_env,
+    must_env,
+    save_env,
+    select_idp_with_args,
+)
+
+HANDLER_PATH = DEPLOY_DIR / "lambda" / "interceptor.py"
+HANDLER = "interceptor.lambda_handler"
+INVOKE_POLICY_NAME = "InterceptorInvoke"
+GATEWAY_TERMINAL = ("READY", "FAILED", "UPDATE_FAILED", "UPDATE_UNSUCCESSFUL")
+
+# --- Adopter-facing configuration -------------------------------------------
+# All optional, all read from .env (or the environment), all with defaults that
+# work as-is. See README "Configuration you can change".
+#
+# INTERCEPTOR_TARGET_URL      where users are sent instead of the identity URL.
+#                             Defaults to PORTAL_URL. Point it at your own
+#                             landing page if you would rather explain what is
+#                             about to happen before handing off to the portal —
+#                             the portal still does the consent, this only
+#                             changes the first hop the user sees.
+# INTERCEPTOR_LAMBDA_NAME     override the derived function name
+# INTERCEPTOR_ROLE_NAME       override the derived execution role name
+# INTERCEPTOR_RUNTIME         Lambda runtime (default python3.12)
+# INTERCEPTOR_TIMEOUT_SECONDS Lambda timeout (default 10). The gateway waits on
+#                             this on every response, so keep it small.
+# INTERCEPTOR_MEMORY_MB       Lambda memory (default 128; observed 37 MB used)
+# INTERCEPTOR_LOG_RETENTION_DAYS  retention on the Lambda's log group. Unset
+#                             means "never expire", which is a slow cost leak.
+# INTERCEPTOR_IDENTITY_URL_HOST   host substring that marks a URL as rewritable
+#                             (default "bedrock-agentcore"). The safety guard —
+#                             widen it only if you know why.
+# INTERCEPTOR_PASS_REQUEST_HEADERS  "true" to let the interceptor see request
+#                             headers. Default false, which keeps the caller's
+#                             JWT out of the event and out of CloudWatch.
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(f"ERROR: {name} must be an integer, got {raw!r}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+LAMBDA_TRUST = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "lambda.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
+BASIC_EXECUTION = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+
+def ensure_lambda_role(iam, role_name: str) -> str:
+    try:
+        iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(LAMBDA_TRUST),
+            Description="Execution role for the AgentCore consent JIT interceptor",
+        )
+        print(f"  ✓ Created IAM role: {role_name}")
+        print("  ⏳ Waiting 10s for IAM propagation…")
+        time.sleep(10)
+    except iam.exceptions.EntityAlreadyExistsException:
+        print(f"  • IAM role already exists: {role_name}")
+    iam.attach_role_policy(RoleName=role_name, PolicyArn=BASIC_EXECUTION)
+    return iam.get_role(RoleName=role_name)["Role"]["Arn"]
+
+
+def zip_handler() -> bytes:
+    """Zip the single-file handler in memory, as interceptor.py at the root."""
+    source = HANDLER_PATH.read_bytes()
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        info = zipfile.ZipInfo("interceptor.py")
+        info.external_attr = 0o644 << 16
+        zf.writestr(info, source)
+    return buffer.getvalue()
+
+
+def _wait_lambda_updated(lambda_client, fn_name: str) -> None:
+    """A second update is rejected while the first is still InProgress."""
+    for _ in range(30):
+        cfg = lambda_client.get_function(FunctionName=fn_name)["Configuration"]
+        if cfg.get("LastUpdateStatus") != "InProgress":
+            return
+        time.sleep(2)
+
+
+def deploy_lambda(lambda_client, fn_name: str, role_arn: str, env_vars: dict) -> str:
+    code = zip_handler()
+    environment = {"Variables": env_vars}
+    runtime = os.environ.get("INTERCEPTOR_RUNTIME") or "python3.12"
+    timeout = _env_int("INTERCEPTOR_TIMEOUT_SECONDS", 10)
+    memory = _env_int("INTERCEPTOR_MEMORY_MB", 128)
+    print(f"  runtime={runtime} timeout={timeout}s memory={memory}MB")
+    try:
+        resp = lambda_client.create_function(
+            FunctionName=fn_name,
+            Runtime=runtime,
+            Role=role_arn,
+            Handler=HANDLER,
+            Code={"ZipFile": code},
+            Timeout=timeout,
+            MemorySize=memory,
+            Environment=environment,
+            Description="AgentCore Gateway RESPONSE interceptor — consent portal JIT auth",
+        )
+        print(f"  ✓ Created Lambda: {fn_name}")
+        return resp["FunctionArn"]
+    except lambda_client.exceptions.ResourceConflictException:
+        lambda_client.update_function_code(FunctionName=fn_name, ZipFile=code)
+        _wait_lambda_updated(lambda_client, fn_name)
+        lambda_client.update_function_configuration(
+            FunctionName=fn_name,
+            Runtime=runtime,
+            Role=role_arn,
+            Handler=HANDLER,
+            Timeout=timeout,
+            MemorySize=memory,
+            Environment=environment,
+        )
+        _wait_lambda_updated(lambda_client, fn_name)
+        print(f"  ✓ Updated Lambda: {fn_name}")
+        return lambda_client.get_function(FunctionName=fn_name)["Configuration"]["FunctionArn"]
+
+
+def set_log_retention(logs_client, fn_name: str) -> None:
+    """Apply INTERCEPTOR_LOG_RETENTION_DAYS, if set.
+
+    Lambda creates the log group on first invocation with no expiry, so without
+    this the interceptor's logs accumulate forever.
+    """
+    days = os.environ.get("INTERCEPTOR_LOG_RETENTION_DAYS", "").strip()
+    if not days:
+        return
+    group = f"/aws/lambda/{fn_name}"
+    try:
+        logs_client.create_log_group(logGroupName=group)
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceAlreadyExistsException":
+            print(f"  ⚠ could not create {group}: {e.response['Error']['Code']}", file=sys.stderr)
+            return
+    try:
+        logs_client.put_retention_policy(
+            logGroupName=group, retentionInDays=_env_int("INTERCEPTOR_LOG_RETENTION_DAYS", 14)
+        )
+        print(f"  ✓ Log retention set to {days} day(s) on {group}")
+    except ClientError as e:
+        print(f"  ⚠ could not set retention: {e.response['Error']['Code']}", file=sys.stderr)
+
+
+def grant_gateway_invoke(iam, role_name: str, lambda_arn: str) -> None:
+    """Scoped invoke grant, as its own inline policy.
+
+    Scoped to this one function ARN rather than a wildcard, and kept separate
+    from the gateway's own policy so neither overwrites the other.
+    """
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName=INVOKE_POLICY_NAME,
+        PolicyDocument=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "lambda:InvokeFunction",
+                        "Resource": lambda_arn,
+                    }
+                ],
+            }
+        ),
+    )
+    print(f"  ✓ Granted lambda:InvokeFunction on {role_name} (scoped to this function)")
+
+
+def update_gateway_interceptors(control, gateway_id: str, configs: list) -> None:
+    """UpdateGateway preserving everything else about the gateway.
+
+    UpdateGateway is a full replace, so every field we care about has to be read
+    back and passed in — dropping protocolConfiguration here would silently
+    reset supportedVersions and break URL-mode elicitation altogether.
+    """
+    gw = control.get_gateway(gatewayIdentifier=gateway_id)
+    kwargs = {
+        "gatewayIdentifier": gateway_id,
+        "name": gw["name"],
+        "roleArn": gw["roleArn"],
+        "protocolType": gw.get("protocolType", "MCP"),
+        "authorizerType": gw["authorizerType"],
+        "authorizerConfiguration": gw["authorizerConfiguration"],
+        "interceptorConfigurations": configs,
+    }
+    if gw.get("protocolConfiguration"):
+        kwargs["protocolConfiguration"] = gw["protocolConfiguration"]
+    if gw.get("exceptionLevel"):
+        kwargs["exceptionLevel"] = gw["exceptionLevel"]
+    if gw.get("description"):
+        kwargs["description"] = gw["description"]
+    control.update_gateway(**kwargs)
+
+    print("  ⏳ Waiting for the gateway to settle…")
+    last = None
+    for _ in range(30):
+        time.sleep(5)
+        status = control.get_gateway(gatewayIdentifier=gateway_id)["status"]
+        if status != last:
+            print(f"    status: {status}")
+            last = status
+        if status in GATEWAY_TERMINAL:
+            return
+    print("  ⚠ Gateway did not settle within 150s; check its status.", file=sys.stderr)
+
+
+def remove(control, iam, lambda_client, idp: dict, gateway_id: str) -> None:
+    print("--- Detaching the interceptor from the gateway ---")
+    try:
+        update_gateway_interceptors(control, gateway_id, [])
+        print("  ✓ interceptorConfigurations cleared")
+    except control.exceptions.ResourceNotFoundException:
+        # Running this after teardown.py is a normal order of events. With the
+        # gateway already gone there is nothing to detach from, and stopping here
+        # would orphan the Lambda and its role — so carry on and delete them.
+        print("  • Gateway already gone; nothing to detach")
+
+    fn_name = interceptor_lambda_name(idp)
+    role_name = interceptor_role_name(idp)
+
+    print("\n--- Removing the invoke grant from the gateway role ---")
+    try:
+        iam.delete_role_policy(RoleName=gateway_role_name(idp), PolicyName=INVOKE_POLICY_NAME)
+        print(f"  ✓ Deleted inline policy {INVOKE_POLICY_NAME}")
+    except iam.exceptions.NoSuchEntityException:
+        print(f"  • {INVOKE_POLICY_NAME} not present, skipping")
+
+    print("\n--- Deleting the Lambda and its role ---")
+    try:
+        lambda_client.delete_function(FunctionName=fn_name)
+        print(f"  ✓ Deleted Lambda: {fn_name}")
+    except lambda_client.exceptions.ResourceNotFoundException:
+        print(f"  • Lambda already gone: {fn_name}")
+    try:
+        iam.detach_role_policy(RoleName=role_name, PolicyArn=BASIC_EXECUTION)
+    except ClientError:
+        pass
+    try:
+        iam.delete_role(RoleName=role_name)
+        print(f"  ✓ Deleted IAM role: {role_name}")
+    except iam.exceptions.NoSuchEntityException:
+        print(f"  • IAM role already gone: {role_name}")
+
+    save_env(INTERCEPTOR_LAMBDA_ARN="", INTERCEPTOR_ROLE_ARN="", INTERCEPTOR_MODE="")
+    print("\n✓ Interceptor removed. The agent's own -32042 handling still applies.")
+
+
+def main() -> None:
+    idp, args = select_idp_with_args(
+        __doc__,
+        [
+            (
+                ["--mode"],
+                {
+                    "choices": ["rewrite", "log-only"],
+                    "default": "rewrite",
+                    "help": "rewrite (default) injects the portal URL; log-only just logs.",
+                },
+            ),
+            (["--remove"], {"action": "store_true", "help": "Detach and delete the interceptor."}),
+        ],
+    )
+    check_boto_version()
+    load_env()
+
+    gateway_id = must_env("GATEWAY_ID")
+    control, region = control_client()
+    iam = boto3.client("iam", region_name=region)
+    lambda_client = boto3.client("lambda", region_name=region)
+
+    if args.remove:
+        remove(control, iam, lambda_client, idp, gateway_id)
+        return
+
+    mode = "REWRITE" if args.mode == "rewrite" else "LOG_ONLY"
+    # Where the user is sent. Defaults to the portal; override to interpose your
+    # own landing page (the portal still gathers the consent).
+    target_url = os.environ.get("INTERCEPTOR_TARGET_URL", "").strip() or os.environ.get("PORTAL_URL", "").strip()
+    if mode == "REWRITE" and not target_url:
+        print("ERROR: --mode rewrite needs PORTAL_URL in .env.", file=sys.stderr)
+        print("  Run deploy/02_create_portal.py first, or set INTERCEPTOR_TARGET_URL.", file=sys.stderr)
+        sys.exit(1)
+    # PORTAL_URL is stored as a bare host. The interceptor injects this value
+    # straight into the elicitation, and an MCP client resolves a scheme-less
+    # string against its own origin — the Inspector would turn it into
+    # http://localhost:6274/<host>. Force an absolute URL.
+    if target_url and not target_url.startswith(("http://", "https://")):
+        target_url = f"https://{target_url}"
+    if os.environ.get("INTERCEPTOR_TARGET_URL", "").strip():
+        print(f"  (using INTERCEPTOR_TARGET_URL override: {target_url})")
+
+    fn_name = interceptor_lambda_name(idp)
+    print(f"--- Interceptor deploy (mode: {mode}) ---")
+    print(f"  gateway: {gateway_name(idp)} ({gateway_id})")
+    print(f"  lambda:  {fn_name}")
+    if mode == "REWRITE":
+        print(f"  target:  {target_url}")
+
+    print("\n--- Step 1: Lambda execution role ---")
+    lambda_role_arn = ensure_lambda_role(iam, interceptor_role_name(idp))
+    print(f"  arn: {lambda_role_arn}")
+
+    print("\n--- Step 2: package and deploy the Lambda ---")
+    lambda_arn = deploy_lambda(
+        lambda_client,
+        fn_name,
+        lambda_role_arn,
+        {
+            "INTERCEPTOR_MODE": mode,
+            "PORTAL_URL": target_url,
+            "IDENTITY_URL_HOST": os.environ.get("INTERCEPTOR_IDENTITY_URL_HOST") or "bedrock-agentcore",
+        },
+    )
+    print(f"  arn: {lambda_arn}")
+    set_log_retention(boto3.client("logs", region_name=region), fn_name)
+
+    print("\n--- Step 3: grant the gateway role invoke access ---")
+    grant_gateway_invoke(iam, gateway_role_name(idp), lambda_arn)
+
+    print("\n--- Step 4: attach it as the RESPONSE interceptor ---")
+    update_gateway_interceptors(
+        control,
+        gateway_id,
+        [
+            {
+                "interceptor": {"lambda": {"arn": lambda_arn}},
+                "interceptionPoints": ["RESPONSE"],
+                # The rewrite needs only the response body. Turning headers off
+                # keeps the caller's JWT out of the interceptor event, and out of
+                # CloudWatch in log-only mode.
+                "inputConfiguration": {"passRequestHeaders": _env_bool("INTERCEPTOR_PASS_REQUEST_HEADERS", False)},
+            }
+        ],
+    )
+
+    save_env(
+        INTERCEPTOR_LAMBDA_ARN=lambda_arn,
+        INTERCEPTOR_ROLE_ARN=lambda_role_arn,
+        INTERCEPTOR_MODE=mode,
+    )
+    print("  Saved to .env: INTERCEPTOR_LAMBDA_ARN, INTERCEPTOR_ROLE_ARN, INTERCEPTOR_MODE")
+
+    log_group = f"/aws/lambda/{fn_name}"
+    print()
+    print("=" * 68)
+    if mode == "LOG_ONLY":
+        print("  LOG_ONLY is live — nothing is being rewritten.")
+        print("  1. Invoke a tool as a user who has NOT consented.")
+        print(f"  2. Read the INTERCEPTOR_EVENT line in {log_group}")
+        print(f"  3. Flip to rewriting: python deploy/07_deploy_interceptor.py --{idp['name']}")
+    else:
+        print("  REWRITE is live. Any MCP client on this gateway now receives the")
+        print("  portal URL instead of the raw identity URL.")
+        print()
+        print("  Try it: sign in as an IdP user who has NOT consented yet (the")
+        print("  portal has no Disconnect action, and consent is per user), then")
+        print("  invoke a tool from a plain MCP client — the Inspector, or Claude")
+        print("  Code. The elicitation should carry the portal URL, not the raw")
+        print("  identity URL.")
+        print(f"  Logs: {log_group}  (look for CONSENT_ELICITATION)")
+    print()
+    print(f"  Remove: python deploy/07_deploy_interceptor.py --{idp['name']} --remove")
+    print("=" * 68)
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/_common.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/_common.py
@@ -1,0 +1,343 @@
+"""Shared plumbing for the consent-portal sample's deploy scripts.
+
+Owns three things every numbered script needs:
+
+  1. `.env` state at the sample root — steps pass ids/URLs to each other
+     through it (`load_env` / `save_env` / `must_env`).
+  2. The required `--entra` / `--okta` flag. There is deliberately no default
+     and no environment fallback: a script that guessed its IdP could create
+     — or on teardown, delete — the wrong portal. The flag names a profile in
+     `deploy/idps/<name>.json`, which holds the IdP's *shape* (vendor, which
+     env vars carry its values, how scopes are spelled). The tenant-specific
+     *values* stay in `.env`, because they belong to your tenant, not to this
+     repository.
+  3. The boto3 floor. The consent-portal operations were added to the
+     `bedrock-agentcore-control` model in botocore 1.43.88; on an older SDK
+     they fail with
+         'BedrockAgentCoreControlPlaneFrontingLayer' object has no attribute
+         'create_consent_portal'
+     which reads like a missing feature rather than a stale SDK, so the guard
+     turns it into a clear error up front.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import boto3
+
+DEPLOY_DIR = Path(__file__).resolve().parent
+SAMPLE_ROOT = DEPLOY_DIR.parent
+IDPS_DIR = DEPLOY_DIR / "idps"
+
+# `.env` holds one deployment's state. Running a second identity provider
+# side by side would overwrite the first's GATEWAY_ID, PORTAL_ID and so on —
+# the AWS resources coexist happily (their names are IdP-prefixed) but the
+# state file is a single flat namespace. Set CONSENT_ENV_FILE to keep them
+# apart:
+#
+#     CONSENT_ENV_FILE=.env.okta python deploy/01_create_gateway.py --okta
+#
+# Relative paths resolve against the sample root.
+_env_override = os.environ.get("CONSENT_ENV_FILE", "").strip()
+ENV_PATH = (
+    (Path(_env_override) if Path(_env_override).is_absolute() else SAMPLE_ROOT / _env_override)
+    if _env_override
+    else SAMPLE_ROOT / ".env"
+)
+
+# Consent-portal operations (create/get/list/delete-consent-portal) landed in
+# this botocore release. grantType=AUTHORIZATION_CODE on gateway targets and
+# mcpServer target configurations are older, so this single floor covers
+# everything the sample calls.
+MIN_BOTO_VERSION = (1, 43, 88)
+
+REQUIRED_PROFILE_KEYS = (
+    "name",
+    "displayName",
+    "vendor",
+    "providerConfigKey",
+    "discoveryUrlMustContain",
+    "resourcePrefix",
+)
+
+
+def check_boto_version() -> None:
+    installed = tuple(int(x) for x in boto3.__version__.split(".")[:3])
+    if installed < MIN_BOTO_VERSION:
+        floor = ".".join(map(str, MIN_BOTO_VERSION))
+        print(
+            f"ERROR: boto3 {boto3.__version__} is too old for the consent-portal "
+            f"APIs.\n"
+            f"       They were added in boto3/botocore {floor}. Without it the "
+            f"calls fail with\n"
+            f"       \"object has no attribute 'create_consent_portal'\".\n"
+            f"       Fix: pip install -U 'boto3>={floor}' 'botocore>={floor}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# --- .env state ---------------------------------------------------------------
+
+
+def load_env() -> None:
+    """Read the sample root's .env into the environment without clobbering exports.
+
+    setdefault, not assignment: a value exported on the command line always
+    wins over one saved by an earlier step.
+    """
+    if not ENV_PATH.exists():
+        return
+    for line in ENV_PATH.read_text().splitlines():
+        line = line.strip()
+        if "=" in line and not line.startswith("#"):
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key, value.strip().strip('"'))
+
+
+def must_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        print(
+            f"ERROR: {name} is not set. Export it or add it to .env (see config.example.env).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return value
+
+
+def save_env(**kwargs: str) -> None:
+    """Upsert keys into the sample root's .env and export them for this run.
+
+    Rewrites in place rather than regenerating the file, so config.example.env's
+    comments and ordering survive every deploy step.
+    """
+    lines = ENV_PATH.read_text().splitlines() if ENV_PATH.exists() else []
+    remaining = dict(kwargs)
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0]
+            if key in remaining:
+                out.append(f"{key}={remaining.pop(key)}")
+                continue
+        out.append(line)
+    for key, value in remaining.items():
+        out.append(f"{key}={value}")
+    ENV_PATH.write_text("\n".join(out) + "\n")
+    for key, value in kwargs.items():
+        os.environ[key] = str(value)
+
+
+# --- IdP profile selection ------------------------------------------------------
+
+
+def available_idps() -> list[str]:
+    if not IDPS_DIR.is_dir():
+        return []
+    return sorted(p.stem for p in IDPS_DIR.glob("*.json"))
+
+
+def load_idp(name: str) -> dict:
+    path = IDPS_DIR / f"{name}.json"
+    if not path.exists():
+        print(f"ERROR: no such IdP profile: {name}", file=sys.stderr)
+        print(f"  available: {', '.join(available_idps()) or '(none)'}", file=sys.stderr)
+        sys.exit(1)
+    idp = json.loads(path.read_text())
+    missing = [k for k in REQUIRED_PROFILE_KEYS if k not in idp]
+    if missing:
+        print(
+            f"ERROR: profile {name}.json is missing required keys: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return idp
+
+
+def select_idp(description: str) -> dict:
+    """Parse argv for a required, mutually exclusive --<idp> flag."""
+    names = available_idps()
+    if not names:
+        print(f"ERROR: no IdP profiles found in {IDPS_DIR}", file=sys.stderr)
+        sys.exit(1)
+    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group(required=True)
+    for name in names:
+        group.add_argument(f"--{name}", dest=name, action="store_true", help=f"use the {name} IdP profile")
+    args = parser.parse_args()
+    chosen = next(name for name in names if getattr(args, name))
+    return load_idp(chosen)
+
+
+def select_idp_with_args(description: str, extra_args: list[tuple[list[str], dict]]):
+    """Like select_idp, but also returns extra parsed args (used by teardown)."""
+    names = available_idps()
+    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group(required=True)
+    for name in names:
+        group.add_argument(f"--{name}", dest=name, action="store_true", help=f"use the {name} IdP profile")
+    for flags, kwargs in extra_args:
+        parser.add_argument(*flags, **kwargs)
+    args = parser.parse_args()
+    chosen = next(name for name in names if getattr(args, name))
+    return load_idp(chosen), args
+
+
+# --- Derived resource names ------------------------------------------------------
+# Each name is needed by the script that creates the resource and again by
+# teardown.py. Deriving both from the profile keeps the pair in agreement.
+
+
+def gateway_name(idp: dict) -> str:
+    # `or`, not a get() default: config.example.env ships these keys present
+    # but empty, and a get() default would not fire for an empty string —
+    # which would create a gateway with no name.
+    return os.environ.get("GATEWAY_NAME") or f"{idp['resourcePrefix']}-consent-github-gw"
+
+
+def gateway_role_name(idp: dict) -> str:
+    return f"AmazonBedrockAgentCoreGatewayRole-{gateway_name(idp)}"
+
+
+def portal_name(idp: dict) -> str:
+    # See gateway_name for why this is `or` and not a get() default.
+    return os.environ.get("PORTAL_NAME") or f"{idp['resourcePrefix']}-github-consent-portal"
+
+
+def idp_provider_name(idp: dict) -> str:
+    return f"{idp['resourcePrefix']}-consent-portal-idp"
+
+
+def portal_role_name(idp: dict) -> str:
+    return f"{idp['resourcePrefix'].capitalize()}GithubConsentPortalRole"
+
+
+def github_provider_name(idp: dict) -> str:
+    return f"{idp['resourcePrefix']}-consent-github-provider"
+
+
+def github_target_name(idp: dict) -> str:
+    # Shown to end users on the portal's Connections page — keep it readable.
+    return "github-mcp-server"
+
+
+def interceptor_lambda_name(idp: dict) -> str:
+    # Env-overridable like the gateway and portal names, so an org with its own
+    # naming convention does not have to edit the script.
+    return os.environ.get("INTERCEPTOR_LAMBDA_NAME") or f"{idp['resourcePrefix']}-consent-jit-interceptor"
+
+
+def interceptor_role_name(idp: dict) -> str:
+    return os.environ.get("INTERCEPTOR_ROLE_NAME") or f"{idp['resourcePrefix'].capitalize()}ConsentInterceptorRole"
+
+
+# --- Discovery URL / scope helpers ------------------------------------------------
+
+
+def discovery_url(idp: dict) -> str:
+    """Return IDP_DISCOVERY_URL, enforcing the profile's required substring.
+
+    For Entra the substring is /v2.0/, and it is not cosmetic: the v1.0
+    document advertises iss = https://sts.windows.net/<tenant>/, which does
+    not match the iss in the v2.0 tokens Entra actually issues, so token
+    validation fails later in a way that looks like a scope bug. Checking here
+    turns it into an error at step one.
+    """
+    url = must_env("IDP_DISCOVERY_URL")
+    required = idp["discoveryUrlMustContain"]
+    if required not in url:
+        print(f"ERROR: IDP_DISCOVERY_URL must contain {required}", file=sys.stderr)
+        print(f"  got:      {url}", file=sys.stderr)
+        example = idp.get("discoveryUrlExample")
+        if example:
+            print(f"  expected: {example}", file=sys.stderr)
+        sys.exit(1)
+    return url
+
+
+def okta_domain() -> str:
+    """OKTA_DOMAIN as a bare hostname.
+
+    Tolerates the three forms people paste: with a scheme, with a trailing
+    slash, and the `-admin` console hostname (the admin API works on the
+    app-facing host). Every caller builds `https://{domain}/...`, so a scheme
+    left in place would produce `https://https://...`.
+    """
+    raw = must_env("OKTA_DOMAIN").strip()
+    host = raw.removeprefix("https://").removeprefix("http://").rstrip("/")
+    if "-admin." in host:
+        host = host.replace("-admin.", ".")
+    return host
+
+
+def portal_scopes() -> list[str]:
+    """Return idpConfig.scopes with openid guaranteed present.
+
+    A consent portal always requests openid on top of the scopes you
+    configure, and every scope it requests — openid included — must be
+    defined and permitted on the IdP application, or authorization fails
+    with invalid_scope.
+    """
+    scopes = must_env("PORTAL_SCOPES").split()
+    if "openid" not in scopes:
+        scopes.insert(0, "openid")
+    return scopes
+
+
+# --- boto3 find helpers -----------------------------------------------------------
+
+
+def find_gateway_by_name(control, name: str) -> dict | None:
+    paginator = control.get_paginator("list_gateways")
+    for page in paginator.paginate():
+        for gw in page.get("items", []):
+            if gw.get("name") == name:
+                return gw
+    return None
+
+
+def find_target_by_name(control, gateway_id: str, name: str) -> dict | None:
+    paginator = control.get_paginator("list_gateway_targets")
+    for page in paginator.paginate(gatewayIdentifier=gateway_id):
+        for target in page.get("items", []):
+            if target.get("name") == name:
+                return target
+    return None
+
+
+def find_provider(control, name: str) -> bool:
+    paginator = control.get_paginator("list_oauth2_credential_providers")
+    for page in paginator.paginate():
+        for prov in page.get("credentialProviders", []):
+            if prov.get("name") == name:
+                return True
+    return False
+
+
+def find_portal_by_name(control, name: str) -> dict | None:
+    """Paged, because a truncated scan would silently create a duplicate portal."""
+    kwargs = {"maxResults": 50}
+    while True:
+        page = control.list_consent_portals(**kwargs)
+        for item in page.get("consentPortals", []):
+            if item.get("name") == name:
+                return item
+        token = page.get("nextToken")
+        if not token:
+            return None
+        kwargs["nextToken"] = token
+
+
+def control_client():
+    region = os.environ.get("AWS_REGION") or boto3.Session().region_name
+    if not region:
+        print("ERROR: no AWS region. Set AWS_REGION in .env.", file=sys.stderr)
+        sys.exit(1)
+    return boto3.client("bedrock-agentcore-control", region_name=region), region

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/_common.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/_common.py
@@ -101,6 +101,30 @@ def load_env() -> None:
 
 
 def must_env(name: str) -> str:
+    """Read a required NON-SENSITIVE setting (ids, URLs, audiences, names).
+
+    Secrets go through must_secret_env instead. Keeping the two apart is not
+    cosmetic: when one accessor returns both, every value it yields inherits the
+    "this may be a credential" property, and static analysis then reports
+    ordinary config — a callback URL, say — as a leaked password. Splitting them
+    keeps that signal meaningful.
+    """
+    value = os.environ.get(name)
+    if not value:
+        print(
+            f"ERROR: {name} is not set. Export it or add it to .env (see config.example.env).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return value
+
+
+def must_secret_env(name: str) -> str:
+    """Read a required secret (client secrets, admin tokens).
+
+    Same contract as must_env, deliberately a separate function so the values
+    that must never be printed or logged are visible as such at every call site.
+    """
     value = os.environ.get(name)
     if not value:
         print(
@@ -131,6 +155,13 @@ def save_env(**kwargs: str) -> None:
     for key, value in remaining.items():
         out.append(f"{key}={value}")
     ENV_PATH.write_text("\n".join(out) + "\n")
+    # .env holds client secrets and, for Okta, an admin API token in plaintext.
+    # It is gitignored, but the default umask would still leave it group- and
+    # world-readable, so narrow it to the owner on every write.
+    try:
+        ENV_PATH.chmod(0o600)
+    except OSError:
+        pass  # non-POSIX filesystem; the write already succeeded
     for key, value in kwargs.items():
         os.environ[key] = str(value)
 

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/idps/entra.json
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/idps/entra.json
@@ -1,0 +1,18 @@
+{
+  "name": "entra",
+  "displayName": "Microsoft Entra ID",
+  "vendor": "CustomOauth2",
+  "providerConfigKey": "customOauth2ProviderConfig",
+  "discoveryUrlMustContain": "/v2.0/",
+  "discoveryUrlExample": "https://login.microsoftonline.com/<TENANT_ID>/v2.0/.well-known/openid-configuration",
+  "resourcePrefix": "entra",
+  "audienceNote": "the gateway resource app GUID, not api://<GUID> -- with requestedAccessTokenVersion 2, Entra sets aud to the application id",
+  "portalCallbackHint": [
+    "    az ad app update --id $GATEWAY_CLIENT_ID \\",
+    "      --web-redirect-uris \"<PORTAL_CALLBACK_URL>\"",
+    "",
+    "  --web-redirect-uris REPLACES the whole array. Under Entra this app is",
+    "  the gateway resource app AND the portal's login client; pass every web",
+    "  redirect URI you need in one call so you do not drop the others."
+  ]
+}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/idps/okta.json
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/idps/okta.json
@@ -1,0 +1,17 @@
+{
+  "name": "okta",
+  "displayName": "Okta",
+  "vendor": "CustomOauth2",
+  "providerConfigKey": "customOauth2ProviderConfig",
+  "discoveryUrlMustContain": "/oauth2/",
+  "discoveryUrlExample": "https://<OKTA_DOMAIN>/oauth2/<AS_ID>/.well-known/openid-configuration",
+  "resourcePrefix": "okta",
+  "audienceNote": "the authorization server's `audiences` value (e.g. api://default); it becomes the token aud. Must be a CUSTOM authorization server -- the org server issues opaque access tokens the portal and gateway cannot validate",
+  "portalCallbackHint": [
+    "    Add this URI to the portal app's Sign-in redirect URIs:",
+    "      <PORTAL_CALLBACK_URL>",
+    "    Console: Applications -> agentcore-consent-portal-login -> General ->",
+    "    Sign-in redirect URIs -> Edit. (deploy/02_create_portal.py attempts",
+    "    this automatically when OKTA_ADMIN_TOKEN is set.)"
+  ]
+}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/lambda/interceptor.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/lambda/interceptor.py
@@ -1,0 +1,143 @@
+"""AgentCore Gateway RESPONSE interceptor — rewrite the elicitation URL.
+
+Packaged and wired onto the gateway by `deploy/07_deploy_interceptor.py`. See
+https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-interceptors.html
+
+When a user who has not consented invokes a tool, the gateway answers with a
+URL-mode elicitation carrying an AgentCore Identity authorize URL. Following
+that URL directly works, but it bypasses the consent portal's session binding.
+This interceptor swaps it for the portal URL, so **every** MCP client reaching
+this gateway is steered to the portal — not only the agent in this sample, which
+does the same substitution in its own code.
+
+Modes, via INTERCEPTOR_MODE:
+
+    REWRITE   (default) replace the identity URL with PORTAL_URL on a -32042
+              auth elicitation. Everything else passes through untouched.
+    LOG_ONLY  pass everything through but log the full interceptor event. Useful
+              if the elicitation payload ever changes shape and the rewrite
+              stops matching.
+
+The payload shape below was confirmed live against this sample's gateway: the
+just-in-time prompt is **not** a streaming `elicitation/create` request. It is a
+JSON-RPC error on the `tools/call` response — `isStreamingResponse: false`,
+`statusCode: 200`, `body.error.code: -32042` — with the URLs at
+`body.error.data.elicitations[*].url`:
+
+    {"jsonrpc": "2.0", "id": 3,
+     "error": {"code": -32042,
+               "message": "This request requires more information.",
+               "data": {"elicitations": [
+                   {"mode": "url", "elicitationId": "…",
+                    "url": "https://bedrock-agentcore.<region>.amazonaws.com/identities/oauth2/authorize?request_uri=…",
+                    "message": "Please login to this URL for authorization."}]}}}
+
+`statusCode` is echoed only when the input carried one, so the handler stays
+correct if a future flow does stream (later stream events may override only the
+body — the status code and headers are already sent).
+
+The handler is stateless: the gateway may retry it, and identical input must
+produce identical output.
+
+Env:
+    INTERCEPTOR_MODE   REWRITE | LOG_ONLY          (default REWRITE)
+    PORTAL_URL         absolute https URL of the consent portal
+    IDENTITY_URL_HOST  host substring identifying the URL to replace
+                       (default "bedrock-agentcore")
+"""
+
+import json
+import logging
+import os
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+MODE = os.environ.get("INTERCEPTOR_MODE", "REWRITE").upper()
+PORTAL_URL = os.environ.get("PORTAL_URL", "")
+IDENTITY_URL_HOST = os.environ.get("IDENTITY_URL_HOST", "bedrock-agentcore")
+
+OUTPUT_VERSION = "1.0"
+ELICITATION_ERROR_CODE = -32042
+
+
+def _passthrough_request(request_body):
+    """A REQUEST interception — this interceptor only transforms responses."""
+    return {
+        "interceptorOutputVersion": OUTPUT_VERSION,
+        "mcp": {"transformedGatewayRequest": {"body": request_body}},
+    }
+
+
+def _response(body, status_code):
+    transformed = {"body": body}
+    if status_code is not None:
+        transformed["statusCode"] = status_code
+    return {
+        "interceptorOutputVersion": OUTPUT_VERSION,
+        "mcp": {"transformedGatewayResponse": transformed},
+    }
+
+
+def _looks_like_identity_url(value):
+    """Guard so the rewrite cannot touch a URL that is not AgentCore Identity's."""
+    return isinstance(value, str) and value.startswith(("http://", "https://")) and IDENTITY_URL_HOST in value
+
+
+def rewrite_elicitation_urls(body, portal_url):
+    """Swap each URL-mode elicitation's identity URL for the portal URL.
+
+    Returns the number of replacements made, so the log line is meaningful when
+    the shape stops matching (zero replacements on a -32042 is the signal).
+    """
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return 0
+    data = err.get("data")
+    if not isinstance(data, dict):
+        return 0
+    elicitations = data.get("elicitations")
+    if not isinstance(elicitations, list):
+        return 0
+
+    count = 0
+    for el in elicitations:
+        if isinstance(el, dict) and el.get("mode") == "url" and _looks_like_identity_url(el.get("url")):
+            el["url"] = portal_url
+            count += 1
+    return count
+
+
+def lambda_handler(event, context):
+    if MODE == "LOG_ONLY":
+        # passRequestHeaders is false on this interceptor, so the event carries
+        # no inbound auth token to leak into CloudWatch.
+        logger.info("INTERCEPTOR_EVENT %s", json.dumps(event, default=str))
+
+    mcp = event.get("mcp", {})
+    gateway_response = mcp.get("gatewayResponse")
+    if not gateway_response:
+        return _passthrough_request(mcp.get("gatewayRequest", {}).get("body", {}))
+
+    body = gateway_response.get("body", {})
+    status_code = gateway_response.get("statusCode")
+
+    is_elicitation = (
+        isinstance(body, dict)
+        and isinstance(body.get("error"), dict)
+        and body["error"].get("code") == ELICITATION_ERROR_CODE
+    )
+
+    if MODE == "REWRITE" and is_elicitation:
+        if not PORTAL_URL:
+            logger.warning("REWRITE mode but PORTAL_URL is empty; passing through")
+        else:
+            replaced = rewrite_elicitation_urls(body, PORTAL_URL)
+            logger.info("CONSENT_ELICITATION rewrote %d identity URL(s) to the portal", replaced)
+            if replaced == 0:
+                logger.warning(
+                    "a -32042 elicitation matched no URL to rewrite; the payload shape "
+                    "may have changed. Redeploy with --mode log-only to inspect it."
+                )
+
+    return _response(body, status_code)

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/teardown.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/deploy/teardown.py
@@ -1,0 +1,414 @@
+"""Tear down the AWS resources this sample creates, in reverse-dependency order.
+
+Order matters in two places:
+
+  * Gateway targets must be gone before the gateway (DeleteGateway refuses
+    while any target remains), and target deletion is async, so this waits.
+
+  * The consent portal must finish DELETING before its IdP credential provider
+    and execution role are removed. The portal holds references to both, and
+    deleting them from under a still-DELETING portal is how you get a stuck
+    delete.
+
+Deletes: gateway targets -> GitHub credential provider -> consent portal (and
+waits) -> primary IdP credential provider -> portal execution role -> gateway
+-> gateway service role. Then verifies each is gone and reports survivors.
+
+Does NOT touch:
+  * The agent runtime / its CDK stack — remove that first with, from inside
+    the scaffolded project folder:
+        agentcore remove agent --name "$AGENT_RUNTIME_NAME" -y && agentcore deploy -y -v
+  * Your IdP app registrations — `00_delete_entra_apps.py` /
+    `00_delete_okta_apps.py`, or leave them (they cost nothing).
+  * Your GitHub OAuth App — delete it yourself at
+    https://github.com/settings/developers if you are done with it.
+
+Run from the sample root:
+    python deploy/teardown.py --entra
+    python deploy/teardown.py --entra --verify-only
+    python deploy/teardown.py --entra --clean-env
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import (
+    ENV_PATH,
+    check_boto_version,
+    control_client,
+    find_gateway_by_name,
+    find_portal_by_name,
+    gateway_name,
+    gateway_role_name,
+    github_provider_name,
+    idp_provider_name,
+    interceptor_lambda_name,
+    load_env,
+    portal_name,
+    portal_role_name,
+    select_idp_with_args,
+)
+
+NOT_FOUND = {"ResourceNotFoundException", "NotFoundException"}
+NO_SUCH_ENTITY = {"NoSuchEntity", "NoSuchEntityException"}
+
+
+def interceptor_present(control, gateway_id: str, idp: dict, region: str) -> bool:
+    """True if step 07's interceptor is attached, or its Lambda still exists."""
+    try:
+        gw = control.get_gateway(gatewayIdentifier=gateway_id)
+        if gw.get("interceptorConfigurations"):
+            return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in NOT_FOUND:
+            raise
+    # The Lambda outliving the attachment is the case that orphans resources, so
+    # it counts on its own.
+    try:
+        boto3.client("lambda", region_name=region).get_function(FunctionName=interceptor_lambda_name(idp))
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] in NOT_FOUND:
+            return False
+        raise
+
+
+DEPLOY_POPULATED_KEYS = [
+    "GATEWAY_ID",
+    "GATEWAY_URL",
+    "GATEWAY_MCP_URL",
+    "GATEWAY_SERVICE_ROLE_ARN",
+    "PORTAL_ID",
+    "PORTAL_ARN",
+    "PORTAL_URL",
+    "PORTAL_CALLBACK_URL",
+    "PORTAL_CONNECT_RETURN_URL",
+    "IDP_PROVIDER_ARN",
+    "PORTAL_EXECUTION_ROLE_ARN",
+    "GITHUB_PROVIDER_ARN",
+    "GITHUB_PROVIDER_CALLBACK_URL",
+    "GITHUB_TARGET_ID",
+    "AGENT_RUNTIME_INVOKE_URL",
+]
+
+
+def list_all_targets(control, gateway_id: str) -> list[dict]:
+    targets: list[dict] = []
+    for page in control.get_paginator("list_gateway_targets").paginate(gatewayIdentifier=gateway_id):
+        targets.extend(page.get("items", []))
+    return targets
+
+
+def delete_all_targets(control, gateway_id: str) -> None:
+    """Delete every target on the gateway, then wait for the async deletes."""
+    targets = list_all_targets(control, gateway_id)
+    if not targets:
+        print(f"• No gateway targets on {gateway_id}")
+        return
+    print(f"• Deleting {len(targets)} target(s) on {gateway_id}…")
+    for t in targets:
+        label = t.get("name") or t["targetId"]
+        try:
+            control.delete_gateway_target(gatewayIdentifier=gateway_id, targetId=t["targetId"])
+            print(f"  ✓ Deleted target: {label}")
+        except ClientError as e:
+            if e.response["Error"].get("Code") in NOT_FOUND:
+                print(f"  • Target already gone: {label}")
+            else:
+                raise
+    deadline = time.monotonic() + 90
+    while time.monotonic() < deadline:
+        remaining = list_all_targets(control, gateway_id)
+        if not remaining:
+            return
+        print(f"  ⏳ Waiting for {len(remaining)} target(s) to finish deleting…")
+        time.sleep(3)
+    remaining = list_all_targets(control, gateway_id)
+    if remaining:
+        names = ", ".join(t.get("name", t["targetId"]) for t in remaining)
+        print(
+            f"ERROR: gateway {gateway_id} still has targets after 90s: {names}.\n"
+            f"  Re-run teardown once they finish deleting.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def delete_portal(control, portal_id: str | None) -> None:
+    print("• Consent portal…")
+    if not portal_id:
+        print("  • None found, skipping")
+        return
+    try:
+        control.delete_consent_portal(consentPortalIdentifier=portal_id)
+        print(f"  ✓ Deleting: {portal_id}")
+    except ClientError as e:
+        if e.response["Error"].get("Code") not in NOT_FOUND:
+            raise
+        print(f"  • Already gone: {portal_id}")
+        return
+    # Wait it out — see the module docstring.
+    for _ in range(30):
+        try:
+            status = control.get_consent_portal(consentPortalIdentifier=portal_id)["status"]
+        except ClientError as e:
+            if e.response["Error"].get("Code") in NOT_FOUND:
+                print("  ✓ Deleted")
+                return
+            raise
+        print(f"    status: {status}")
+        time.sleep(10)
+    print(
+        "ERROR: portal still present after waiting; not touching its execution\n"
+        "  role or IdP provider while they may still be in use. Re-run teardown\n"
+        "  once the delete finishes.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def delete_provider(control, name: str) -> None:
+    try:
+        control.delete_oauth2_credential_provider(name=name)
+        print(f"  ✓ Deleted credential provider: {name}")
+    except ClientError as e:
+        if e.response["Error"].get("Code") in NOT_FOUND:
+            print(f"  • Credential provider already gone: {name}")
+        else:
+            raise
+
+
+def delete_gateway(control, gateway_id: str, name: str) -> None:
+    try:
+        control.delete_gateway(gatewayIdentifier=gateway_id)
+        print(f"  ✓ Deleted gateway: {name}")
+    except ClientError as e:
+        if e.response["Error"].get("Code") in NOT_FOUND:
+            print(f"  • Gateway already gone: {name}")
+        else:
+            raise
+
+
+def delete_role(iam, role_name: str) -> None:
+    try:
+        for policy_name in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
+            iam.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
+        for p in iam.list_attached_role_policies(RoleName=role_name).get("AttachedPolicies", []):
+            iam.detach_role_policy(RoleName=role_name, PolicyArn=p["PolicyArn"])
+        iam.delete_role(RoleName=role_name)
+        print(f"  ✓ Deleted IAM role: {role_name}")
+    except ClientError as e:
+        if e.response["Error"].get("Code") in NO_SUCH_ENTITY:
+            print(f"  • IAM role already gone: {role_name}")
+        else:
+            raise
+
+
+# --- verification ----------------------------------------------------------------
+
+
+def provider_exists(control, name: str) -> bool:
+    try:
+        control.get_oauth2_credential_provider(name=name)
+        return True
+    except ClientError as e:
+        if e.response["Error"].get("Code") in NOT_FOUND:
+            return False
+        raise
+
+
+def role_exists(iam, role_name: str) -> bool:
+    try:
+        iam.get_role(RoleName=role_name)
+        return True
+    except ClientError as e:
+        if e.response["Error"].get("Code") in NO_SUCH_ENTITY:
+            return False
+        raise
+
+
+def verify_all_gone(control, iam, idp: dict) -> list[str]:
+    survivors: list[str] = []
+
+    def check(label: str, present: bool, detail: str) -> None:
+        if present:
+            survivors.append(f"{label} still exists: {detail}")
+            print(f"  ✗ {label:<26}: {detail} — STILL PRESENT")
+        else:
+            print(f"  ✓ {label:<26}: {detail} — gone")
+
+    try:
+        portal = find_portal_by_name(control, portal_name(idp))
+        check("consent portal", portal is not None, portal_name(idp))
+    except Exception as e:  # noqa: BLE001
+        print(f"  ? consent portal            : check errored ({type(e).__name__}: {e})")
+
+    for label, name in (
+        ("GitHub cred provider", github_provider_name(idp)),
+        ("IdP cred provider", idp_provider_name(idp)),
+    ):
+        try:
+            check(label, provider_exists(control, name), name)
+        except Exception as e:  # noqa: BLE001
+            print(f"  ? {label:<26}: check errored ({type(e).__name__}: {e})")
+
+    try:
+        gw = find_gateway_by_name(control, gateway_name(idp))
+        detail = gateway_name(idp)
+        if gw:
+            try:
+                targets = list_all_targets(control, gw["gatewayId"])
+            except ClientError as e:
+                # ListGateways is eventually consistent and can still return a
+                # gateway that DeleteGateway has already removed. A 404 from the
+                # target listing settles it: the gateway is gone, not surviving.
+                if e.response["Error"]["Code"] in NOT_FOUND:
+                    gw, targets = None, []
+                else:
+                    raise
+            if targets:
+                detail += f" with {len(targets)} target(s)"
+        check("gateway", gw is not None, detail)
+    except Exception as e:  # noqa: BLE001
+        print(f"  ? gateway                   : check errored ({type(e).__name__}: {e})")
+
+    for label, role in (
+        ("portal execution role", portal_role_name(idp)),
+        ("gateway service role", gateway_role_name(idp)),
+    ):
+        try:
+            check(label, role_exists(iam, role), role)
+        except Exception as e:  # noqa: BLE001
+            print(f"  ? {label:<26}: check errored ({type(e).__name__}: {e})")
+
+    return survivors
+
+
+def clean_env_values() -> None:
+    """Blank the values of deploy-populated keys, leaving IdP config intact."""
+    if not ENV_PATH.exists():
+        return
+    lines = ENV_PATH.read_text().splitlines()
+    changed = False
+    for i, line in enumerate(lines):
+        for key in DEPLOY_POPULATED_KEYS:
+            if line.startswith(f"{key}=") and line.split("=", 1)[1]:
+                lines[i] = f"{key}="
+                changed = True
+                print(f"  ✓ Cleared .env value: {key}")
+                break
+    if changed:
+        ENV_PATH.write_text("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    idp, args = select_idp_with_args(
+        __doc__,
+        [
+            (["--verify-only"], {"action": "store_true", "help": "Skip deletions; just report survivors."}),
+            (["--clean-env"], {"action": "store_true", "help": "Also blank deploy-populated .env values."}),
+        ],
+    )
+    check_boto_version()
+    load_env()
+
+    control, region = control_client()
+    iam = boto3.client("iam", region_name=region)
+
+    if not args.verify_only:
+        print("[1/2] Deleting AWS resources…")
+        gw = find_gateway_by_name(control, gateway_name(idp))
+
+        # The optional interceptor (step 07) must be detached before the gateway
+        # goes, or its Lambda and role are orphaned with nothing referencing them.
+        #
+        # Detect it from GetGateway, never from the ListGateways summary that
+        # find_gateway_by_name returns — the summary carries no
+        # interceptorConfigurations, so testing it there always looks empty and
+        # silently skips this step. Fall back to the Lambda's own existence, which
+        # also covers a re-run after a partial teardown.
+        if gw and interceptor_present(control, gw["gatewayId"], idp, region):
+            print("• Optional interceptor detected — removing it first…")
+            import subprocess
+
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("07_deploy_interceptor.py")),
+                    f"--{idp['name']}",
+                    "--remove",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            print("  " + (r.stdout.strip().splitlines() or ["(no output)"])[-1])
+            if r.returncode != 0:
+                print(f"  ⚠ interceptor removal reported an error:\n{r.stderr.strip()[:400]}", file=sys.stderr)
+            gw = find_gateway_by_name(control, gateway_name(idp))
+
+        if gw:
+            delete_all_targets(control, gw["gatewayId"])
+        else:
+            print(f"• Gateway not found (already gone?): {gateway_name(idp)}")
+
+        print("• Credential provider (GitHub outbound)…")
+        delete_provider(control, github_provider_name(idp))
+
+        portal = find_portal_by_name(control, portal_name(idp))
+        delete_portal(control, (portal or {}).get("consentPortalId") or os.environ.get("PORTAL_ID"))
+
+        print("• Credential provider (primary IdP)…")
+        delete_provider(control, idp_provider_name(idp))
+
+        print("• Portal execution role…")
+        delete_role(iam, portal_role_name(idp))
+
+        if gw:
+            print("• Gateway…")
+            delete_gateway(control, gw["gatewayId"], gateway_name(idp))
+
+        print("• Gateway service role…")
+        delete_role(iam, gateway_role_name(idp))
+        print()
+
+    print("[2/2] Verifying…" if not args.verify_only else "[verify-only] Checking…")
+    survivors = verify_all_gone(control, iam, idp)
+
+    if survivors:
+        print()
+        print(f"⚠ {len(survivors)} resource(s) still present:")
+        for s in survivors:
+            print(f"    - {s}")
+        print()
+        print("Some AgentCore deletes are async. Wait 30 seconds and re-run:")
+        print(f"    python deploy/teardown.py --{idp['name']}")
+        sys.exit(1 if not args.verify_only else 0)
+
+    print()
+    print(f"✓ All AWS resources for the {idp['displayName']} run are cleaned up.")
+
+    if args.clean_env:
+        print()
+        print("[clean-env] Blanking deploy-populated .env values…")
+        clean_env_values()
+
+    print()
+    print("Still yours to clean up, if you are done for good:")
+    print("  - The agent runtime, from inside the scaffolded project folder:")
+    print('      agentcore remove agent --name "$AGENT_RUNTIME_NAME" -y && agentcore deploy -y -v')
+    print("  - The scaffolded project folder itself (rm -rf $AGENT_RUNTIME_NAME/).")
+    print(f"  - Your IdP apps: python deploy/00_delete_{idp['name']}_apps.py --yes")
+    print("  - Your GitHub OAuth App: https://github.com/settings/developers")
+
+
+if __name__ == "__main__":
+    main()

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/README.md
@@ -1,0 +1,61 @@
+# The frontend (a backend-for-frontend)
+
+A small FastAPI app that stands in for whatever real interface your users would
+have. Run it from the sample root:
+
+```bash
+python frontend/app.py      # http://localhost:8000
+```
+
+## What it does
+
+- Signs the user in to the primary IdP with the authorization code flow, and
+  keeps the resulting access token in a **server-side signed session cookie**.
+  The browser never receives the token.
+- Links to the AgentCore consent portal so the user can connect GitHub. That
+  flow is entirely AWS-hosted — this app takes no part in it and sees no GitHub
+  credential.
+- Forwards prompts to the deployed agent with the user's token as the Bearer
+  credential, and renders the reply. AgentCore Runtime streams Server-Sent
+  Events, so `_parse_agent_response` concatenates the `data:` lines.
+
+## Structure
+
+| File | Purpose |
+| :--- | :--- |
+| `app.py` | Routes, session, agent invocation. IdP-agnostic. |
+| `auth_entra.py` | MSAL confidential client |
+| `auth_okta.py` | authlib, authorization code + PKCE |
+| `templates/` | `base.html` and three pages |
+
+`IDP=entra|okta` in `.env` selects the adapter. Both expose the same three
+methods — `login_redirect`, `exchange_code`, `label` — so nothing in `app.py`
+branches on the identity provider. The Entra adapter is synchronous and the Okta
+one is async, which `_maybe_await` absorbs.
+
+## Routes
+
+| Route | Notes |
+| :--- | :--- |
+| `GET /` | Sign-in state, the portal link, the prompt box |
+| `GET /auth/login`, `/auth/callback`, `/auth/logout` | The authorization code flow |
+| `POST /ask` | Invokes the agent; renders the consent call-to-action when the reply carries the portal URL |
+| `GET /debug/token` | Shows the session's access token so you can decode it at jwt.io |
+
+`/debug/token` exists because the two claims that decide whether this sample
+works are in that token: `aud` (must satisfy both the runtime's and the
+gateway's authorizer) and the subject claim (must be the same user who consented
+on the portal). **Remove this route if you reuse the scaffold** — it displays a
+live credential.
+
+## Notes
+
+- `AGENT_RUNTIME_INVOKE_URL` must end with `?qualifier=DEFAULT`; without it the
+  invoke returns `404 UnknownOperationException`. `/ask` says so when it sees a
+  404, and adds a similar hint for a 401/403 (which means the runtime rejected
+  the token, i.e. the runtime and gateway audiences disagree).
+- `FRONTEND_REDIRECT_URI` must match what is registered on the frontend app in
+  your IdP. Entra requires `http://` redirect URIs to use the literal hostname
+  `localhost`, not `127.0.0.1`.
+- `FRONTEND_SESSION_SECRET` should be a long random value. If it is unset a
+  random one is generated per process, so sessions do not survive a restart.

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/app.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/app.py
@@ -1,0 +1,295 @@
+"""FastAPI backend-for-frontend for the consent-portal + GitHub MCP sample.
+
+Responsibilities, and deliberately nothing more:
+  - Sign the user in to the primary IdP (authorization code flow) and keep the
+    resulting access token in a server-side signed session cookie. The browser
+    never sees the token.
+  - Link to the AgentCore consent portal, where the user grants GitHub access.
+    That flow is entirely AWS-hosted; this app takes no part in it.
+  - Forward prompts to the deployed AgentCore Runtime agent with the user's
+    token as the Bearer credential.
+
+Which IdP is used comes from IDP=entra|okta in .env, written by
+deploy/00_create_*_apps.py. The two adapters (auth_entra.py, auth_okta.py)
+share one interface so everything below is IdP-agnostic.
+
+Run from the sample root, after the agent is deployed:
+    python frontend/app.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import secrets
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+
+FRONTEND_DIR = Path(__file__).resolve().parent
+SAMPLE_ROOT = FRONTEND_DIR.parent
+sys.path.insert(0, str(FRONTEND_DIR))
+
+# Honour the same CONSENT_ENV_FILE override the deploy scripts use, so one
+# checkout can serve either identity provider's deployment:
+#     CONSENT_ENV_FILE=.env.okta python frontend/app.py
+_env_file = os.environ.get("CONSENT_ENV_FILE", "").strip() or ".env"
+ENV_PATH = Path(_env_file) if Path(_env_file).is_absolute() else SAMPLE_ROOT / _env_file
+load_dotenv(ENV_PATH, override=True)
+
+IDP = os.environ.get("IDP", "").strip().lower()
+if IDP == "entra":
+    from auth_entra import EntraAuth
+
+    auth = EntraAuth()
+elif IDP == "okta":
+    from auth_okta import OktaAuth
+
+    auth = OktaAuth()
+else:
+    raise RuntimeError(
+        "IDP must be 'entra' or 'okta' in .env. Run deploy/00_create_entra_apps.py "
+        "or deploy/00_create_okta_apps.py first."
+    )
+
+SESSION_SECRET = os.environ.get("FRONTEND_SESSION_SECRET") or secrets.token_hex(32)
+AGENT_RUNTIME_INVOKE_URL = os.environ.get("AGENT_RUNTIME_INVOKE_URL", "").strip()
+# Stored bare in .env; give it a scheme for the browser.
+PORTAL_URL = os.environ.get("PORTAL_URL", "").strip()
+PORTAL_LINK = f"https://{PORTAL_URL.removeprefix('https://').rstrip('/')}" if PORTAL_URL else ""
+
+DEFAULT_PROMPT = "Search GitHub for amazon-bedrock-agentcore-samples and summarize the top result."
+
+app = FastAPI(title="AgentCore consent portal + GitHub MCP sample")
+app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET, same_site="lax")
+templates = Jinja2Templates(directory=str(FRONTEND_DIR / "templates"))
+
+
+# Identifies this deployment. A session cookie is only meaningful for the
+# deployment that minted it: the access token inside it was issued by one
+# identity provider, for one gateway's audience. Running a second variant from
+# the same checkout — with the same FRONTEND_SESSION_SECRET — would otherwise
+# leave you apparently signed in with a token the other runtime rejects, which
+# looks like "the wrong deployment is showing".
+DEPLOYMENT_ID = hashlib.sha256(f"{IDP}|{PORTAL_URL}|{AGENT_RUNTIME_INVOKE_URL}".encode()).hexdigest()[:16]
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Adapters are sync for Entra (MSAL) and async for Okta (authlib)."""
+    return await value if inspect.isawaitable(value) else value
+
+
+def _drop_foreign_session(request: Request) -> bool:
+    """Clear a session that belongs to a different deployment. True if dropped."""
+    if not request.session.get("user"):
+        return False
+    if request.session.get("deployment") == DEPLOYMENT_ID:
+        return False
+    request.session.clear()
+    return True
+
+
+def _page_context(request: Request, **extra: Any) -> dict:
+    return {
+        "user": request.session.get("user"),
+        "idp": IDP,
+        "signin_label": auth.label(),
+        "portal_link": PORTAL_LINK,
+        "agent_configured": bool(AGENT_RUNTIME_INVOKE_URL),
+        "default_prompt": DEFAULT_PROMPT,
+        **extra,
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request) -> Any:
+    dropped = _drop_foreign_session(request)
+    return templates.TemplateResponse(request, "home.html", _page_context(request, session_dropped=dropped))
+
+
+@app.get("/auth/login")
+async def login(request: Request):
+    return await _maybe_await(auth.login_redirect(request))
+
+
+@app.get("/auth/callback")
+async def callback(request: Request) -> RedirectResponse:
+    user, access_token = await _maybe_await(auth.exchange_code(request))
+    request.session["user"] = user
+    request.session["access_token"] = access_token
+    request.session["deployment"] = DEPLOYMENT_ID
+    return RedirectResponse("/", status_code=302)
+
+
+@app.get("/auth/logout")
+async def logout(request: Request) -> RedirectResponse:
+    request.session.clear()
+    return RedirectResponse("/", status_code=302)
+
+
+def _decode_claims(jwt: str) -> dict:
+    """Decode a JWT payload without verifying its signature.
+
+    Display only. The claims that decide whether this sample works are `aud`
+    (must satisfy both the runtime's and the gateway's authorizer), `iss`, and
+    the subject — which is the identity AgentCore stores GitHub consent under.
+    """
+    import base64
+
+    try:
+        payload = jwt.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload))
+    except (IndexError, ValueError, TypeError):
+        return {}
+
+
+@app.get("/debug/token", response_class=HTMLResponse)
+async def debug_token(request: Request) -> Any:
+    """Show the session's access token and its decoded claims.
+
+    Useful for confirming the passthrough contract, and for diagnosing the
+    "Connect succeeded but tool calls still ask for consent" case: compare the
+    subject claim shown here against the user id the consent portal displays.
+    If they differ, consent is being stored under one identity and looked up
+    under another. Debug route only — remove it if you reuse this scaffold.
+    """
+    _drop_foreign_session(request)
+    access_token = request.session.get("access_token")
+    if not access_token:
+        return RedirectResponse("/auth/login", status_code=302)
+    claims = _decode_claims(access_token)
+    # azp/appid is the CLIENT that requested the token; aud is the resource.
+    # Under Entra `sub` is pairwise on the *resource*, not the client — verified
+    # live: this app and the portal sign in through different clients against
+    # the same audience and get identical `sub` values. Both are shown so a
+    # subject mismatch can be attributed to the right one.
+    interesting = {
+        k: claims.get(k)
+        for k in ("aud", "iss", "sub", "oid", "azp", "appid", "scp", "preferred_username", "ver")
+        if claims.get(k) is not None
+    }
+    return templates.TemplateResponse(
+        request,
+        "token.html",
+        _page_context(request, access_token=access_token, claims=interesting),
+    )
+
+
+def _parse_agent_response(response: httpx.Response) -> dict:
+    """AgentCore Runtime streams Server-Sent Events; concatenate the data lines."""
+    content_type = response.headers.get("content-type", "")
+    raw = response.text
+    if "text/event-stream" in content_type or raw.startswith("data:"):
+        chunks: list[str] = []
+        for line in raw.splitlines():
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if not payload:
+                continue
+            try:
+                chunks.append(json.loads(payload))
+            except ValueError:
+                chunks.append(payload)
+        return {"answer": "".join(chunks).strip()}
+    try:
+        return response.json()
+    except ValueError:
+        return {"answer": raw}
+
+
+async def _invoke_agent(request: Request, body: dict, label: str) -> Any:
+    """Send one prompt to the runtime and render the reply."""
+    _drop_foreign_session(request)
+    access_token = request.session.get("access_token")
+    if not access_token or not request.session.get("user"):
+        return RedirectResponse("/auth/login", status_code=302)
+
+    if not AGENT_RUNTIME_INVOKE_URL:
+        raise HTTPException(
+            503,
+            "AGENT_RUNTIME_INVOKE_URL is not set. Deploy the agent "
+            "(`agentcore deploy -y -v`), take the invoke URL from "
+            "`agentcore status`, append ?qualifier=DEFAULT, add it to .env, and "
+            "restart this frontend.",
+        )
+
+    async with httpx.AsyncClient(timeout=180.0) as client:
+        try:
+            response = await client.post(
+                AGENT_RUNTIME_INVOKE_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+        except httpx.HTTPError as e:
+            return templates.TemplateResponse(
+                request,
+                "result.html",
+                _page_context(request, prompt=label, error=f"Network error calling the agent: {e}"),
+            )
+
+    if response.status_code != 200:
+        hint = ""
+        if response.status_code == 404:
+            hint = (
+                "\n\nA 404 UnknownOperationException usually means "
+                "AGENT_RUNTIME_INVOKE_URL is missing the ?qualifier=DEFAULT suffix."
+            )
+        elif response.status_code in (401, 403):
+            hint = (
+                "\n\nA 401/403 here means the runtime rejected your token. Check that "
+                "the runtime's allowedAudience matches the gateway's — re-run "
+                "deploy/05_patch_agentcore_json.py and redeploy."
+            )
+        return templates.TemplateResponse(
+            request,
+            "result.html",
+            _page_context(
+                request,
+                prompt=label,
+                error=f"Agent returned {response.status_code}: {response.text}{hint}",
+            ),
+        )
+
+    result = _parse_agent_response(response)
+    # The agent replies with the portal URL when the caller has not consented.
+    # Flagging it lets the template render it as a call to action rather than
+    # burying it in prose.
+    answer = result.get("answer") or ""
+    needs_consent = bool(PORTAL_LINK) and PORTAL_LINK in answer
+    return templates.TemplateResponse(
+        request,
+        "result.html",
+        _page_context(request, prompt=label, result=result, needs_consent=needs_consent),
+    )
+
+
+@app.post("/ask", response_class=HTMLResponse)
+async def ask(request: Request) -> Any:
+    """The model picks which GitHub tool to call. Needs Bedrock model access."""
+    form = await request.form()
+    prompt = form.get("prompt") or DEFAULT_PROMPT
+    return await _invoke_agent(request, {"prompt": prompt}, prompt)
+
+
+if __name__ == "__main__":
+    host = os.environ.get("FRONTEND_HOST") or "localhost"
+    port = int(os.environ.get("FRONTEND_PORT") or "8000")
+    print(f"IdP: {IDP}")
+    print(f"Consent portal: {PORTAL_LINK or '(PORTAL_URL not set)'}")
+    print(f"Starting frontend on http://{host}:{port}")
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/auth_entra.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/auth_entra.py
@@ -1,0 +1,80 @@
+"""Entra ID sign-in adapter for the BFF (MSAL confidential client).
+
+Implements the three-method interface app.py expects:
+    login_redirect(request)  -> RedirectResponse to the IdP
+    exchange_code(request)    -> (user_dict, access_token)
+    label()                   -> button text
+
+The scope requested is GATEWAY_SCOPE, the fully qualified
+`api://<GATEWAY_CLIENT_ID>/access_as_user`. Entra's /authorize only accepts the
+qualified form, and the resulting token's `aud` is the bare GUID — which is
+what both the runtime and the gateway are configured to accept. One token,
+both hops: that is the passthrough contract.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+import msal
+from fastapi import HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+
+class EntraAuth:
+    name = "entra"
+
+    def __init__(self) -> None:
+        self.tenant_id = _env("TENANT_ID")
+        self.client_id = _env("FRONTEND_CLIENT_ID")
+        self.client_secret = _env("FRONTEND_CLIENT_SECRET")
+        self.scope = _env("GATEWAY_SCOPE")
+        self.redirect_uri = os.environ.get("FRONTEND_REDIRECT_URI", "http://localhost:8000/auth/callback")
+        self.authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+
+    def label(self) -> str:
+        return "Sign in with Microsoft"
+
+    def _client(self) -> msal.ConfidentialClientApplication:
+        return msal.ConfidentialClientApplication(
+            client_id=self.client_id,
+            client_credential=self.client_secret,
+            authority=self.authority,
+        )
+
+    def login_redirect(self, request: Request) -> RedirectResponse:
+        state = secrets.token_urlsafe(16)
+        request.session["auth_state"] = state
+        url = self._client().get_authorization_request_url(
+            scopes=[self.scope], state=state, redirect_uri=self.redirect_uri
+        )
+        return RedirectResponse(url, status_code=302)
+
+    def exchange_code(self, request: Request) -> tuple[dict, str]:
+        code = request.query_params.get("code")
+        state = request.query_params.get("state")
+        if not code or state != request.session.get("auth_state"):
+            raise HTTPException(400, "Invalid OAuth callback — missing or mismatched state")
+        result = self._client().acquire_token_by_authorization_code(
+            code=code, scopes=[self.scope], redirect_uri=self.redirect_uri
+        )
+        if "error" in result:
+            raise HTTPException(400, f"{result['error']}: {result.get('error_description', '')}")
+        claims = result.get("id_token_claims", {}) or {}
+        user = {
+            "name": claims.get("name"),
+            "username": claims.get("preferred_username"),
+            # Entra's `sub` is pairwise per application, so `oid` is the
+            # stable per-user value worth showing here.
+            "subject_label": "oid",
+            "subject": claims.get("oid"),
+        }
+        return user, result["access_token"]
+
+
+def _env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required env var {name} is not set (see config.example.env)")
+    return value

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/auth_okta.py
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/auth_okta.py
@@ -1,0 +1,79 @@
+"""Okta sign-in adapter for the BFF (authlib, authorization code + PKCE).
+
+Implements the same three-method interface as auth_entra.py:
+    login_redirect(request)  -> RedirectResponse to the IdP
+    exchange_code(request)    -> (user_dict, access_token)
+    label()                   -> button text
+
+The scope requested is `openid profile email` plus GATEWAY_SCOPE (the short
+`access_as_user`; Okta uses one spelling end to end). The token is issued by
+the CUSTOM authorization server, so its `aud` is that server's `audiences`
+value — which is what both the runtime and the gateway accept. One token, both
+hops: that is the passthrough contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+from authlib.integrations.starlette_client import OAuth
+from fastapi import HTTPException, Request
+
+
+class OktaAuth:
+    name = "okta"
+
+    def __init__(self) -> None:
+        domain = _env("OKTA_DOMAIN")
+        as_id = os.environ.get("OKTA_AUTH_SERVER_ID") or "default"
+        self.redirect_uri = os.environ.get("FRONTEND_REDIRECT_URI", "http://localhost:8000/auth/callback")
+        scope = f"openid profile email {_env('GATEWAY_SCOPE')}"
+        self.oauth = OAuth()
+        self.oauth.register(
+            name="okta",
+            client_id=_env("FRONTEND_CLIENT_ID"),
+            client_secret=_env("FRONTEND_CLIENT_SECRET"),
+            server_metadata_url=(f"https://{domain}/oauth2/{as_id}/.well-known/openid-configuration"),
+            client_kwargs={
+                "scope": scope,
+                # PKCE is sent even though this is a confidential client with a
+                # secret, and even though 00_create_okta_apps.py does not set
+                # "Require PKCE" on the app. authlib omits the code challenge
+                # unless asked, so this is opt-in: it costs nothing, and it means
+                # the flow still works if you later tighten the app to require
+                # PKCE.
+                "code_challenge_method": "S256",
+            },
+        )
+
+    def label(self) -> str:
+        return "Sign in with Okta"
+
+    async def login_redirect(self, request: Request):
+        return await self.oauth.okta.authorize_redirect(request, self.redirect_uri)
+
+    async def exchange_code(self, request: Request) -> tuple[dict, str]:
+        try:
+            token = await self.oauth.okta.authorize_access_token(request)
+        except Exception as e:
+            raise HTTPException(400, f"OAuth callback failed: {e}") from e
+        access_token = token.get("access_token")
+        if not access_token:
+            raise HTTPException(400, "No access_token in the Okta response")
+        claims = token.get("userinfo") or {}
+        user = {
+            "name": claims.get("name"),
+            "username": claims.get("preferred_username") or claims.get("email"),
+            # Okta's `sub` is stable per user across client apps, which is why
+            # the consent portal can use its own login app here.
+            "subject_label": "sub",
+            "subject": claims.get("sub"),
+        }
+        return user, access_token
+
+
+def _env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required env var {name} is not set (see config.example.env)")
+    return value

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/base.html
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/base.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}AgentCore consent portal sample{% endblock %}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; color: #1f2328; line-height: 1.5; }
+    h1 { margin-bottom: 0.25rem; font-size: 1.5rem; }
+    h2 { font-size: 1.1rem; margin-top: 0; }
+    .muted { color: #636c76; }
+    .chain { font-family: ui-monospace, monospace; font-size: 0.85rem; color: #636c76; }
+    .box { border: 1px solid #d1d9e0; border-radius: 8px; padding: 1rem 1.25rem; margin: 1rem 0; background: #f6f8fa; }
+    .warn { background: #fff8c5; border-color: #d4a72c; }
+    .err { background: #ffebe9; border-color: #ff8182; }
+    .ok { background: #dafbe1; border-color: #4ac26b; }
+    .cta { background: #ddf4ff; border-color: #54aeff; }
+    button, input[type=submit] { background: #1f883d; color: #fff; border: 0; padding: 0.5rem 1rem; border-radius: 6px; cursor: pointer; font-size: 0.95rem; }
+    button:hover, input[type=submit]:hover { background: #1a7f37; }
+    input[type=submit][disabled] { background: #8c959f; cursor: not-allowed; }
+    input[type=text] { width: 100%; padding: 0.5rem; border: 1px solid #d1d9e0; border-radius: 6px; box-sizing: border-box; font-size: 0.95rem; }
+    code { background: #eff1f3; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.9em; }
+    pre { background: #1f2328; color: #e6edf3; padding: 1rem; border-radius: 6px; overflow-x: auto; font-size: 0.8rem; }
+    textarea { width: 100%; height: 200px; font-family: ui-monospace, monospace; font-size: 0.72rem; padding: 0.75rem; border: 1px solid #d1d9e0; border-radius: 6px; box-sizing: border-box; }
+    a { color: #0969da; }
+    .diagram { width: 100%; height: auto; display: block; margin: 0.5rem 0 0; }
+    .diagram text { font-family: system-ui, sans-serif; }
+  </style>
+</head>
+<body>
+{% block content %}{% endblock %}
+<p class="muted" style="margin-top: 3rem; font-size: 0.85rem;">
+  Sample code. See <code>README.md</code> and <code>ARCHITECTURE.md</code> in this
+  folder for what happens on each hop.
+</p>
+</body>
+</html>

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/home.html
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/home.html
@@ -2,7 +2,7 @@
 {% block content %}
   <h1>AgentCore consent portal &mdash; GitHub MCP</h1>
   <p class="muted">You &rarr; this app &rarr; agent on AgentCore Runtime &rarr; AgentCore Gateway &rarr; GitHub MCP server</p>
-  <p class="chain">signed in with {{ idp }} &middot; GitHub access granted out of band on the hosted consent portal (3LO)</p>
+  <p class="chain">signed in with {{ idp }} &middot; GitHub access granted out of band on the hosted consent portal</p>
 
   <div class="box" style="background: #fff;">
     <svg class="diagram" viewBox="0 0 700 380" role="img"

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/home.html
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/home.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>AgentCore consent portal &mdash; GitHub MCP</h1>
+  <p class="muted">You &rarr; this app &rarr; agent on AgentCore Runtime &rarr; AgentCore Gateway &rarr; GitHub MCP server</p>
+  <p class="chain">signed in with {{ idp }} &middot; GitHub access granted out of band on the hosted consent portal (3LO)</p>
+
+  <div class="box" style="background: #fff;">
+    <svg class="diagram" viewBox="0 0 700 380" role="img"
+         aria-labelledby="dgm-title dgm-desc">
+      <title id="dgm-title">How this demo works</title>
+      <desc id="dgm-desc">Consent happens once on an AWS-hosted portal, which stores your
+        GitHub token in the AgentCore token vault. Every later request goes from you through
+        this app to an agent, then a gateway, which reads that stored consent to call GitHub
+        as you.</desc>
+
+      <defs>
+        <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5"
+                markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 1 L 9 5 L 0 9 z" fill="#57606a"/>
+        </marker>
+      </defs>
+
+      <!-- band 1: consent, once -->
+      <rect x="8" y="8" width="684" height="96" rx="8" fill="#f0fdf4" stroke="#4ac26b"/>
+      <text x="24" y="30" font-size="12" font-weight="600" fill="#1a7f37">
+        1 &#8212; Consent, once. On a page AWS hosts; this app is not involved.
+      </text>
+      <rect x="24"  y="48" width="80"  height="38" rx="6" fill="#fff" stroke="#8c959f"/>
+      <text x="64"  y="72" font-size="12" text-anchor="middle" fill="#1f2328">You</text>
+      <rect x="170" y="48" width="240" height="38" rx="6" fill="#dafbe1" stroke="#4ac26b"/>
+      <text x="290" y="66" font-size="12" font-weight="600" text-anchor="middle" fill="#1f2328">Consent portal</text>
+      <text x="290" y="80" font-size="10" text-anchor="middle" fill="#57606a">AWS-managed and hosted</text>
+      <rect x="476" y="48" width="124" height="38" rx="6" fill="#f6f8fa" stroke="#8c959f"/>
+      <text x="538" y="72" font-size="12" text-anchor="middle" fill="#1f2328">GitHub</text>
+      <line x1="104" y1="67" x2="164" y2="67" stroke="#57606a" marker-end="url(#ah)"/>
+      <text x="134" y="61" font-size="10" text-anchor="middle" fill="#57606a">sign in</text>
+      <line x1="410" y1="67" x2="470" y2="67" stroke="#57606a" marker-end="url(#ah)"/>
+      <text x="440" y="61" font-size="10" text-anchor="middle" fill="#57606a">approve</text>
+
+      <!-- the vault: where the two flows meet -->
+      <rect x="248" y="138" width="204" height="38" rx="19" fill="#ecfdf5" stroke="#4ac26b"/>
+      <text x="350" y="156" font-size="12" font-weight="600" text-anchor="middle" fill="#1f2328">Token vault</text>
+      <text x="350" y="169" font-size="10" text-anchor="middle" fill="#57606a">AgentCore Identity</text>
+      <line x1="300" y1="104" x2="300" y2="136" stroke="#57606a" marker-end="url(#ah)"/>
+      <text x="292" y="126" font-size="10" text-anchor="end" fill="#57606a">stores your token</text>
+      <line x1="400" y1="210" x2="400" y2="178" stroke="#57606a" marker-end="url(#ah)"/>
+      <text x="408" y="126" font-size="10" fill="#57606a">reads it back</text>
+
+      <!-- band 2: every request -->
+      <rect x="8" y="210" width="684" height="160" rx="8" fill="#f0f6ff" stroke="#54aeff"/>
+      <text x="24" y="232" font-size="12" font-weight="600" fill="#0969da">
+        2 &#8212; Every request afterwards. No prompting; your consent is reused.
+      </text>
+      <text x="24" y="249" font-size="10" fill="#57606a">
+        one sign-in token is forwarded unchanged along this path
+      </text>
+      <rect x="24"  y="266" width="80"  height="38" rx="6" fill="#fff" stroke="#8c959f"/>
+      <text x="64"  y="290" font-size="12" text-anchor="middle" fill="#1f2328">You</text>
+      <rect x="130" y="266" width="114" height="38" rx="6" fill="#ddf4ff" stroke="#54aeff"/>
+      <text x="187" y="290" font-size="12" text-anchor="middle" fill="#1f2328">This app</text>
+      <rect x="270" y="266" width="120" height="38" rx="6" fill="#ddf4ff" stroke="#54aeff"/>
+      <text x="330" y="284" font-size="12" font-weight="600" text-anchor="middle" fill="#1f2328">Agent</text>
+      <text x="330" y="297" font-size="10" text-anchor="middle" fill="#57606a">AgentCore Runtime</text>
+      <rect x="416" y="266" width="120" height="38" rx="6" fill="#dafbe1" stroke="#4ac26b"/>
+      <text x="476" y="284" font-size="12" font-weight="600" text-anchor="middle" fill="#1f2328">Gateway</text>
+      <text x="476" y="297" font-size="10" text-anchor="middle" fill="#57606a">AgentCore</text>
+      <rect x="562" y="266" width="106" height="38" rx="6" fill="#f6f8fa" stroke="#8c959f"/>
+      <text x="615" y="290" font-size="12" text-anchor="middle" fill="#1f2328">GitHub</text>
+      <line x1="104" y1="285" x2="126" y2="285" stroke="#57606a" marker-end="url(#ah)"/>
+      <line x1="244" y1="285" x2="266" y2="285" stroke="#57606a" marker-end="url(#ah)"/>
+      <line x1="390" y1="285" x2="412" y2="285" stroke="#57606a" marker-end="url(#ah)"/>
+      <line x1="536" y1="285" x2="558" y2="285" stroke="#57606a" marker-end="url(#ah)"/>
+
+      <!-- the model: chooses which tool, never sees a credential -->
+      <rect x="270" y="326" width="120" height="34" rx="6" fill="#f6f8fa" stroke="#8c959f"/>
+      <text x="330" y="347" font-size="11" text-anchor="middle" fill="#1f2328">Bedrock model</text>
+      <line x1="330" y1="304" x2="330" y2="324" stroke="#57606a" marker-end="url(#ah)"/>
+      <text x="400" y="341" font-size="10" fill="#57606a">picks which tool to call &#8212;</text>
+      <text x="400" y="354" font-size="10" fill="#57606a">never sees a GitHub credential</text>
+    </svg>
+    <p class="muted" style="font-size: 0.85rem; margin-bottom: 0;">
+      Your GitHub credential never reaches this app or the agent &mdash; only the gateway
+      uses it, and only because you granted it on the portal. Consent is per user, so it
+      covers you and nobody else; you can withdraw it from
+      <a href="https://github.com/settings/applications" target="_blank" rel="noopener">your
+      GitHub authorized&nbsp;apps</a>.
+    </p>
+  </div>
+
+  {% if session_dropped %}
+    <div class="box warn">
+      <strong>Signed you out.</strong> Your previous session belonged to a different
+      deployment of this sample (a different identity provider or gateway), so the token
+      in it would have been rejected. Sign in again below.
+    </div>
+  {% endif %}
+
+  {% if not agent_configured %}
+    <div class="box warn">
+      <strong>Agent not deployed yet.</strong>
+      Deploy it with <code>agentcore deploy -y -v</code>, take the invoke URL from
+      <code>agentcore status</code>, append <code>?qualifier=DEFAULT</code>, set it in
+      <code>.env</code> as <code>AGENT_RUNTIME_INVOKE_URL</code>, and restart this app.
+    </div>
+  {% endif %}
+
+  {% if user %}
+    <div class="box">
+      <p>Signed in as <strong>{{ user.name or user.username }}</strong>{% if user.username %} ({{ user.username }}){% endif %}</p>
+      {% if user.subject %}
+        <p class="muted"><code>{{ user.subject_label }}</code>: <code>{{ user.subject }}</code> &mdash;
+          the consent portal binds your GitHub consent under this identity, and the gateway
+          resolves the same one from the token this app sends.</p>
+      {% endif %}
+      <p><a href="/auth/logout">Sign out</a> &middot; <a href="/debug/token">Inspect my token</a></p>
+    </div>
+
+    <div class="box cta">
+      <h2>Step 1 &mdash; connect GitHub on the consent portal</h2>
+      <p>The portal is hosted and managed by AWS. It authenticates you against the same
+        identity provider, then walks you through GitHub's authorization and binds that
+        consent to you. Nothing here handles your GitHub token.</p>
+      {% if portal_link %}
+        <p><a href="{{ portal_link }}" target="_blank" rel="noopener"><button type="button">Open the consent portal</button></a></p>
+        <p class="muted" style="font-size: 0.85rem;">A newly created connection can take up to
+          5 minutes to appear on that page.</p>
+      {% else %}
+        <p class="muted">Set <code>PORTAL_URL</code> in <code>.env</code> (written by
+          <code>deploy/02_create_portal.py</code>) to get a link here.</p>
+      {% endif %}
+    </div>
+
+    <div class="box">
+      <h2>Step 2 &mdash; ask the agent about GitHub</h2>
+      <p class="muted">This app sends the agent your access token. The agent forwards it to
+        the gateway, which calls the GitHub MCP server with the authorization <em>you</em>
+        granted. If you have not connected yet, the agent points you back to the portal
+        instead of failing.</p>
+      <form method="post" action="/ask">
+        <p><input type="text" name="prompt" value="{{ default_prompt }}" /></p>
+        <p><input type="submit" value="Ask the agent" {% if not agent_configured %}disabled{% endif %} /></p>
+      </form>
+    </div>
+  {% else %}
+    <div class="box">
+      <p>Sign in to try the flow. Use an account that exists in the identity provider you
+        configured, and sign in to the consent portal with the same one.</p>
+      <p><a href="/auth/login"><button type="button">{{ signin_label }}</button></a></p>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/result.html
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/result.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}Result{% endblock %}
+{% block content %}
+  <h1>Result</h1>
+  <p class="muted">You asked: <em>{{ prompt }}</em></p>
+
+  {% if error %}
+    <div class="box err">
+      <h2>Something went wrong</h2>
+      <pre>{{ error }}</pre>
+    </div>
+  {% elif needs_consent %}
+    <div class="box cta">
+      <h2>GitHub is not connected yet</h2>
+      <p style="white-space: pre-wrap;">{{ result.answer }}</p>
+      {% if portal_link %}
+        <p><a href="{{ portal_link }}" target="_blank" rel="noopener"><button type="button">Open the consent portal</button></a></p>
+      {% endif %}
+      <p class="muted" style="font-size: 0.85rem;">The gateway returned a URL-mode elicitation
+        (JSON-RPC <code>-32042</code>) because it has no stored GitHub authorization for you.
+        The agent replaced the raw authorization URL with the portal's, so your consent is
+        bound to your session.</p>
+    </div>
+  {% else %}
+    <div class="box ok">
+      <h2>The agent answered</h2>
+      {% if result.answer %}
+        <p style="font-size: 1.05rem; white-space: pre-wrap;">{{ result.answer }}</p>
+      {% else %}
+        <pre>{{ result | tojson(indent=2) }}</pre>
+      {% endif %}
+      <details style="margin-top: 1rem;">
+        <summary class="muted" style="cursor: pointer; font-size: 0.85rem;">Show raw response</summary>
+        <pre style="margin-top: 0.5rem;">{{ result | tojson(indent=2) }}</pre>
+      </details>
+    </div>
+  {% endif %}
+
+  <p><a href="/">&larr; back</a></p>
+{% endblock %}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/token.html
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/frontend/templates/token.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Debug: your access token{% endblock %}
+{% block content %}
+  <h1>Your access token</h1>
+  <div class="box warn">
+    <p>This is the token this app received from {{ idp }} at sign-in, and the same token it
+      sends to the AgentCore Runtime as <code>Authorization: Bearer</code>. The agent forwards
+      it to the gateway unchanged &mdash; that is the passthrough contract.</p>
+    <p>Debug route only. The token is sensitive; remove this route if you reuse this
+      scaffold.</p>
+  </div>
+  {% if claims %}
+    <div class="box">
+      <h2>Decoded claims</h2>
+      <table style="border-collapse: collapse; width: 100%; font-size: 0.9rem;">
+        {% for k, v in claims.items() %}
+          <tr>
+            <td style="padding: 0.25rem 0.75rem 0.25rem 0; vertical-align: top;"><code>{{ k }}</code></td>
+            <td style="padding: 0.25rem 0; word-break: break-all;">{{ v }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+      <p class="muted" style="margin-top: 0.75rem; font-size: 0.85rem;">
+        <strong>Diagnosing "Connect worked but the agent still asks for consent":</strong>
+        compare <code>sub</code> above against the user id shown in the consent portal's
+        header. They must match &mdash; consent is stored under the portal's subject and
+        looked up under this one.
+        <br><br>
+        Under Entra <code>sub</code> is a pairwise identifier keyed on the
+        <strong>resource</strong> the token is audienced at (<code>aud</code>), not on the
+        client that requested it (<code>azp</code>). Verified here: this token's
+        <code>azp</code> is the frontend app while the portal signs in through the resource
+        app, and the two <code>sub</code> values are still identical. So what matters is
+        that both sign-ins target the same <code>aud</code> &mdash; which is what
+        <code>PORTAL_SCOPES</code> and <code>GATEWAY_SCOPE</code> both pointing at
+        <code>api://&lt;resource&gt;/access_as_user</code> guarantees.
+      </p>
+    </div>
+  {% endif %}
+
+  <p>You can also paste the raw token into <a href="https://jwt.io" target="_blank" rel="noopener">jwt.io</a>:</p>
+  <ul>
+    <li><code>aud</code> &mdash; must match the <code>allowedAudience</code> on both the runtime
+      and the gateway, or you get a 401 that looks like a gateway fault.</li>
+    <li><code>iss</code> &mdash; must match the issuer in <code>IDP_DISCOVERY_URL</code>. Under Entra a
+      v1-style <code>sts.windows.net</code> issuer here means
+      <code>requestedAccessTokenVersion</code> is not 2.</li>
+    <li>{% if idp == 'entra' %}<code>oid</code>{% else %}<code>sub</code>{% endif %} &mdash; the identity
+      your GitHub consent is stored under. It must be the same user you signed in as on the
+      consent portal.</li>
+  </ul>
+  <textarea readonly onclick="this.select()">{{ access_token }}</textarea>
+  <p><a href="/">&larr; back</a></p>
+{% endblock %}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/README.md
@@ -1,0 +1,47 @@
+# The GitHub MCP tool schema
+
+[`github-tools.json`](github-tools.json) is the tool schema for
+[GitHub's MCP server](https://github.com/github/github-mcp-server)
+(`https://api.githubcopilot.com/mcp`), supplied to the gateway target as
+`targetConfiguration.mcp.mcpServer.mcpToolSchema.inlinePayload` by
+[`../deploy/04_create_github_target.py`](../deploy/04_create_github_target.py).
+
+## Why the schema is supplied upfront
+
+A gateway target for an MCP server can get its tool list two ways.
+
+**Implicit sync** — the gateway connects to the MCP server at create time and
+discovers the tools itself. For a target using the authorization code flow, that
+means an admin has to complete a three-legged OAuth flow *during*
+`CreateGatewayTarget`. That is exactly what the consent portal exists to avoid,
+and it does not work from a pipeline.
+
+**Schema upfront** (used here) — you provide the schema and the gateway parses
+and caches it. The target is `READY` immediately, nobody authorizes anything at
+deployment time, and `tools/list` works for every user without them having
+connected GitHub. Only `tools/call` triggers the consent flow, which is what
+makes the portal's out-of-band model work: users browse the catalogue freely and
+authorize only the servers whose tools they actually invoke.
+
+Two consequences worth knowing:
+
+- `SynchronizeGatewayTargets` is not supported for a schema-upfront target. If
+  GitHub adds tools, update the schema. You can switch a target between the two
+  methods by updating its configuration.
+- `listingMode: DYNAMIC` is incompatible with outbound 3LO, so it is not used.
+
+## Trimming it
+
+Everything in this file becomes a tool the model can call, and a permission
+surface. For anything beyond a tutorial, cut it to the tools you actually want
+exposed and narrow the `scopes` in
+[`../deploy/03_create_github_provider.py`](../deploy/03_create_github_provider.py)
+and [`../deploy/04_create_github_target.py`](../deploy/04_create_github_target.py)
+to match. The gateway's semantic search (`searchType: SEMANTIC`) helps the model
+choose among many tools, but it does not reduce what a compromised prompt could
+reach.
+
+This file is copied verbatim from the gateway-only walkthrough in
+[`01-features/07-…/authorization-code-flow/github/github.json`](../../../07-centralize-and-govern-your-ai-infrastructure/01-gateway/01-attach-targets/mcp/mcp-servers/01-configure-auth/authorization-code-flow/github/github.json),
+so the two samples describe the same server identically. Samples are
+self-contained by convention — hence a copy rather than a shared import.

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/README.md
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/README.md
@@ -28,7 +28,8 @@ Two consequences worth knowing:
 - `SynchronizeGatewayTargets` is not supported for a schema-upfront target. If
   GitHub adds tools, update the schema. You can switch a target between the two
   methods by updating its configuration.
-- `listingMode: DYNAMIC` is incompatible with outbound 3LO, so it is not used.
+- `listingMode: DYNAMIC` is incompatible with the outbound authorization code
+  flow, so it is not used.
 
 ## Trimming it
 

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/github-tools.json
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/gateway/github-tools.json
@@ -1,0 +1,1956 @@
+{
+  "tools": [
+    {
+      "name": "add_comment_to_pending_review",
+      "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "The text of the review comment"
+          },
+          "line": {
+            "type": "number",
+            "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "path": {
+            "type": "string",
+            "description": "The relative path to the file that necessitates a comment"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "side": {
+            "type": "string",
+            "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "startLine": {
+            "type": "number",
+            "description": "For multi-line comments, the first line of the range that the comment applies to"
+          },
+          "startSide": {
+            "type": "string",
+            "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "subjectType": {
+            "type": "string",
+            "description": "The level at which the comment is targeted",
+            "enum": [
+              "FILE",
+              "LINE"
+            ]
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "pullNumber",
+          "path",
+          "body",
+          "subjectType"
+        ]
+      }
+    },
+    {
+      "name": "add_issue_comment",
+      "description": "Add a comment and/or reaction to a specific issue or issue comment in a GitHub repository. Use this tool with pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add or react to review comments. At least one of body or reaction is required.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Comment content. Required unless reaction is provided."
+          },
+          "comment_id": {
+            "type": "number",
+            "description": "The numeric ID of the issue or pull request comment to react to. Use this for reactions to comments; omit it to react to the issue or pull request itself. Cannot be combined with body.",
+            "minimum": 1
+          },
+          "issue_number": {
+            "type": "number",
+            "description": "Issue or pull request number to comment on or react to."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "reaction": {
+            "type": "string",
+            "description": "Emoji reaction to add. Required unless body is provided.",
+            "enum": [
+              "+1",
+              "-1",
+              "laugh",
+              "confused",
+              "heart",
+              "hooray",
+              "rocket",
+              "eyes"
+            ]
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "issue_number"
+        ]
+      }
+    },
+    {
+      "name": "add_reply_to_pull_request_comment",
+      "description": "Add a reply and/or reaction to an existing pull request comment. This can create a new comment linked as a reply to the specified comment, add an emoji reaction to the specified comment, or do both. At least one of body or reaction is required.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "The text of the reply. Required unless reaction is provided."
+          },
+          "commentId": {
+            "type": "number",
+            "description": "The numeric ID of the pull request review comment to reply or react to. Use the number from a #discussion_r... anchor, not the GraphQL thread node ID (PRRT_...).",
+            "minimum": 1
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number. Required when body is provided."
+          },
+          "reaction": {
+            "type": "string",
+            "description": "Emoji reaction to add. Required unless body is provided.",
+            "enum": [
+              "+1",
+              "-1",
+              "laugh",
+              "confused",
+              "heart",
+              "hooray",
+              "rocket",
+              "eyes"
+            ]
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "commentId"
+        ]
+      }
+    },
+    {
+      "name": "create_branch",
+      "description": "Create a new branch in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Name for new branch"
+          },
+          "from_branch": {
+            "type": "string",
+            "description": "Source branch (defaults to repo default)"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "branch"
+        ]
+      }
+    },
+    {
+      "name": "create_or_update_file",
+      "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch to create/update the file in"
+          },
+          "content": {
+            "type": "string",
+            "description": "Content of the file"
+          },
+          "message": {
+            "type": "string",
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner (username or organization)",
+            "x-mcp-header": "owner"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path where to create/update the file"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sha": {
+            "type": "string",
+            "description": "The blob SHA of the file being replaced. Required if the file already exists."
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "path",
+          "content",
+          "message",
+          "branch"
+        ]
+      }
+    },
+    {
+      "name": "create_pull_request",
+      "description": "Create a new pull request in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "base": {
+            "type": "string",
+            "description": "Branch to merge into"
+          },
+          "body": {
+            "type": "string",
+            "description": "PR description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Create as draft PR"
+          },
+          "head": {
+            "type": "string",
+            "description": "Branch containing changes"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "reviewers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "GitHub usernames or ORG/team-slug team reviewers to request reviews from"
+          },
+          "title": {
+            "type": "string",
+            "description": "PR title"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "title",
+          "head",
+          "base"
+        ]
+      }
+    },
+    {
+      "name": "create_repository",
+      "description": "Create a new GitHub repository in your account or specified organization",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "autoInit": {
+            "type": "boolean",
+            "description": "Initialize with README"
+          },
+          "description": {
+            "type": "string",
+            "description": "Repository description"
+          },
+          "name": {
+            "type": "string",
+            "description": "Repository name"
+          },
+          "organization": {
+            "type": "string",
+            "description": "Organization to create the repository in (omit to create in your personal account)"
+          },
+          "private": {
+            "type": "boolean",
+            "description": "Whether the repository should be private. Defaults to true (private) when omitted.",
+            "default": true
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    {
+      "name": "delete_file",
+      "description": "Delete a file from a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch to delete the file from"
+          },
+          "message": {
+            "type": "string",
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner (username or organization)",
+            "x-mcp-header": "owner"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path to the file to delete"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "path",
+          "message",
+          "branch"
+        ]
+      }
+    },
+    {
+      "name": "fork_repository",
+      "description": "Fork a GitHub repository to your account or specified organization",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "Organization to fork to"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "get_commit",
+      "description": "Get details for a commit from a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Level of detail to include for changed files. \"none\" omits stats and files entirely. \"stats\" (default) includes per-file metadata: filename, status, and lines-of-code counts (additions, deletions, changes), with no patch content. \"full_patch\" additionally includes the unified diff content for each file and can be very large.",
+            "default": "stats",
+            "enum": [
+              "none",
+              "stats",
+              "full_patch"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Commit SHA, branch name, or tag name"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "sha"
+        ]
+      }
+    },
+    {
+      "name": "get_file_contents",
+      "description": "Get the contents of a file or directory from a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner (username or organization)",
+            "x-mcp-header": "owner"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path to file/directory",
+            "default": "/"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Accepts optional commit SHA. If specified, it will be used instead of ref"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "get_label",
+      "description": "Get a specific label from a repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Label name."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner (username or organization name)",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "name"
+        ]
+      }
+    },
+    {
+      "name": "get_latest_release",
+      "description": "Get the latest release in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "get_me",
+      "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "get_release_by_tag",
+      "description": "Get a specific release by its tag name in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "tag": {
+            "type": "string",
+            "description": "Tag name (e.g., 'v1.0.0')"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "tag"
+        ]
+      }
+    },
+    {
+      "name": "get_tag",
+      "description": "Get details about a specific git tag in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "tag": {
+            "type": "string",
+            "description": "Tag name"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "tag"
+        ]
+      }
+    },
+    {
+      "name": "get_team_members",
+      "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "org": {
+            "type": "string",
+            "description": "Organization login (owner) that contains the team."
+          },
+          "team_slug": {
+            "type": "string",
+            "description": "Team slug"
+          }
+        },
+        "required": [
+          "org",
+          "team_slug"
+        ]
+      }
+    },
+    {
+      "name": "get_teams",
+      "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "string",
+            "description": "Username to get teams for. If not provided, uses the authenticated user."
+          }
+        }
+      }
+    },
+    {
+      "name": "issue_read",
+      "description": "Get information about a specific issue in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "issue_number": {
+            "type": "number",
+            "description": "The number of the issue"
+          },
+          "method": {
+            "type": "string",
+            "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues (children) of the issue.\n4. get_parent - Get the parent issue, if this issue is a sub-issue of another.\n5. get_labels - Get labels assigned to the issue.\n",
+            "enum": [
+              "get",
+              "get_comments",
+              "get_sub_issues",
+              "get_parent",
+              "get_labels"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "The owner of the repository",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "The name of the repository",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "method",
+          "owner",
+          "repo",
+          "issue_number"
+        ]
+      }
+    },
+    {
+      "name": "issue_write",
+      "description": "Create a new or update an existing issue in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "assignees": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Usernames to assign to this issue"
+          },
+          "body": {
+            "type": "string",
+            "description": "Issue body content"
+          },
+          "duplicate_of": {
+            "type": "number",
+            "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'."
+          },
+          "issue_fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "delete": {
+                  "type": "boolean",
+                  "description": "Set to true to clear this field's current value on the issue. Cannot be combined with 'value' or 'field_option_name'.",
+                  "enum": [
+                    true
+                  ]
+                },
+                "field_name": {
+                  "type": "string",
+                  "description": "Issue field name (case-insensitive). Must match a field returned by list_issue_fields for this repository or its organization."
+                },
+                "field_option_name": {
+                  "type": "string",
+                  "description": "Option name for single-select fields. Validated against the field's options before the API call. Cannot be combined with 'value' or 'delete'."
+                },
+                "value": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ],
+                  "description": "Value to set. Use for text, number, and date fields (date as YYYY-MM-DD). For single-select fields, prefer 'field_option_name' so the option is validated before the API call. Cannot be combined with 'field_option_name' or 'delete'."
+                }
+              },
+              "required": [
+                "field_name"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Issue field values to set or clear. Each item requires 'field_name' and exactly one of 'value', 'field_option_name', or 'delete: true'."
+          },
+          "issue_number": {
+            "type": "number",
+            "description": "Issue number to update"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Labels to apply to this issue"
+          },
+          "method": {
+            "type": "string",
+            "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+            "enum": [
+              "create",
+              "update"
+            ]
+          },
+          "milestone": {
+            "type": "number",
+            "description": "Milestone number"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "state_reason": {
+            "type": "string",
+            "description": "Reason for the state change. Ignored unless state is changed.",
+            "enum": [
+              "completed",
+              "not_planned",
+              "duplicate"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Issue title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of this issue. Only use if issue types are enabled for this repository. Use list_issue_types tool to get valid type values for this repository or its owner organization. If the repository doesn't support issue types, omit this parameter."
+          }
+        },
+        "required": [
+          "method",
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_branches",
+      "description": "List branches in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_commits",
+      "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "author": {
+            "type": "string",
+            "description": "Author username or email address to filter commits by"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "path": {
+            "type": "string",
+            "description": "Only commits containing this file path will be returned"
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA."
+          },
+          "since": {
+            "type": "string",
+            "description": "Only commits after this date will be returned (ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DD)"
+          },
+          "until": {
+            "type": "string",
+            "description": "Only commits before this date will be returned (ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DD)"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_issue_fields",
+      "description": "List issue fields for a repository or organization. Returns field definitions including name, type (text, number, date, single_select), and for single_select fields the list of valid option names. When repo is omitted, returns org-level fields directly.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "The account owner of the repository or organization. The name is not case sensitive.",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "The name of the repository. When provided, returns fields for this specific repository (inherited from its organization). When omitted, returns org-level fields directly.",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner"
+        ]
+      }
+    },
+    {
+      "name": "list_issue_types",
+      "description": "List supported issue types for a repository or its owner organization. When repo is omitted, returns org-level issue types directly.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "The account owner of the repository or organization.",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "The name of the repository. When provided, returns issue types for this specific repository. When omitted, returns org-level issue types directly.",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner"
+        ]
+      }
+    },
+    {
+      "name": "list_issues",
+      "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "description": "Cursor for pagination. Use the cursor from the previous response."
+          },
+          "direction": {
+            "type": "string",
+            "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+            "enum": [
+              "ASC",
+              "DESC"
+            ]
+          },
+          "field_filters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field_name": {
+                  "type": "string",
+                  "description": "Name of the custom field (e.g. \"Priority\"). Case-insensitive."
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value to filter on. For single-select fields, the option name (e.g. \"P1\"). For dates, YYYY-MM-DD. For numbers, the numeric value as a string. For text, the text value."
+                }
+              },
+              "required": [
+                "field_name",
+                "value"
+              ]
+            },
+            "description": "Filter by custom issue field values. Each entry takes a field_name and a value; the server looks up the field and coerces the value to its type (single-select option name, text, number, or YYYY-MM-DD date)."
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Filter by labels"
+          },
+          "orderBy": {
+            "type": "string",
+            "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+            "enum": [
+              "CREATED_AT",
+              "UPDATED_AT",
+              "COMMENTS"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "since": {
+            "type": "string",
+            "description": "Filter by date (ISO 8601 timestamp)"
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state, by default both open and closed issues are returned when not provided",
+            "enum": [
+              "OPEN",
+              "CLOSED"
+            ]
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_pull_requests",
+      "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "base": {
+            "type": "string",
+            "description": "Filter by base branch"
+          },
+          "direction": {
+            "type": "string",
+            "description": "Sort direction",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "head": {
+            "type": "string",
+            "description": "Filter by head user/org and branch"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort by",
+            "enum": [
+              "created",
+              "updated",
+              "popularity",
+              "long-running"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ]
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_releases",
+      "description": "List releases in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_repository_collaborators",
+      "description": "List collaborators of a GitHub repository. Results are paginated; the response includes `nextPage`, `prevPage`, `firstPage`, and `lastPage` fields. To get the next page, use the `nextPage` value as the `page` parameter.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "affiliation": {
+            "type": "string",
+            "description": "Filter by affiliation. Can be one of: 'outside' (outside collaborators), 'direct' (all with permissions regardless of org membership), 'all' (all collaborators). Default: 'all'",
+            "enum": [
+              "outside",
+              "direct",
+              "all"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (default 1, min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (default 30, min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "list_tags",
+      "description": "List git tags in a GitHub repository",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "merge_pull_request",
+      "description": "Merge a pull request in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "commit_message": {
+            "type": "string",
+            "description": "Extra detail for merge commit"
+          },
+          "commit_title": {
+            "type": "string",
+            "description": "Title for merge commit"
+          },
+          "merge_method": {
+            "type": "string",
+            "description": "Merge method",
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    },
+    {
+      "name": "pull_request_read",
+      "description": "Get information on a specific pull request in GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "description": "Cursor for pagination, used only by the get_review_comments method. Pass the endCursor from the previous page's PageInfo to fetch the next page."
+          },
+          "method": {
+            "type": "string",
+            "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_commits - Get the list of commits on a pull request. Use with pagination parameters to control the number of results returned.\n 6. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 7. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method. Use with pagination parameters to control the number of results returned.\n 8. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 9. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+            "enum": [
+              "get",
+              "get_diff",
+              "get_status",
+              "get_files",
+              "get_commits",
+              "get_review_comments",
+              "get_reviews",
+              "get_comments",
+              "get_check_runs"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "method",
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    },
+    {
+      "name": "pull_request_review_write",
+      "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n- resolve_thread: Resolve a review thread. Requires only \"threadId\" parameter with the thread's node ID (e.g., PRRT_kwDOxxx). The owner, repo, and pullNumber parameters are not used for this method. Resolving an already-resolved thread is a no-op.\n- unresolve_thread: Unresolve a previously resolved review thread. Requires only \"threadId\" parameter. The owner, repo, and pullNumber parameters are not used for this method. Unresolving an already-unresolved thread is a no-op.\n",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Review comment text"
+          },
+          "commitID": {
+            "type": "string",
+            "description": "SHA of commit to review"
+          },
+          "event": {
+            "type": "string",
+            "description": "Review action to perform.",
+            "enum": [
+              "APPROVE",
+              "REQUEST_CHANGES",
+              "COMMENT"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "description": "The write operation to perform on pull request review.",
+            "enum": [
+              "create",
+              "submit_pending",
+              "delete_pending",
+              "resolve_thread",
+              "unresolve_thread"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "threadId": {
+            "type": "string",
+            "description": "The node ID of the review thread (e.g., PRRT_kwDOxxx). Required for resolve_thread and unresolve_thread methods. Get thread IDs from pull_request_read with method get_review_comments."
+          }
+        },
+        "required": [
+          "method",
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    },
+    {
+      "name": "push_files",
+      "description": "Push multiple files to a GitHub repository in a single commit",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "Branch to push to"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "file content"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "path to the file"
+                }
+              },
+              "required": [
+                "path",
+                "content"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Array of file objects to push, each object with path (string) and content (string)"
+          },
+          "message": {
+            "type": "string",
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "branch",
+          "files",
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "request_copilot_review",
+      "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    },
+    {
+      "name": "run_secret_scanning",
+      "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. The files parameter accepts either a single string or an array of strings containing raw file contents or diff hunks, and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "description": "A single string or an array of strings containing file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths.",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "maxItems": 100
+              }
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "files",
+          "owner",
+          "repo"
+        ]
+      }
+    },
+    {
+      "name": "search_code",
+      "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "string",
+            "description": "Sort order for results",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query (GitHub code search REST). Implicit AND between terms; supports `OR`, `NOT`, and `\"quoted phrase\"` for exact match. Qualifiers: `repo:owner/repo`, `org:`, `user:`, `language:`, `path:dir` (prefix match), `filename:exact.ext`, `extension:`, `in:file`, `in:path`, `size:`, `is:archived`, `is:fork`. Max 256 chars. Examples: `WithContext language:go org:github`; `\"package main\" repo:o/r`; `func extension:go path:cmd repo:o/r`; `NOT TODO language:go repo:o/r`."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field ('indexed' only)"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "search_commits",
+      "description": "Search for commits across GitHub repositories using GitHub's commit search syntax. Useful for finding specific changes, authors, or messages across one or many repositories. Searches the default branch only.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "Commit search query (GitHub commit search REST). Searches commit messages on the default branch only. Scope the search with `repo:owner/repo`, `org:`, or `user:` (queries without a scope qualifier match across all of GitHub and are usually not what you want). Other qualifiers: `author:`, `committer:`, `author-name:`, `committer-name:`, `author-email:`, `committer-email:`, `author-date:`, `committer-date:` (supports `>`, `<`, `>=`, `<=`, and `YYYY-MM-DD..YYYY-MM-DD` ranges), `merge:true|false`, `hash:`, `tree:`, `parent:`, `is:public`. Examples: `repo:owner/repo fix panic`; `org:github author:defunkt committer-date:>=2024-01-01`; `\"refactor cache\" repo:o/r`; `hash:abc1234 repo:o/r`."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort by author or committer date (defaults to best match)",
+            "enum": [
+              "author-date",
+              "committer-date"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "search_issues",
+      "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only issues for this repository are listed.",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query using GitHub issues search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only issues for this repository are listed.",
+            "x-mcp-header": "repo"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "search_pull_requests",
+      "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed.",
+            "x-mcp-header": "owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query using GitHub pull request search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed.",
+            "x-mcp-header": "repo"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "search_repositories",
+      "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "minimal_output": {
+            "type": "boolean",
+            "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+            "default": true
+          },
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort repositories by field, defaults to best match",
+            "enum": [
+              "stars",
+              "forks",
+              "help-wanted-issues",
+              "updated"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "search_users",
+      "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+            "enum": [
+              "followers",
+              "repositories",
+              "joined"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "sub_issue_write",
+      "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "after_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)"
+          },
+          "before_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)"
+          },
+          "issue_number": {
+            "type": "number",
+            "description": "The number of the parent issue"
+          },
+          "method": {
+            "type": "string",
+            "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "replace_parent": {
+            "type": "boolean",
+            "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only."
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "sub_issue_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to add. ID is not the same as issue number"
+          }
+        },
+        "required": [
+          "method",
+          "owner",
+          "repo",
+          "issue_number",
+          "sub_issue_id"
+        ]
+      }
+    },
+    {
+      "name": "update_pull_request",
+      "description": "Update an existing pull request in a GitHub repository.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "base": {
+            "type": "string",
+            "description": "New base branch name"
+          },
+          "body": {
+            "type": "string",
+            "description": "New description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Mark pull request as draft (true) or ready for review (false)"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number to update"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          },
+          "reviewers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "GitHub usernames or ORG/team-slug team reviewers to request reviews from"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "New title"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    },
+    {
+      "name": "update_pull_request_branch",
+      "description": "Update the branch of a pull request with the latest changes from the base branch.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "expectedHeadSha": {
+            "type": "string",
+            "description": "The expected SHA of the pull request's HEAD ref"
+          },
+          "owner": {
+            "type": "string",
+            "description": "Repository owner",
+            "x-mcp-header": "owner"
+          },
+          "pullNumber": {
+            "type": "number",
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository name",
+            "x-mcp-header": "repo"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "pullNumber"
+        ]
+      }
+    }
+  ]
+}

--- a/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/requirements.txt
+++ b/01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets/requirements.txt
@@ -1,0 +1,26 @@
+# Deploy scripts + the frontend BFF. The agent's runtime container has its own
+# requirements at agent/requirements.txt.
+
+# AWS. 1.43.88 is the first release whose bedrock-agentcore-control model
+# carries the consent-portal operations. On anything older the calls fail with
+#   'BedrockAgentCoreControlPlaneFrontingLayer' object has no attribute
+#   'create_consent_portal'
+# which reads like a missing feature rather than a stale SDK.
+boto3>=1.43.88
+botocore>=1.43.88
+
+# Frontend (BFF)
+fastapi>=0.115
+uvicorn[standard]>=0.32
+itsdangerous>=2.2
+jinja2>=3.1
+python-multipart>=0.0.18
+httpx>=0.27
+# Entra sign-in
+msal>=1.31
+# Okta sign-in
+authlib>=1.3
+
+# Config + Okta Admin API calls
+python-dotenv>=1.0
+requests>=2.32

--- a/01-features/05-authenticate-and-authorize/README.md
+++ b/01-features/05-authenticate-and-authorize/README.md
@@ -86,7 +86,7 @@ AgentCore identity integrates seamlessly with other AgentCore components:
 | `04-entra-obo-mcp-runtime/` | Advanced: Entra ID On-Behalf-Of token exchange across two runtimes (Agent + MCP Server); user identity preserved end-to-end |
 | `05-certificate-based-auth/` | Outbound `PRIVATE_KEY_JWT` client authentication (RFC 7523) with KMS-hosted signing keys for Okta and Entra ID; M2M, 3LO, and OBO flows |
 | `06-okta-xaa/` | Okta Cross-App Access: an agent reaches a resource app through Okta's identity-assertion grant |
-| `07-consent-portal-auth-code-flow-targets/` | Managed consent dashboard end-to-end: FastAPI BFF → agent on Runtime → Gateway → GitHub MCP server (3LO). Users connect GitHub themselves on the AWS-hosted consent portal (Entra ID or Okta) |
+| `07-consent-portal-auth-code-flow-targets/` | Managed consent dashboard end-to-end: FastAPI BFF → agent on Runtime → Gateway → GitHub MCP server over the authorization code flow (3LO). Users connect GitHub themselves on the AWS-hosted consent portal (Entra ID or Okta) |
 | `obo-training/` | On-Behalf-Of training curriculum: concept guides plus worked Entra and Okta examples for agent-to-downstream and agent-via-gateway |
 | `okta-auth-three-tier-end-to-end-demo/` | End-to-end Okta OAuth2 three-tier demo: per-tier JWT isolation across User → Runtime → Gateway → MCP Server with RBAC |
 | `auth0-multi-agent-obo/` | Multi-agent RFC 8693 On-Behalf-Of token exchange via Auth0: coordinator mints attenuated tokens per sub-agent rather than forwarding the user JWT |
@@ -116,7 +116,7 @@ followed by combined multi-flow examples in `03-m2m-3lo/` and `04-entra-obo-mcp-
 | Entra OBO | 04-entra-obo-mcp-runtime/ | Agent calls MCP server carrying user-delegated Graph token |
 | PRIVATE_KEY_JWT (Okta + Entra) | 05-certificate-based-auth/ | KMS-signed client assertions for outbound M2M, 3LO, and OBO flows; no client secret |
 | Okta Cross-App Access | 06-okta-xaa/ | Agent reaches a resource app via Okta's identity-assertion grant |
-| Consent portal + 3LO MCP target | 07-consent-portal-auth-code-flow-targets/ | Hosted consent dashboard where end users grant the agent GitHub access out of band |
+| Consent portal + authorization-code-flow MCP target | 07-consent-portal-auth-code-flow-targets/ | Hosted consent dashboard where end users grant the agent GitHub access out of band |
 | Auth0 OBO (multi-agent) | auth0-multi-agent-obo/ | Coordinator mints scoped tokens per sub-agent using RFC 8693 via Auth0 |
 
 ## Finding Things

--- a/01-features/05-authenticate-and-authorize/README.md
+++ b/01-features/05-authenticate-and-authorize/README.md
@@ -85,6 +85,9 @@ AgentCore identity integrates seamlessly with other AgentCore components:
 | `03-m2m-3lo/` | Combined M2M + Auth Code flows in one runtime agent using the AgentCore CLI; Cognito inbound, GitHub + Google outbound |
 | `04-entra-obo-mcp-runtime/` | Advanced: Entra ID On-Behalf-Of token exchange across two runtimes (Agent + MCP Server); user identity preserved end-to-end |
 | `05-certificate-based-auth/` | Outbound `PRIVATE_KEY_JWT` client authentication (RFC 7523) with KMS-hosted signing keys for Okta and Entra ID; M2M, 3LO, and OBO flows |
+| `06-okta-xaa/` | Okta Cross-App Access: an agent reaches a resource app through Okta's identity-assertion grant |
+| `07-consent-portal-auth-code-flow-targets/` | Managed consent dashboard end-to-end: FastAPI BFF → agent on Runtime → Gateway → GitHub MCP server (3LO). Users connect GitHub themselves on the AWS-hosted consent portal (Entra ID or Okta) |
+| `obo-training/` | On-Behalf-Of training curriculum: concept guides plus worked Entra and Okta examples for agent-to-downstream and agent-via-gateway |
 | `okta-auth-three-tier-end-to-end-demo/` | End-to-end Okta OAuth2 three-tier demo: per-tier JWT isolation across User → Runtime → Gateway → MCP Server with RBAC |
 | `auth0-multi-agent-obo/` | Multi-agent RFC 8693 On-Behalf-Of token exchange via Auth0: coordinator mints attenuated tokens per sub-agent rather than forwarding the user JWT |
 
@@ -112,33 +115,42 @@ followed by combined multi-flow examples in `03-m2m-3lo/` and `04-entra-obo-mcp-
 | M2M + 3LO combined | 03-m2m-3lo/ | Single agent with both M2M and Auth Code outbound flows |
 | Entra OBO | 04-entra-obo-mcp-runtime/ | Agent calls MCP server carrying user-delegated Graph token |
 | PRIVATE_KEY_JWT (Okta + Entra) | 05-certificate-based-auth/ | KMS-signed client assertions for outbound M2M, 3LO, and OBO flows; no client secret |
+| Okta Cross-App Access | 06-okta-xaa/ | Agent reaches a resource app via Okta's identity-assertion grant |
+| Consent portal + 3LO MCP target | 07-consent-portal-auth-code-flow-targets/ | Hosted consent dashboard where end users grant the agent GitHub access out of band |
 | Auth0 OBO (multi-agent) | auth0-multi-agent-obo/ | Coordinator mints scoped tokens per sub-agent using RFC 8693 via Auth0 |
 
 ## Finding Things
 
 **By identity provider:**
 - Cognito → `01-inbound-auth/01-inbound-auth-cognito/`, `03-m2m-3lo/`
-- Microsoft Entra ID → `01-inbound-auth/02-inbound-auth-EntraID/`, `04-entra-obo-mcp-runtime/`, `05-certificate-based-auth/entra/`
-- Okta → `01-inbound-auth/03-inbound-auth-okta/`, `05-certificate-based-auth/okta/`
+- Microsoft Entra ID → `01-inbound-auth/02-inbound-auth-EntraID/`, `04-entra-obo-mcp-runtime/`, `05-certificate-based-auth/entra/`, `07-consent-portal-auth-code-flow-targets/`, `obo-training/`
+- Okta → `01-inbound-auth/03-inbound-auth-okta/`, `05-certificate-based-auth/okta/`, `06-okta-xaa/`, `07-consent-portal-auth-code-flow-targets/`, `obo-training/`
 - PingFederate → `01-inbound-auth/04-inbound-auth-pingfederate/`
+- Auth0 → `auth0-multi-agent-obo/`
 
 **By external API:**
 - OpenAI → `02-outbound-auth/01-outbound-auth-openai/`
 - Google Calendar → `02-outbound-auth/02-outbound-auth-3lo/`, `03-m2m-3lo/`
-- GitHub → `02-outbound-auth/03-outbound-auth-github/`, `03-m2m-3lo/`
-- Microsoft Graph → `01-inbound-auth/02-inbound-auth-EntraID/` (OneNote), `04-entra-obo-mcp-runtime/`
+- GitHub → `02-outbound-auth/03-outbound-auth-github/` (REST API), `03-m2m-3lo/`, `07-consent-portal-auth-code-flow-targets/` (MCP server via Gateway)
+- Microsoft Graph → `01-inbound-auth/02-inbound-auth-EntraID/` (OneNote), `04-entra-obo-mcp-runtime/`, `obo-training/`
 
 **By deployment method:**
-- AgentCore CLI (`agentcore create/deploy`) → `03-m2m-3lo/`
+- AgentCore CLI (`agentcore create/deploy`) → `03-m2m-3lo/`, `07-consent-portal-auth-code-flow-targets/`, `obo-training/3-examples/`
 - Python SDK (`boto3` `bedrock-agentcore-control`) → all other folders
 - AWS CDK → `01-inbound-auth/04-inbound-auth-pingfederate/`
+
+**By end-user experience:**
+- Hosted consent dashboard (AWS-managed, no consent UI to build) → `07-consent-portal-auth-code-flow-targets/`
+- Local callback server you run → `02-outbound-auth/02-outbound-auth-3lo/`, `02-outbound-auth/03-outbound-auth-github/`
+- No user interaction (M2M / OBO) → `03-m2m-3lo/`, `04-entra-obo-mcp-runtime/`, `obo-training/`
 
 ## Prerequisites
 
 - Python 3.10+
 - AWS CLI configured with credentials
-- Node.js 20+ and `@aws/agentcore` npm package (for `03-m2m-3lo/` only)
-- AWS CDK (`npm install -g aws-cdk`) for `04-inbound-auth-pingfederate/` only
+- Node.js 20+ and `@aws/agentcore` npm package (for `03-m2m-3lo/`, `07-consent-portal-auth-code-flow-targets/`, and `obo-training/3-examples/`)
+- AWS CDK (`npm install -g aws-cdk`) for `04-inbound-auth-pingfederate/`, and for any folder deployed with the AgentCore CLI
+- boto3/botocore **≥ 1.43.88** for `07-consent-portal-auth-code-flow-targets/` — earlier releases have no consent-portal operations in the `bedrock-agentcore-control` model
 - Bedrock model access: enable `claude-haiku-4-5` and/or `claude-sonnet-4-5` in the Bedrock console
 - identity provider accounts as needed (see individual sub-folder READMEs)
 
@@ -196,6 +208,15 @@ python setup_cognito.py
 cd 04-entra-obo-mcp-runtime/
 pip install -r requirements.txt
 python entra_obo_mcp_runtime.py
+
+# Consent portal + GitHub MCP server (multi-step; see its README)
+cd 07-consent-portal-auth-code-flow-targets/
+cp config.example.env .env
+pip install -r requirements.txt
+python deploy/00_create_entra_apps.py     # or 00_create_okta_apps.py
+python deploy/01_create_gateway.py --entra
+python deploy/02_create_portal.py --entra
+# ... see 07-consent-portal-auth-code-flow-targets/README.md for the remaining steps
 
 # PRIVATE_KEY_JWT — Okta (M2M + OBO)
 cd 05-certificate-based-auth/okta/


### PR DESCRIPTION
# Amazon Bedrock AgentCore Samples Pull Request

**Issue number**: #2069

### Concise description of the PR

```
Adds 01-features/05-authenticate-and-authorize/07-consent-portal-auth-code-flow-targets:
a complete, deployable solution where an agent reaches a gateway target that requires
the OAuth 2.0 authorization code flow (3LO), and each end user grants that access
themselves on the AWS-managed consent dashboard.
```

```
user -> FastAPI BFF -> Strands agent on AgentCore Runtime -> AgentCore Gateway
     -> GitHub MCP server (AUTHORIZATION_CODE target)
```

A deployed agent cannot complete an authorization code flow on its own: that flow needs a browser, a consent screen, and somewhere to receive the redirect. The **AgentCore consent portal** supplies all three as a hosted, AWS-managed page. Users connect their own GitHub account there, *out of band*, before or independently of any conversation with the agent — so the agent never handles a GitHub credential, and there is no consent UI or callback server to write.

What the sample provides:

- **Both Entra ID and Okta** from one deploy path, selected by a required `--entra` / `--okta` flag. IdP *shape* lives in `deploy/idps/<name>.json`; tenant *values* stay in `.env`, so adding a provider is a new profile plus one bootstrap script.
- **Passthrough** on the agent→gateway hop — the runtime and gateway share a discovery URL and audience, so the caller JWT is forwarded unchanged and one token satisfies both. Deliberately **not** an OBO sample; `obo-training/` covers token exchange.
- **Schema-upfront MCP target** with 44 GitHub tools, so `tools/list` works before anyone consents and only `tools/call` needs the user token.
- **Graceful unconsented path.** The gateway answers a `tools/call` with no stored token by returning a `-32042` URL-mode elicitation rather than an error; the agent turns that into a plain instruction naming the portal, and never echoes the raw authorize URL.
- **Optional Lambda RESPONSE interceptor** that rewrites the elicitation URL to the portal, for adopters who want *every* MCP client steered there rather than relying on agent-side handling. Off by default, with a configuration table.
- Idempotent numbered deploy scripts and a teardown that verifies what it deleted and reports survivors.

### User experience

**Before**: reaching a target that requires the authorization code flow from a deployed agent means building the browser consent leg yourself — a callback endpoint, session binding, and somewhere to store per-user tokens.

**After**: run `deploy/00` … `07`, sign in at `localhost:8000`, and ask a question. A user who has not connected GitHub gets a portal link instead of an error. Once they connect, the same question returns their own data.

The demo that lands the idea is `Who am I on GitHub?` — two people asking it get two different answers from one agent, one gateway and one target, because the authorization is per user.

Most of the documentation effort went into invariants that fail *late and quietly*, each written up with the symptom it produces:

| Invariant | Symptom when wrong |
| :--- | :--- |
| Three callback URLs, none interchangeable | generic login failure, or GitHub rejecting `redirect_uri` at **Connect** |
| Gateway authorizer and portal IdP provider need **byte-identical** discovery URLs | `login_unavailable`, which names no cause |
| Entra `sub` is pairwise per **resource**, so both sign-ins need one shared audience | consent stored under one identity, looked up under another — re-prompts forever, with no error anywhere |
| Okta needs a **custom** authorization server | `CreateConsentPortal` rejects the provider, because the org server issues opaque tokens |
| `supportedVersions` must include `2025-11-25` | no URL-mode elicitation, so there is no `-32042` to catch |
| boto3/botocore ≥ 1.43.88 | `object has no attribute 'create_consent_portal'`, which reads like a missing feature |

### Validation

Deployed and run end to end in a real AWS account against real tenants, for **both** IdPs: portal sign-in, GitHub **Connect**, and a live GitHub MCP call returning the signed-in user’s own data. The optional interceptor was verified live (22 invocations, 2 rewrites — it fires only on `-32042`). Teardown was then run for both variants and the account verified empty.

The one hop **not** exercised is the **Bedrock model call**: the test account’s daily token quota is zero pending a Support increase. Everything the model depends on — runtime IAM, the inference profile, tool discovery — is verified. The README states this in a *Validation status* callout rather than implying full coverage.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/agentcore-samples/blob/main/CONTRIBUTING.md)
* [x] Add your name to [CONTRIBUTORS.md](https://github.com/awslabs/agentcore-samples/blob/main/CONTRIBUTORS.md) — already listed
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/awslabs/agentcore-samples/pulls) for the same update/change?
* [ ] Are you uploading a dataset? — no
* [x] Have you documented **Introduction**, **Architecture Diagram**, **Prerequisites**, **Usage**, **Sample Prompts**, and **Clean Up** steps in your example README?
* [x] I agree to resolve any issues created for this example in the future
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Notes for reviewers

- **IAM: neither role uses `Resource: "*"`.** The AgentCore Identity actions do support resource-level permissions, so both roles are scoped to `token-vault/*` and `workload-identity-directory/*` in this account and region. The ids stay wildcarded because AgentCore owns those names and mints a workload identity per runtime/gateway. Both rendered policies validate with **no IAM Access Analyzer findings**. The README also records the `InboundJwtClaim/*` and `userid` condition keys as the next tightening step available to adopters.
- **The BFF session cookie is not `Secure`**, because the sample runs on `http://localhost`. Documented, along with the one-line change needed to serve it anywhere else.
- **GitHub scopes (`repo user workflow`) are broad** for a sample; the README points at the two places to trim them.
- **Terminology**: "authorization code flow" is used throughout, with "(3LO)" noted once on first use for readers who know it by that name.
- `ruff check` and `ruff format --check` are clean under the repo’s `pyproject.toml`.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agentcore-samples/blob/main/LICENSE).