### PR TITLE
docs(02-use-cases): Add a pointer to the multi-tenant travel assistant

### DIFF
--- a/02-use-cases/01-conversational-agents/README.md
+++ b/02-use-cases/01-conversational-agents/README.md
@@ -35,6 +35,7 @@ Agents that interact with users in real time through a chat or query interface. 
 | [healthcare-appointment-agent](./healthcare-appointment-agent/) | Healthcare | Intermediate | Runtime, Gateway, Policy, Observability; FHIR R4 via HealthLake |
 | [lakehouse-agent](./lakehouse-agent/) | Data and Analytics | Advanced | Runtime, Gateway, Memory, Policy; OAuth row-level security over S3 Tables and Athena |
 | [market-trends-agent](./market-trends-agent/) | Financial Services | Advanced | Runtime, Memory, Browser, Evaluations, Optimization; personalized broker investment assistant |
+| [multi-tenant-travel-assistant](./multi-tenant-travel-assistant/) | Travel & Hospitality (corporate travel) | Advanced | Runtime, Gateway, Memory, Policy (Cedar), Identity (Cognito), Guardrails, Observability, Evaluations; tenant isolation at independent layers. Code hosted in [aws-samples](https://github.com/aws-samples/sample-multi-tenant-travel-assistant) |
 | [SRE-agent](./SRE-agent/) | Site Reliability | Advanced | Runtime, Gateway, Memory, Observability; multi-agent system with MCP-based tools and runbooks |
 | [video-games-sales-assistant](./video-games-sales-assistant/) | Retail / Gaming | Intermediate | Runtime, Gateway, Memory; Next.js frontend with Amplify Gen 2 |
 

--- a/02-use-cases/01-conversational-agents/multi-tenant-travel-assistant/README.md
+++ b/02-use-cases/01-conversational-agents/multi-tenant-travel-assistant/README.md
@@ -1,0 +1,64 @@
+# Multi-tenant travel assistant
+
+> **The code for this sample lives in its own repository:**
+> **[aws-samples/sample-multi-tenant-travel-assistant](https://github.com/aws-samples/sample-multi-tenant-travel-assistant)**
+
+A corporate travel assistant that serves two tenant companies from a single pooled serverless
+deployment, demonstrating tenant isolation as a property of the architecture rather than a promise in
+the prompt.
+
+Two travelers ask the same agent the same question and get different, correct answers:
+
+```
+Priya (Globex)   "What's my hotel nightly cap?"   ->  $250.00 USD, 4-star maximum
+Sam (Initech)    "What's my hotel nightly cap?"   ->  EUR 150.00 per night, 3-star maximum
+```
+
+Same agent, same tool, same arguments. Nothing in the question says which company, and nothing the
+model can influence decides it: tenant identity arrives from a verified JWT claim injected
+server-side, after the model has finished choosing what to call.
+
+## What it demonstrates
+
+Isolation is enforced at independent layers, so no single decision has to be correct for the property
+to hold:
+
+| Layer | What it refuses |
+|-------|-----------------|
+| Cognito claims | A token for one tenant does not carry another's `custom:tenant_id`. Immutable, so a traveler cannot edit their own tenancy |
+| Cedar at the Gateway | Policy engine in `ENFORCE`; a call with no verified tenant tag matches no permit and is denied before the tool Lambda runs |
+| Gateway interceptor | A forged `X-Tenant-Id` header is overwritten, not validated. Validation invites a bypass; overwriting has none |
+| Tool schemas | No tenant field exists to supply. Identity arrives in the Lambda client context, unreachable from anything the model shapes |
+| IAM row-scoping | `dynamodb:LeadingKeys` on a per-request role assumed with a tenant session tag. The read is impossible, not merely audited |
+| Knowledge base | Per-tenant metadata filter built server-side, so retrieval cannot cross tenants |
+
+The two tenants differ in behavior rather than in configuration: one confirms bookings in chat, the
+other refuses at the tool and returns a checkout link instead. That difference is a real per-customer
+capability boundary, not a feature flag.
+
+## AgentCore features used
+
+Runtime, Gateway, Memory, Policy (Cedar), Identity (Cognito), Guardrails, Observability, and
+Evaluations. 14 tools across 9 Lambda gateway targets, retrieval-augmented generation with a
+per-tenant knowledge base filter, short and long term memory, response streaming, per-turn cost
+attribution by tenant, an evaluation suite behind a CI gate, and human escalation.
+
+Built with Strands Agents and AWS CDK.
+
+## Where the code lives
+
+The full sample is in
+[aws-samples/sample-multi-tenant-travel-assistant](https://github.com/aws-samples/sample-multi-tenant-travel-assistant),
+published under MIT-0. That repository carries the CDK infrastructure, the agent, the tool Lambdas,
+the React frontend, the test and evaluation suites, and a one-command deploy.
+
+## Before you adopt it
+
+It is sample code for learning, not a production-ready artifact, and every fixture record is
+synthetic. Note in particular that all of the controls above defend the **application**, not the
+service plane: the tenant session tag is asserted by the service, so code running with the service's
+own permissions can assert any tenant's tag. That is a property of pooled tenancy rather than a gap in
+the implementation. The repository's README covers this in
+"[Pooled tenancy, and when to choose silos instead](https://github.com/aws-samples/sample-multi-tenant-travel-assistant#pooled-tenancy-and-when-to-choose-silos-instead)",
+along with the compliance obligations an adopter inherits in
+"[Handling real traveler data](https://github.com/aws-samples/sample-multi-tenant-travel-assistant#handling-real-traveler-data)".


### PR DESCRIPTION
## What this adds

A pointer to the multi-tenant travel assistant sample, whose code lives in its own repository:
[aws-samples/sample-multi-tenant-travel-assistant](https://github.com/aws-samples/sample-multi-tenant-travel-assistant).

Two files, 65 insertions, no deletions:

- `02-use-cases/01-conversational-agents/multi-tenant-travel-assistant/README.md` — a brief
  introduction and a link to the sample
- one row added to `02-use-cases/01-conversational-agents/README.md`, placed alphabetically in the
  Samples table so it is discoverable alongside the others

This supersedes #1996, which proposed adding the sample's files directly to this repository.

## What the sample demonstrates

Tenant isolation for an agentic application. Two tenant companies are served from one pooled
serverless deployment, and the same agent, tool and arguments return different correct answers for
each, because tenant identity arrives from a verified JWT claim injected server-side after the model
has finished choosing what to call. No tool schema exposes a tenant parameter, so tenancy is never a
value the model can influence.

Isolation is enforced at independent layers: immutable Cognito claims, a gateway request interceptor
that overwrites client-supplied tenant headers rather than validating them, Cedar in `ENFORCE`,
per-tenant knowledge base filtering, and DynamoDB row-level scoping through `dynamodb:LeadingKeys`
pinned to an STS session tag.

AgentCore features: Runtime, Gateway, Memory, Policy, Identity, Guardrails, Observability,
Evaluations. Built with Strands Agents and AWS CDK.

## Notes for review

The linked repository is public, MIT-0, and has completed its security review. The pointer README is
explicit that the sample is for learning rather than production, and links to the sections covering
the pooled-tenancy isolation ceiling and the compliance obligations an adopter inherits.

Closes #1975
